### PR TITLE
Tighten webview CSP and remove CDN scripts

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,6 +9,9 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 node_modules/**
+!node_modules/3dmol/**
+!node_modules/ngl/**
+!node_modules/plotly.js-dist-min/**
 !node_modules/vscode-languageclient/**
 !node_modules/vscode-languageserver-protocol/**
 !node_modules/vscode-languageserver-types/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
+        "3dmol": "^2.0.6",
+        "ngl": "^2.2.1",
+        "plotly.js-dist-min": "^2.27.0",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -5051,6 +5054,28 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/3dmol": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.0.6.tgz",
+      "integrity": "sha512-KpfC7mR8fPDVG71Aarc5a7gOkARiW3xE1pJqh4DTmgRQRGT0yJxK1YxWPZOJ6B7IfPA2l5pbXbUo5gbl2TLfqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "iobuffer": "^5.3.1",
+        "netcdfjs": "^3.0.0",
+        "pako": "^2.1.0",
+        "upng-js": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.16.0",
+        "npm": ">=8.11"
+      }
+    },
+    "node_modules/3dmol/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5643,6 +5668,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-1.4.1.tgz",
+      "integrity": "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -7150,6 +7180,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -10899,6 +10935,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/netcdfjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/netcdfjs/-/netcdfjs-3.0.0.tgz",
+      "integrity": "sha512-LOvT8KkC308qtpUkcBPiCMBtii7ZQCN6LxcVheWgyUeZ6DQWcpSRFV9dcVXLj/2eHZ/bre9tV5HTH4Sf93vrFw==",
+      "license": "MIT",
+      "dependencies": {
+        "iobuffer": "^5.3.2"
+      }
+    },
+    "node_modules/ngl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ngl/-/ngl-2.2.1.tgz",
+      "integrity": "sha512-n+HwdsTzvn+erPkNqRsd+sQoTH6NuKdNMgqrJ0+X2+m+K3byMeSBMTCfF2gw79Ae7HWK57p7VzBQvJ0wHeZ/2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chroma-js": "^1.3.7",
+        "signals": "^1.0.0",
+        "sprintf-js": "^1.1.2",
+        "three": "^0.118.0"
+      }
+    },
+    "node_modules/ngl/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11111,7 +11174,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -11344,6 +11406,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/plotly.js-dist-min": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.27.0.tgz",
+      "integrity": "sha512-mbO7Mh1GlNEMSwqtdG1SjxVt/aAO47WBpzbkY5/YQyEa1n3MOX92AfhhIBq6xZ/dfJ82RHq92dQDm7WBahQ7DQ==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -12031,6 +12099,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/signals": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signals/-/signals-1.0.0.tgz",
+      "integrity": "sha512-dE3lBiqgrgIvpGHYBy6/kiYKfh0HXRmbg0ocakBKiOefbal6ZeTtNlQlxsu9ADkNzv5OmRwRKu+IaTPSqJdZDg=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -12826,6 +12899,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -604,9 +604,13 @@
     "vitepress": "^1.6.4"
   },
   "dependencies": {
+    "3dmol": "^2.0.6",
+    "ngl": "^2.2.1",
+    "plotly.js-dist-min": "^2.27.0",
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {
+    "three": "^0.183.2",
     "vite": "^6.4.3"
   },
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,8 +225,8 @@ export function activate(context: vscode.ExtensionContext) {
         `Results: ${item.label}`,
         vscode.ViewColumn.Two,
         {
-          enableScripts: true,
           retainContextWhenHidden: true,
+          localResourceRoots: [],
         }
       );
 
@@ -244,7 +244,7 @@ export function activate(context: vscode.ExtensionContext) {
         output: `Results for ${item.label}\n\nSoftware: ${item.software}\nStatus: ${item.status}\n\nSample output data would appear here.\n\nFor completed jobs, this would include:\n- Final energies\n- Optimized geometries\n- Convergence data\n- Properties calculated\n\nFor failed jobs, this would include:\n- Error messages\n- Stack traces\n- Diagnostic information`,
       };
 
-      panel.webview.html = getResultsHtml(resultsData);
+      panel.webview.html = getResultsHtml(resultsData, panel.webview.cspSource);
     }),
 
     // Sidebar: Export data
@@ -350,13 +350,32 @@ export function activate(context: vscode.ExtensionContext) {
   });
 }
 
-function getResultsHtml(data: any): string {
+function getResultsHtml(data: any, cspSource: string): string {
+  const nonce = getNonce();
+  const csp = [
+    `default-src 'none';`,
+    `script-src 'none';`,
+    `style-src 'nonce-${nonce}';`,
+    `img-src ${cspSource} data:;`,
+    `font-src ${cspSource};`,
+  ].join(' ');
+  const jobName = escapeHtml(data.jobName);
+  const jobId = escapeHtml(data.jobId);
+  const software = escapeHtml(data.software);
+  const status = escapeHtml(data.status);
+  const duration = escapeHtml(data.duration || 'N/A');
+  const startTime = data.startTime ? escapeHtml(new Date(data.startTime).toLocaleString()) : '';
+  const endTime = data.endTime ? escapeHtml(new Date(data.endTime).toLocaleString()) : '';
+  const output = escapeHtml(data.output);
+  const statusColor = data.status === 'completed' ? '#3c9' : '#f66';
+
   return `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Results: ${data.jobName}</title>
-    <style>
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <title>Results: ${jobName}</title>
+    <style nonce="${nonce}">
         body {
             margin: 0;
             padding: 0;
@@ -380,7 +399,7 @@ function getResultsHtml(data: any): string {
             border-radius: 3px;
             font-size: 11px;
             text-transform: uppercase;
-            background: ${data.status === 'completed' ? '#3c9' : '#f66'};
+            background: ${statusColor};
             color: white;
         }
         #content {
@@ -430,44 +449,44 @@ function getResultsHtml(data: any): string {
 </head>
 <body>
     <div id="header">
-        <div id="title">${data.jobName}</div>
-        <div><span id="status">${data.status}</span> ${data.software}</div>
+        <div id="title">${jobName}</div>
+        <div><span id="status">${status}</span> ${software}</div>
     </div>
     <div id="content">
         <div class="info-section">
             <h3>Job Information</h3>
             <div class="info-row">
                 <span class="info-label">Job ID:</span>
-                <span class="info-value">${data.jobId}</span>
+                <span class="info-value">${jobId}</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Software:</span>
-                <span class="info-value">${data.software}</span>
+                <span class="info-value">${software}</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Status:</span>
-                <span class="info-value">${data.status}</span>
+                <span class="info-value">${status}</span>
             </div>
             <div class="info-row">
                 <span class="info-label">Duration:</span>
-                <span class="info-value">${data.duration || 'N/A'}</span>
+                <span class="info-value">${duration}</span>
             </div>
             ${
-              data.startTime
+              startTime
                 ? `
             <div class="info-row">
                 <span class="info-label">Started:</span>
-                <span class="info-value">${new Date(data.startTime).toLocaleString()}</span>
+                <span class="info-value">${startTime}</span>
             </div>
             `
                 : ''
             }
             ${
-              data.endTime
+              endTime
                 ? `
             <div class="info-row">
                 <span class="info-label">Completed:</span>
-                <span class="info-value">${new Date(data.endTime).toLocaleString()}</span>
+                <span class="info-value">${endTime}</span>
             </div>
             `
                 : ''
@@ -475,11 +494,29 @@ function getResultsHtml(data: any): string {
         </div>
         <div class="info-section">
             <h3>Output</h3>
-            <div id="output">${data.output}</div>
+            <div id="output">${output}</div>
         </div>
     </div>
 </body>
 </html>`;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function getNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }
 
 export function deactivate() {

--- a/src/providers/DataPlotter.ts
+++ b/src/providers/DataPlotter.ts
@@ -34,7 +34,9 @@ export class DataPlotter {
         column,
         {
           enableScripts: true,
-          localResourceRoots: [this.extensionUri],
+          localResourceRoots: [
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', 'plotly.js-dist-min'),
+          ],
           retainContextWhenHidden: true,
         }
       );
@@ -55,7 +57,7 @@ export class DataPlotter {
     const content = document.getText();
     const plotData = this.extractPlotData(content, software);
 
-    this.panel.webview.html = this.getPlotterHtml(plotData, software);
+    this.panel.webview.html = this.getPlotterHtml(plotData, software, this.panel.webview);
   }
 
   private extractPlotData(content: string, software: QuantumChemistrySoftware): any {
@@ -246,16 +248,27 @@ export class DataPlotter {
     return plots;
   }
 
-  private getPlotterHtml(data: any, software: QuantumChemistrySoftware): string {
-    const plotsJson = JSON.stringify(data.plots);
+  private getPlotterHtml(
+    data: any,
+    software: QuantumChemistrySoftware,
+    webview: vscode.Webview
+  ): string {
+    const nonce = getNonce();
+    const plotlyUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, 'node_modules', 'plotly.js-dist-min', 'plotly.min.js')
+    );
+    const csp = getWebviewCsp(webview.cspSource, nonce);
+    const plotsJson = escapeScriptJson(data.plots);
+    const softwareLabel = escapeHtml(software);
 
     return `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>OpenQC: Data Plotter - ${software}</title>
-    <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
-    <style>
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <title>OpenQC: Data Plotter - ${softwareLabel}</title>
+    <script nonce="${nonce}" src="${plotlyUri}"></script>
+    <style nonce="${nonce}">
         body { 
             margin: 0; 
             padding: 0; 
@@ -314,12 +327,12 @@ export class DataPlotter {
 <body>
     <div id="header">
         <span id="title">Data Plotter</span>
-        <span id="software-badge">${software}</span>
+        <span id="software-badge">${softwareLabel}</span>
     </div>
     <div id="container">
         <div id="plots"></div>
     </div>
-    <script>
+    <script nonce="${nonce}">
         const plots = ${plotsJson};
         const container = document.getElementById('plots');
         
@@ -327,8 +340,14 @@ export class DataPlotter {
             plots.forEach((plot, index) => {
                 const plotDiv = document.createElement('div');
                 plotDiv.className = 'plot-container';
-                plotDiv.innerHTML = '<div class="plot-title">' + plot.title + '</div>' +
-                    '<div class="plot-area" id="plot-' + index + '"></div>';
+                const titleDiv = document.createElement('div');
+                titleDiv.className = 'plot-title';
+                titleDiv.textContent = plot.title;
+                const plotArea = document.createElement('div');
+                plotArea.className = 'plot-area';
+                plotArea.id = 'plot-' + index;
+                plotDiv.appendChild(titleDiv);
+                plotDiv.appendChild(plotArea);
                 container.appendChild(plotDiv);
                 
                 const layout = {
@@ -375,4 +394,42 @@ export class DataPlotter {
 </body>
 </html>`;
   }
+}
+
+function getWebviewCsp(cspSource: string, nonce: string): string {
+  return [
+    `default-src 'none';`,
+    `script-src 'nonce-${nonce}' ${cspSource};`,
+    `style-src 'nonce-${nonce}';`,
+    `img-src ${cspSource} data: blob:;`,
+    `font-src ${cspSource};`,
+    `media-src ${cspSource};`,
+  ].join(' ');
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003C')
+    .replace(/>/g, '\\u003E')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function getNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }

--- a/src/providers/StructureViewer.ts
+++ b/src/providers/StructureViewer.ts
@@ -38,7 +38,9 @@ export class StructureViewer {
         column,
         {
           enableScripts: true,
-          localResourceRoots: [this.extensionUri],
+          localResourceRoots: [
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '3dmol', 'build'),
+          ],
           retainContextWhenHidden: true,
         }
       );
@@ -74,7 +76,9 @@ export class StructureViewer {
         column,
         {
           enableScripts: true,
-          localResourceRoots: [this.extensionUri],
+          localResourceRoots: [
+            vscode.Uri.joinPath(this.extensionUri, 'node_modules', '3dmol', 'build'),
+          ],
           retainContextWhenHidden: true,
         }
       );
@@ -95,7 +99,7 @@ export class StructureViewer {
     const content = document.getText();
     const atoms = this.molecule3D.parseAtoms(content, software);
 
-    this.panel.webview.html = this.get3DViewerHtml(atoms, software);
+    this.panel.webview.html = this.get3DViewerHtml(atoms, software, this.panel.webview);
   }
 
   private updatePreviewContent(
@@ -109,7 +113,7 @@ export class StructureViewer {
     const content = document.getText();
     const previewData = this.parseInputPreview(content, software);
 
-    this.panel.webview.html = this.getPreviewHtml(previewData, software);
+    this.panel.webview.html = this.getPreviewHtml(previewData, software, this.panel.webview);
   }
 
   private parseInputPreview(content: string, software: QuantumChemistrySoftware): any {
@@ -230,16 +234,27 @@ export class StructureViewer {
     return sections;
   }
 
-  private get3DViewerHtml(atoms: any[], software: QuantumChemistrySoftware): string {
-    const atomsJson = JSON.stringify(atoms);
+  private get3DViewerHtml(
+    atoms: any[],
+    software: QuantumChemistrySoftware,
+    webview: vscode.Webview
+  ): string {
+    const nonce = getNonce();
+    const threeDmolUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, 'node_modules', '3dmol', 'build', '3Dmol-min.js')
+    );
+    const csp = getWebviewCsp(webview.cspSource, nonce);
+    const atomsJson = escapeScriptJson(atoms);
+    const softwareLabel = escapeHtml(software);
 
     return `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>OpenQC: Molecular Structure - ${software}</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.0.6/3Dmol-min.js"></script>
-    <style>
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <title>OpenQC: Molecular Structure - ${softwareLabel}</title>
+    <script nonce="${nonce}" src="${threeDmolUri}"></script>
+    <style nonce="${nonce}">
         body { 
             margin: 0; 
             padding: 0; 
@@ -298,6 +313,11 @@ export class StructureViewer {
         .control-btn:hover {
             background: #1177bb;
         }
+        .empty-state {
+            padding: 50px;
+            text-align: center;
+            color: #888;
+        }
         #info {
             position: absolute;
             top: 20px;
@@ -313,25 +333,25 @@ export class StructureViewer {
 <body>
     <div id="header">
         <span id="title">Molecular Structure Viewer</span>
-        <span id="software-badge">${software}</span>
+        <span id="software-badge">${softwareLabel}</span>
     </div>
     <div id="container">
         <div id="viewer"></div>
         <div id="controls">
-            <button class="control-btn" onclick="setStyle('stick')">Stick</button>
-            <button class="control-btn" onclick="setStyle('sphere')">Sphere</button>
-            <button class="control-btn" onclick="setStyle('line')">Line</button>
-            <button class="control-btn" onclick="setStyle('cartoon')">Cartoon</button>
+            <button class="control-btn" data-style="stick">Stick</button>
+            <button class="control-btn" data-style="sphere">Sphere</button>
+            <button class="control-btn" data-style="line">Line</button>
+            <button class="control-btn" data-style="cartoon">Cartoon</button>
             <br>
-            <button class="control-btn" onclick="viewer.spin(true)">Spin</button>
-            <button class="control-btn" onclick="viewer.spin(false)">Stop</button>
-            <button class="control-btn" onclick="viewer.zoomTo()">Reset View</button>
+            <button class="control-btn" id="spin">Spin</button>
+            <button class="control-btn" id="stop">Stop</button>
+            <button class="control-btn" id="reset-view">Reset View</button>
         </div>
         <div id="info">
             <div>Atoms: <span id="atom-count">0</span></div>
         </div>
     </div>
-    <script>
+    <script nonce="${nonce}">
         let viewer = null;
         const atoms = ${atomsJson};
         
@@ -349,10 +369,19 @@ export class StructureViewer {
                 
                 document.getElementById('atom-count').textContent = atoms.length;
             } else {
-                element.innerHTML = '<div style="padding: 50px; text-align: center; color: #888;">' +
-                    'No atomic coordinates found in file.<br>' +
-                    'Supported formats: XYZ, POSCAR, Gaussian, etc.</div>';
+                const emptyState = document.createElement('div');
+                emptyState.className = 'empty-state';
+                emptyState.innerHTML = 'No atomic coordinates found in file.<br>' +
+                    'Supported formats: XYZ, POSCAR, Gaussian, etc.';
+                element.appendChild(emptyState);
             }
+
+            document.querySelectorAll('[data-style]').forEach((button) => {
+                button.addEventListener('click', () => setStyle(button.dataset.style));
+            });
+            document.getElementById('spin').addEventListener('click', () => viewer && viewer.spin(true));
+            document.getElementById('stop').addEventListener('click', () => viewer && viewer.spin(false));
+            document.getElementById('reset-view').addEventListener('click', () => viewer && viewer.zoomTo());
         });
         
         function setStyle(style) {
@@ -377,13 +406,22 @@ export class StructureViewer {
 </html>`;
   }
 
-  private getPreviewHtml(data: any, software: QuantumChemistrySoftware): string {
+  private getPreviewHtml(
+    data: any,
+    software: QuantumChemistrySoftware,
+    webview: vscode.Webview
+  ): string {
+    const nonce = getNonce();
+    const csp = getWebviewCsp(webview.cspSource, nonce, false);
+    const softwareLabel = escapeHtml(software);
+
     return `<!DOCTYPE html>
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>OpenQC: Input Preview - ${software}</title>
-    <style>
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
+    <title>OpenQC: Input Preview - ${softwareLabel}</title>
+    <style nonce="${nonce}">
         body { 
             margin: 0; 
             padding: 0; 
@@ -459,7 +497,7 @@ export class StructureViewer {
 <body>
     <div id="header">
         <div id="title">Input File Preview</div>
-        <div id="software">${software}</div>
+        <div id="software">${softwareLabel}</div>
     </div>
     <div id="content">
         ${
@@ -473,7 +511,7 @@ export class StructureViewer {
                     (s: any) => `
                     <div class="param-row">
                         <span class="badge">SECTION</span>
-                        <span class="param-name">${s.name}</span>
+                        <span class="param-name">${escapeHtml(s.name)}</span>
                     </div>
                 `
                   )
@@ -494,8 +532,8 @@ export class StructureViewer {
                   .map(
                     (p: any) => `
                     <div class="param-row">
-                        <span class="param-name">${p.name}</span>
-                        <span class="param-value">${p.value}</span>
+                        <span class="param-name">${escapeHtml(p.name)}</span>
+                        <span class="param-value">${escapeHtml(p.value)}</span>
                     </div>
                 `
                   )
@@ -509,4 +547,42 @@ export class StructureViewer {
 </body>
 </html>`;
   }
+}
+
+function getWebviewCsp(cspSource: string, nonce: string, allowScripts = true): string {
+  return [
+    `default-src 'none';`,
+    allowScripts ? `script-src 'nonce-${nonce}' ${cspSource};` : `script-src 'none';`,
+    `style-src 'nonce-${nonce}';`,
+    `img-src ${cspSource} data: blob:;`,
+    `font-src ${cspSource};`,
+    `media-src ${cspSource};`,
+  ].join(' ');
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003C')
+    .replace(/>/g, '\\u003E')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function getNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
 }

--- a/src/visualizers/MoleculeViewerPanel.ts
+++ b/src/visualizers/MoleculeViewerPanel.ts
@@ -34,7 +34,7 @@ export class MoleculeViewerPanel {
       MoleculeViewerPanel.viewType,
       '3D Molecule Viewer',
       column || vscode.ViewColumn.One,
-      MoleculeViewerWebview.getWebviewOptions()
+      MoleculeViewerWebview.getWebviewOptions(extensionUri)
     );
 
     MoleculeViewerPanel.currentPanel = new MoleculeViewerPanel(
@@ -71,7 +71,10 @@ export class MoleculeViewerPanel {
     this._panel = panel;
 
     // Set the webview's initial HTML content
-    this._panel.webview.html = MoleculeViewerWebview.generateWebviewHTML();
+    this._panel.webview.html = MoleculeViewerWebview.generateWebviewHTML(
+      this._panel.webview,
+      this._extensionUri
+    );
 
     // Listen for when the panel is disposed
     this._panel.onDidDispose(() => this.dispose(), null, this._disposables);

--- a/src/visualizers/MoleculeViewerWebview.ts
+++ b/src/visualizers/MoleculeViewerWebview.ts
@@ -5,9 +5,12 @@ export class MoleculeViewerWebview {
    * Generate the HTML content for the molecule viewer webview
    * @returns HTML string with embedded JavaScript
    */
