### PR TITLE
ci: modernize release packaging workflows

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - prod
 
+permissions:
+  contents: write
+
 jobs:
   build-and-package:
     name: Build and Package for Prod
@@ -17,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -33,7 +36,7 @@ jobs:
         run: npm run test:unit
 
       - name: Package extension
-        run: npx vsce package --no-dependencies
+        run: npx @vscode/vsce package --no-dependencies
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,18 @@ jobs:
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.x'
+          cache: 'npm'
       
       - name: Install dependencies
         run: npm ci
@@ -26,7 +29,7 @@ jobs:
         run: npm run compile
       
       - name: Package extension
-        run: npx vsce package
+        run: npx @vscode/vsce package
       
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -40,21 +43,24 @@ jobs:
     name: Publish to VSCode Marketplace
     runs-on: ubuntu-latest
     needs: build-and-release
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.x'
+          cache: 'npm'
       
       - name: Install dependencies
         run: npm ci
       
       - name: Publish to Marketplace
-        run: npx vsce publish -p ${{ secrets.VSCE_TOKEN }}
+        run: npx @vscode/vsce publish -p ${{ secrets.VSCE_TOKEN }}
       
       - name: Publish to Open VSX Registry
         run: npx ovsx publish -p ${{ secrets.OVSX_TOKEN }}
@@ -63,10 +69,12 @@ jobs:
     name: Update Changelog
     runs-on: ubuntu-latest
     needs: build-and-release
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Extract version from tag
         id: get_version


### PR DESCRIPTION
## Summary
- move prod and release packaging workflows to Node 20 on setup-node v4
- use npx @vscode/vsce for VSIX packaging and Marketplace publishing
- scope workflow permissions per job for release creation, publishing, and changelog updates

Closes #53

## Validation
- ruby YAML parse for .github/workflows/prod-build.yml and .github/workflows/release.yml
- git diff --check
- npm ci
- npm run compile
- npm run lint
- npm run test:unit
- npm exec --yes --package @vscode/vsce@2.22.0 -- vsce package --no-dependencies
- npm audit --audit-level=moderate reports existing mocha -> serialize-javascript advisories requiring a breaking mocha change