-  static generateWebviewHTML(): string {
-    const csp = this.getCSP();
+  static generateWebviewHTML(webview: vscode.Webview, extensionUri: vscode.Uri): string {
     const nonce = this.getNonce();
+    const nglScriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(extensionUri, 'node_modules', 'ngl', 'dist', 'ngl.js')
+    );
+    const csp = this.getCSP(webview.cspSource, nonce);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -16,7 +19,7 @@ export class MoleculeViewerWebview {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
   <title>3D Molecular Structure Viewer</title>
-  <style>
+  <style nonce="${nonce}">
     body {
       margin: 0;
       padding: 0;
@@ -120,8 +123,8 @@ export class MoleculeViewerWebview {
     <div id="error"></div>
   </div>
 
-  <script src="https://unpkg.com/ngl@2.2.1/dist/ngl.js"></script>
-  <script>
+  <script nonce="${nonce}" src="${nglScriptUri}"></script>
+  <script nonce="${nonce}">
     (function() {
       const vscode = acquireVsCodeApi();
       let stage = null;
@@ -339,22 +342,26 @@ export class MoleculeViewerWebview {
   /**
    * Get webview options
    */
-  static getWebviewOptions(): vscode.WebviewOptions {
+  static getWebviewOptions(extensionUri?: vscode.Uri): vscode.WebviewOptions {
     return {
       enableScripts: true,
+      localResourceRoots: extensionUri
+        ? [vscode.Uri.joinPath(extensionUri, 'node_modules', 'ngl', 'dist')]
+        : undefined,
     };
   }
 
   /**
    * Generate Content Security Policy for the webview
    */
-  static getCSP(): string {
+  static getCSP(cspSource: string, nonce: string): string {
     return [
       `default-src 'none';`,
-      `script-src https://unpkg.com https://cdn.jsdelivr.net 'nonce-${this.getNonce()}';`,
-      `style-src 'unsafe-inline';`,
-      `img-src https: data:;`,
-      `font-src https: data:;`,
+      `script-src 'nonce-${nonce}' ${cspSource};`,
+      `style-src 'nonce-${nonce}';`,
+      `img-src ${cspSource} data: blob:;`,
+      `font-src ${cspSource};`,
+      `media-src ${cspSource};`,
     ].join(' ');
   }
 

--- a/src/visualizers/ThreeJsWebview.ts
+++ b/src/visualizers/ThreeJsWebview.ts
@@ -79,15 +79,23 @@ export class ThreeJsWebview {
    */
   private getWebviewContent(): string {
     const nonce = getNonce();
+    const cspSource = this.panel.webview.cspSource;
+    const csp = [
+      `default-src 'none';`,
+      `script-src 'nonce-${nonce}';`,
+      `style-src 'nonce-${nonce}';`,
+      `img-src ${cspSource} data: blob:;`,
+      `media-src ${cspSource};`,
+    ].join(' ');
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
+    <meta http-equiv="Content-Security-Policy" content="${csp}">
     <title>3D Molecular Visualization</title>
-    <style>
+    <style nonce="${nonce}">
         body {
             margin: 0;
             padding: 0;
@@ -186,11 +194,14 @@ export class ThreeJsWebview {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 <body>
     <div id="container">
-        <div id="loading" class="loading" style="display: none;">
+        <div id="loading" class="loading hidden">
             <div class="spinner"></div>
             <div>Loading structure...</div>
         </div>
@@ -221,7 +232,7 @@ export class ThreeJsWebview {
             </div>
         </div>
 
-        <div class="info-panel" id="info-panel" style="display: none;">
+        <div class="info-panel hidden" id="info-panel">
             <div id="atom-count">Atoms: 0</div>
             <div id="bond-count">Bonds: 0</div>
         </div>

--- a/tests/mocks/vscode.ts
+++ b/tests/mocks/vscode.ts
@@ -10,6 +10,7 @@ export const window = {
       onDidReceiveMessage: jest.fn(),
       postMessage: jest.fn(),
       asWebviewUri: jest.fn((uri: any) => uri),
+      cspSource: 'vscode-resource:',
     },
     onDidDispose: jest.fn((cb: () => void) => ({ dispose: jest.fn() })),
     reveal: jest.fn(),
@@ -73,6 +74,16 @@ export const Uri = {
     scheme: 'file',
     toString: () => uri,
   })),
+  joinPath: jest.fn((base: any, ...paths: string[]) => {
+    const basePath = base.path || base.fsPath || base.toString();
+    const joinedPath = [basePath, ...paths].join('/').replace(/\/+/g, '/');
+    return {
+      path: joinedPath,
+      fsPath: joinedPath,
+      scheme: base.scheme || 'file',
+      toString: () => joinedPath,
+    };
+  }),
 };
 
 export const EventEmitter = jest.fn().mockImplementation(() => ({

--- a/tests/unit/DataPlotter.test.ts
+++ b/tests/unit/DataPlotter.test.ts
@@ -22,26 +22,36 @@ jest.mock('../../src/managers/FileTypeDetector', () => ({
 
 // Mock vscode module
 jest.mock('vscode', () => {
-  let currentPanel: any = null;
-
-  const mockPanel = {
-    reveal: jest.fn(),
-    onDidDispose: jest.fn(callback => callback()),
-    webview: { html: '' },
-    dispose: jest.fn(),
-  };
-
   return {
     Uri: {
-      file: (path: string) => ({ fsPath: path, scheme: 'file' }),
+      file: (path: string) => ({
+        path,
+        fsPath: path,
+        scheme: 'file',
+        toString: () => path,
+      }),
+      joinPath: (base: any, ...paths: string[]) => {
+        const basePath = base.path || base.fsPath || base.toString();
+        const joinedPath = [basePath, ...paths].join('/').replace(/\/+/g, '/');
+        return {
+          path: joinedPath,
+          fsPath: joinedPath,
+          scheme: base.scheme || 'file',
+          toString: () => joinedPath,
+        };
+      },
     },
     window: {
-      createWebviewPanel: jest.fn(() => {
-        if (!currentPanel) {
-          currentPanel = mockPanel;
-        }
-        return currentPanel;
-      }),
+      createWebviewPanel: jest.fn(() => ({
+        reveal: jest.fn(),
+        onDidDispose: jest.fn(),
+        webview: {
+          html: '',
+          asWebviewUri: jest.fn((uri: any) => uri),
+          cspSource: 'vscode-resource:',
+        },
+        dispose: jest.fn(),
+      })),
       showWarningMessage: jest.fn(),
     },
     ViewColumn: {
@@ -130,7 +140,15 @@ describe('DataPlotter', () => {
         'openqcDataPlotter',
         'OpenQC: Data Plotter',
         expect.any(Number),
-        expect.any(Object)
+        expect.objectContaining({
+          enableScripts: true,
+          localResourceRoots: expect.arrayContaining([
+            expect.objectContaining({
+              fsPath: expect.stringContaining('node_modules/plotly.js-dist-min'),
+            }),
+          ]),
+          retainContextWhenHidden: true,
+        })
       );
     });
 
@@ -309,8 +327,11 @@ FINAL SINGLE POINT ENERGY      -76.38462354
 
       plotter.show(mockEditor);
 
-      // Panel created
-      expect(vscode.window.createWebviewPanel).toHaveBeenCalled();
+      const panel = (vscode.window.createWebviewPanel as jest.Mock).mock.results[0].value;
+      expect(panel.webview.html).toContain('node_modules/plotly.js-dist-min/plotly.min.js');
+      expect(panel.webview.html).toContain('Content-Security-Policy');
+      expect(panel.webview.html).not.toContain('https://cdn.plot.ly');
+      expect(panel.webview.html).not.toContain("'unsafe-inline'");
     });
 
     it('should show software badge in header', () => {

--- a/tests/unit/providers/StructureViewer.test.ts
+++ b/tests/unit/providers/StructureViewer.test.ts
@@ -23,13 +23,32 @@ jest.mock('vscode', () => {
     onDidDispose: jest.fn(callback => {
       currentPanel = null;
     }),
-    webview: { html: '' },
+    webview: {
+      html: '',
+      asWebviewUri: jest.fn((uri: any) => uri),
+      cspSource: 'vscode-resource:',
+    },
     dispose: jest.fn(),
   };
 
   return {
     Uri: {
-      file: (path: string) => ({ fsPath: path, scheme: 'file' }),
+      file: (path: string) => ({
+        path,
+        fsPath: path,
+        scheme: 'file',
+        toString: () => path,
+      }),
+      joinPath: (base: any, ...paths: string[]) => {
+        const basePath = base.path || base.fsPath || base.toString();
+        const joinedPath = [basePath, ...paths].join('/').replace(/\/+/g, '/');
+        return {
+          path: joinedPath,
+          fsPath: joinedPath,
+          scheme: base.scheme || 'file',
+          toString: () => joinedPath,
+        };
+      },
     },
     window: {
       createWebviewPanel: jest.fn(() => {
@@ -100,7 +119,11 @@ Direct
         vscode.ViewColumn.Two,
         expect.objectContaining({
           enableScripts: true,
-          localResourceRoots: [mockUri],
+          localResourceRoots: expect.arrayContaining([
+            expect.objectContaining({
+              fsPath: expect.stringContaining('node_modules/3dmol/build'),
+            }),
+          ]),
           retainContextWhenHidden: true,
         })
       );
@@ -154,7 +177,11 @@ Direct
         expect.any(Number),
         expect.objectContaining({
           enableScripts: true,
-          localResourceRoots: [mockUri],
+          localResourceRoots: expect.arrayContaining([
+            expect.objectContaining({
+              fsPath: expect.stringContaining('node_modules/3dmol/build'),
+            }),
+          ]),
           retainContextWhenHidden: true,
         })
       );
@@ -264,8 +291,27 @@ O 0.0 0.0 0.0`,
 
       viewer.show(mockEditor);
 
-      // Verify the function was called
-      expect(vscode.window.createWebviewPanel).toHaveBeenCalled();
+      const panel = (vscode.window.createWebviewPanel as jest.Mock).mock.results[0].value;
+      expect(panel.webview.html).toContain('data-style="stick"');
+      expect(panel.webview.html).toContain('data-style="sphere"');
+      expect(panel.webview.html).not.toContain('onclick=');
+    });
+
+    it('loads 3Dmol locally with a strict CSP', () => {
+      const mockEditor = {
+        document: {
+          fileName: '/test/POSCAR',
+          getText: () => 'Si\n1.0',
+        },
+      } as unknown as vscode.TextEditor;
+
+      viewer.show(mockEditor);
+
+      const panel = (vscode.window.createWebviewPanel as jest.Mock).mock.results[0].value;
+      expect(panel.webview.html).toContain('node_modules/3dmol/build/3Dmol-min.js');
+      expect(panel.webview.html).toContain('Content-Security-Policy');
+      expect(panel.webview.html).not.toContain('https://cdnjs.cloudflare.com');
+      expect(panel.webview.html).not.toContain("'unsafe-inline'");
     });
   });
 });

--- a/tests/unit/visualizers/MoleculeViewerPanel.test.ts
+++ b/tests/unit/visualizers/MoleculeViewerPanel.test.ts
@@ -7,7 +7,22 @@ import {
 // Mock vscode module
 jest.mock('vscode', () => ({
   Uri: {
-    file: (path: string) => ({ fsPath: path, scheme: 'file' }),
+    file: (path: string) => ({
+      path,
+      fsPath: path,
+      scheme: 'file',
+      toString: () => path,
+    }),
+    joinPath: (base: any, ...paths: string[]) => {
+      const basePath = base.path || base.fsPath || base.toString();
+      const joinedPath = [basePath, ...paths].join('/').replace(/\/+/g, '/');
+      return {
+        path: joinedPath,
+        fsPath: joinedPath,
+        scheme: base.scheme || 'file',
+        toString: () => joinedPath,
+      };
+    },
   },
   window: {
     createWebviewPanel: jest.fn(),
@@ -31,6 +46,8 @@ jest.mock('vscode', () => ({
     webview = {
       postMessage: jest.fn(),
       onDidReceiveMessage: jest.fn(),
+      asWebviewUri: jest.fn((uri: any) => uri),
+      cspSource: 'vscode-resource:',
     };
     reveal = jest.fn();
     dispose = jest.fn();
@@ -47,6 +64,8 @@ describe('MoleculeViewerPanel', () => {
       webview: {
         postMessage: jest.fn(),
         onDidReceiveMessage: jest.fn(),
+        asWebviewUri: jest.fn((uri: any) => uri),
+        cspSource: 'vscode-resource:',
         html: '',
       },
       onDidDispose: jest.fn(),

--- a/tests/unit/visualizers/MoleculeViewerWebview.test.ts
+++ b/tests/unit/visualizers/MoleculeViewerWebview.test.ts
@@ -1,66 +1,94 @@
+import * as vscode from 'vscode';
 import { MoleculeViewerWebview } from '../../../src/visualizers/MoleculeViewerWebview';
 
 describe('MoleculeViewerWebview', () => {
+  const mockExtensionUri = vscode.Uri.file('/test/openqc');
+  const mockWebview = {
+    asWebviewUri: jest.fn((uri: vscode.Uri) => uri),
+    cspSource: 'vscode-resource:',
+  } as unknown as vscode.Webview;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('generateWebviewHTML', () => {
-    it('generates HTML with NGL Viewer script', () => {
-      const html = MoleculeViewerWebview.generateWebviewHTML();
+    it('generates HTML with local NGL Viewer script', () => {
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
 
       expect(html).toContain('ngl');
       expect(html).toContain('<script');
       expect(html).toContain('</script>');
+      expect(html).toContain('node_modules/ngl/dist/ngl.js');
+      expect(html).not.toContain('https://unpkg.com');
+      expect(html).not.toContain('https://cdn.jsdelivr.net');
     });
 
     it('includes VSCode webview API script', () => {
-      const html = MoleculeViewerWebview.generateWebviewHTML();
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
 
       expect(html).toContain('acquireVsCodeApi');
     });
 
     it('includes canvas element for 3D rendering', () => {
-      const html = MoleculeViewerWebview.generateWebviewHTML();
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
 
       expect(html).toContain('<canvas');
       expect(html).toContain('id="ngl-canvas"');
     });
 
     it('includes message listener for extension communication', () => {
-      const html = MoleculeViewerWebview.generateWebviewHTML();
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
 
       expect(html).toContain('window.addEventListener');
       expect(html).toContain('message');
     });
 
     it('handles initialize message with structure data', () => {
-      const html = MoleculeViewerWebview.generateWebviewHTML();
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
 
       expect(html).toContain('initialize');
       expect(html).toContain('loadStructure');
+    });
+
+    it('adds nonces to inline scripts and styles', () => {
+      const html = MoleculeViewerWebview.generateWebviewHTML(mockWebview, mockExtensionUri);
+
+      expect(html).toMatch(/<style nonce="[A-Za-z0-9]{32}">/);
+      expect(html).toMatch(/<script nonce="[A-Za-z0-9]{32}" src="[^"]*ngl\.js"><\/script>/);
+      expect(html).toMatch(/<script nonce="[A-Za-z0-9]{32}">/);
     });
   });
 
   describe('getWebviewOptions', () => {
     it('returns correct webview options', () => {
-      const options = MoleculeViewerWebview.getWebviewOptions();
+      const options = MoleculeViewerWebview.getWebviewOptions(mockExtensionUri);
 
       expect(options).toHaveProperty('enableScripts', true);
+      expect(options.localResourceRoots).toHaveLength(1);
+      expect(options.localResourceRoots?.[0].toString()).toContain('node_modules/ngl/dist');
     });
   });
 
   describe('getCSP', () => {
     it('generates valid Content Security Policy', () => {
-      const csp = MoleculeViewerWebview.getCSP();
+      const csp = MoleculeViewerWebview.getCSP('vscode-resource:', 'testnonce');
 
       expect(csp).toContain('default-src');
       expect(csp).toContain('script-src');
       expect(csp).toContain('style-src');
       expect(csp).toContain('img-src');
+      expect(csp).toContain("'nonce-testnonce'");
+      expect(csp).toContain('vscode-resource:');
     });
 
-    it('allows NGL Viewer CDN', () => {
-      const csp = MoleculeViewerWebview.getCSP();
+    it('does not allow remote CDN resources', () => {
+      const csp = MoleculeViewerWebview.getCSP('vscode-resource:', 'testnonce');
 
-      expect(csp).toContain('https://unpkg.com');
-      expect(csp).toContain('https://cdn.jsdelivr.net');
+      expect(csp).not.toContain('https://unpkg.com');
+      expect(csp).not.toContain('https://cdn.jsdelivr.net');
+      expect(csp).not.toContain('https:');
+      expect(csp).not.toContain("'unsafe-inline'");
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace CDN-loaded webview libraries with local extension-packaged npm assets for NGL, 3Dmol, and Plotly
- add nonce-based CSPs and local resource roots to visualization webviews
- disable scripts and add CSP/HTML escaping for the results webview
- add focused tests guarding local resource loading and CSP behavior

Closes #45

## Verification
- npm run compile
- npm run lint
- npm run typecheck
- npm run format:check
- npm run test:unit
- npm run test:integration
- rg scan: no remote CDN script/link URLs or unsafe-inline CSP tokens remain in src

## Notes
- npm audit still reports the pre-existing Mocha -> serialize-javascript advisory; the new NGL transitive Three advisory was removed with an npm override to the repo's existing Three version.
