### PR TITLE
Harden remote SSH execution

### DIFF
--- a/docs/remote-ssh-security.md
+++ b/docs/remote-ssh-security.md
@@ -1,0 +1,19 @@
+# Remote SSH Security
+
+OpenQC remote compute integration uses Paramiko and verifies server host keys by default.
+Unknown host keys are rejected unless `allow_unknown_host=True` is passed when creating
+`SSHHandler`.
+
+Recommended setup:
+
+1. Add trusted compute hosts to the user's OpenSSH `known_hosts` file with `ssh-keyscan`
+   or by connecting once with the OpenSSH client after verifying the fingerprint out of band.
+2. Pass `known_hosts_path` when the integration should use a project- or environment-specific
+   trust store instead of only the user's default SSH trust store.
+3. Use key-based authentication or environment-managed credentials. Do not hardcode passwords
+   in project files.
+4. Prefer `SSHHandler.execute_args([...])` for remote commands. It shell-quotes arguments before
+   sending the command string to the SSH server.
+
+`allow_unknown_host=True` should only be used for controlled bootstrapping flows where the host
+fingerprint has been verified through another trusted channel.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,6 @@ ase>=3.22.0  # Atomic Simulation Environment
 
 # Optional for crystallographic formats
 pymatgen>=2022.0.0  # Materials Project library
+
+# Remote server integration
+paramiko>=3.4.0

--- a/server/file_transfer.py
+++ b/server/file_transfer.py
@@ -53,7 +53,7 @@ class FileTransfer:
             try:
                 sftp.stat(remote_dir)
             except FileNotFoundError:
-                self.ssh.execute(f"mkdir -p {remote_dir}")
+                self.ssh.execute_args(["mkdir", "-p", remote_dir])
             
             sftp.put(local_path, remote_path, callback=callback)
             return True

--- a/server/slurm_interface.py
+++ b/server/slurm_interface.py
@@ -5,6 +5,16 @@ Slurm job management interface.
 from typing import Optional, List, Dict, Any
 from dataclasses import dataclass
 from datetime import datetime
+import re
+
+
+_SLURM_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _validate_slurm_token(value: str, name: str) -> str:
+    if not isinstance(value, str) or not _SLURM_ID_RE.fullmatch(value):
+        raise ValueError(f"{name} contains unsupported characters")
+    return value
 
 
 @dataclass
@@ -53,11 +63,12 @@ class SlurmInterface:
         Returns:
             Job ID
         """
-        cmd = f"sbatch {script_path}"
+        args = ["sbatch"]
         if job_name:
-            cmd += f" --job-name={job_name}"
+            args.append(f"--job-name={_validate_slurm_token(job_name, 'job_name')}")
+        args.append(script_path)
         
-        exit_code, stdout, stderr = self.ssh.execute(cmd)
+        exit_code, stdout, stderr = self.ssh.execute_args(args)
         
         if exit_code != 0:
             raise RuntimeError(f"Job submission failed: {stderr}")
@@ -69,13 +80,21 @@ class SlurmInterface:
     
     def cancel_job(self, job_id: str) -> bool:
         """Cancel a running job."""
-        exit_code, stdout, stderr = self.ssh.execute(f"scancel {job_id}")
+        exit_code, stdout, stderr = self.ssh.execute_args([
+            "scancel",
+            _validate_slurm_token(job_id, "job_id")
+        ])
         return exit_code == 0
     
     def get_job_status(self, job_id: str) -> Optional[SlurmJob]:
         """Get status of a specific job."""
-        cmd = f"squeue -j {job_id} --format='%i %j %u %T %P %D %C %l %M' --noheader"
-        exit_code, stdout, stderr = self.ssh.execute(cmd)
+        exit_code, stdout, stderr = self.ssh.execute_args([
+            "squeue",
+            "-j",
+            _validate_slurm_token(job_id, "job_id"),
+            "--format=%i %j %u %T %P %D %C %l %M",
+            "--noheader"
+        ])
         
         if exit_code != 0 or not stdout.strip():
             return None
@@ -97,11 +116,15 @@ class SlurmInterface:
     
     def list_jobs(self, user: Optional[str] = None) -> List[SlurmJob]:
         """List all jobs (optionally filtered by user)."""
-        cmd = "squeue --format='%i %j %u %T %P %D %C %l %M' --noheader"
+        args = [
+            "squeue",
+            "--format=%i %j %u %T %P %D %C %l %M",
+            "--noheader"
+        ]
         if user:
-            cmd += f" --user={user}"
+            args.append(f"--user={_validate_slurm_token(user, 'user')}")
         
-        exit_code, stdout, stderr = self.ssh.execute(cmd)
+        exit_code, stdout, stderr = self.ssh.execute_args(args)
         
         if exit_code != 0:
             return []
@@ -126,8 +149,11 @@ class SlurmInterface:
     
     def get_queue_info(self) -> Dict[str, Any]:
         """Get queue/partition information."""
-        cmd = "sinfo --format='%P %a %l %D %T' --noheader"
-        exit_code, stdout, stderr = self.ssh.execute(cmd)
+        exit_code, stdout, stderr = self.ssh.execute_args([
+            "sinfo",
+            "--format=%P %a %l %D %T",
+            "--noheader"
+        ])
         
         if exit_code != 0:
             return {}

--- a/server/ssh_handler.py
+++ b/server/ssh_handler.py
@@ -3,8 +3,12 @@ SSH connection management for remote servers.
 """
 
 import paramiko
-from typing import Optional, Dict, Any
-from pathlib import Path
+import shlex
+from typing import Optional, Sequence
+
+
+class RemoteCommandError(RuntimeError):
+    """Raised when a remote command cannot be executed safely."""
 
 
 class SSHHandler:
@@ -18,7 +22,12 @@ class SSHHandler:
         username: str,
         port: int = 22,
         key_path: Optional[str] = None,
-        password: Optional[str] = None
+        password: Optional[str] = None,
+        known_hosts_path: Optional[str] = None,
+        allow_unknown_host: bool = False,
+        connect_timeout: int = 10,
+        command_timeout: int = 300,
+        max_output_bytes: int = 1024 * 1024
     ):
         """
         Initialize SSH handler.
@@ -29,12 +38,22 @@ class SSHHandler:
             port: SSH port (default 22)
             key_path: Path to SSH private key
             password: Password (if not using key)
+            known_hosts_path: Optional known_hosts file to trust
+            allow_unknown_host: Explicitly trust and save unknown host keys
+            connect_timeout: Connection timeout in seconds
+            command_timeout: Remote command timeout in seconds
+            max_output_bytes: Maximum bytes read from stdout or stderr
         """
         self.host = host
         self.username = username
         self.port = port
         self.key_path = key_path
         self.password = password
+        self.known_hosts_path = known_hosts_path
+        self.allow_unknown_host = allow_unknown_host
+        self.connect_timeout = connect_timeout
+        self.command_timeout = command_timeout
+        self.max_output_bytes = max_output_bytes
         
         self._client: Optional[paramiko.SSHClient] = None
     
@@ -42,12 +61,22 @@ class SSHHandler:
         """Establish SSH connection."""
         try:
             self._client = paramiko.SSHClient()
-            self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self._client.load_system_host_keys()
+            if self.known_hosts_path:
+                self._client.load_host_keys(self.known_hosts_path)
+            if self.allow_unknown_host:
+                self._client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            else:
+                self._client.set_missing_host_key_policy(paramiko.RejectPolicy())
             
             connect_kwargs = {
                 'hostname': self.host,
                 'port': self.port,
                 'username': self.username,
+                'timeout': self.connect_timeout,
+                'banner_timeout': self.connect_timeout,
+                'auth_timeout': self.connect_timeout,
+                'look_for_keys': self.key_path is None and self.password is None,
             }
             
             if self.key_path:
@@ -68,24 +97,57 @@ class SSHHandler:
             self._client.close()
             self._client = None
     
-    def execute(self, command: str) -> tuple[int, str, str]:
+    def execute(self, command: str, *, timeout: Optional[int] = None) -> tuple[int, str, str]:
         """
         Execute command on remote server.
+        
+        Prefer execute_args() for command execution with untrusted arguments.
         
         Returns:
             Tuple of (exit_code, stdout, stderr)
         """
         if not self._client:
             raise RuntimeError("Not connected to server")
+        if not isinstance(command, str) or not command.strip():
+            raise ValueError("command must be a non-empty string")
         
-        stdin, stdout, stderr = self._client.exec_command(command)
+        stdin, stdout, stderr = self._client.exec_command(
+            command,
+            timeout=timeout or self.command_timeout
+        )
         exit_code = stdout.channel.recv_exit_status()
         
         return (
             exit_code,
-            stdout.read().decode('utf-8'),
-            stderr.read().decode('utf-8')
+            self._read_limited(stdout, "stdout"),
+            self._read_limited(stderr, "stderr")
         )
+
+    def execute_args(self, argv: Sequence[str], *, timeout: Optional[int] = None) -> tuple[int, str, str]:
+        """
+        Execute a command from an argv-style sequence.
+
+        Arguments are shell-quoted before being sent to Paramiko because SSH
+        servers execute command strings through the user's login shell.
+        """
+        return self.execute(self.build_command(argv), timeout=timeout)
+
+    @staticmethod
+    def build_command(argv: Sequence[str]) -> str:
+        """Build a safely quoted remote shell command from argv."""
+        if not argv:
+            raise ValueError("argv must contain at least one argument")
+        if any(not isinstance(arg, str) or arg == "" for arg in argv):
+            raise ValueError("argv entries must be non-empty strings")
+        return " ".join(shlex.quote(arg) for arg in argv)
+
+    def _read_limited(self, stream, stream_name: str) -> str:
+        data = stream.read(self.max_output_bytes + 1)
+        if len(data) > self.max_output_bytes:
+            raise RemoteCommandError(
+                f"Remote command {stream_name} exceeded {self.max_output_bytes} bytes"
+            )
+        return data.decode('utf-8', errors='replace')
     
     @property
     def is_connected(self) -> bool:

--- a/tests/python/test_remote_security.py
+++ b/tests/python/test_remote_security.py
@@ -1,0 +1,179 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeAutoAddPolicy:
+    pass
+
+
+class FakeRejectPolicy:
+    pass
+
+
+class FakeSSHClient:
+    def __init__(self):
+        self.loaded_system_host_keys = False
+        self.loaded_host_keys = []
+        self.policy = None
+        self.connected_with = None
+        self.exec_calls = []
+
+    def load_system_host_keys(self):
+        self.loaded_system_host_keys = True
+
+    def load_host_keys(self, path):
+        self.loaded_host_keys.append(path)
+
+    def set_missing_host_key_policy(self, policy):
+        self.policy = policy
+
+    def connect(self, **kwargs):
+        self.connected_with = kwargs
+
+    def exec_command(self, command, timeout=None):
+        self.exec_calls.append((command, timeout))
+        return None, FakeStream(b"ok"), FakeStream(b"")
+
+
+class FakeChannel:
+    def recv_exit_status(self):
+        return 0
+
+
+class FakeStream:
+    def __init__(self, data):
+        self.data = data
+        self.channel = FakeChannel()
+
+    def read(self, size=-1):
+        if size < 0:
+            return self.data
+        return self.data[:size]
+
+
+class FakeSSH:
+    def __init__(self):
+        self.calls = []
+
+    def execute_args(self, args):
+        self.calls.append(args)
+        return 0, "Submitted batch job 12345", ""
+
+
+def install_fake_paramiko():
+    fake_paramiko = types.SimpleNamespace(
+        SSHClient=FakeSSHClient,
+        AutoAddPolicy=FakeAutoAddPolicy,
+        RejectPolicy=FakeRejectPolicy,
+    )
+    sys.modules["paramiko"] = fake_paramiko
+
+
+class RemoteSecurityTests(unittest.TestCase):
+    def setUp(self):
+        install_fake_paramiko()
+        for module_name in [
+            "server.ssh_handler",
+            "server.slurm_interface",
+            "server.file_transfer",
+        ]:
+            sys.modules.pop(module_name, None)
+
+    def test_ssh_rejects_unknown_hosts_by_default(self):
+        ssh_handler = importlib.import_module("server.ssh_handler")
+
+        handler = ssh_handler.SSHHandler(
+            "cluster.example",
+            "alice",
+            known_hosts_path="/tmp/known_hosts",
+        )
+
+        self.assertTrue(handler.connect())
+        self.assertTrue(handler._client.loaded_system_host_keys)
+        self.assertEqual(handler._client.loaded_host_keys, ["/tmp/known_hosts"])
+        self.assertIsInstance(handler._client.policy, FakeRejectPolicy)
+        self.assertEqual(handler._client.connected_with["timeout"], 10)
+        self.assertEqual(handler._client.connected_with["banner_timeout"], 10)
+        self.assertEqual(handler._client.connected_with["auth_timeout"], 10)
+
+    def test_unknown_host_trust_must_be_explicit(self):
+        ssh_handler = importlib.import_module("server.ssh_handler")
+
+        handler = ssh_handler.SSHHandler(
+            "cluster.example",
+            "alice",
+            allow_unknown_host=True,
+        )
+
+        self.assertTrue(handler.connect())
+        self.assertIsInstance(handler._client.policy, FakeAutoAddPolicy)
+
+    def test_execute_args_quotes_shell_arguments_and_sets_timeout(self):
+        ssh_handler = importlib.import_module("server.ssh_handler")
+        handler = ssh_handler.SSHHandler("cluster.example", "alice")
+        self.assertTrue(handler.connect())
+
+        result = handler.execute_args(["mkdir", "-p", "/scratch/alice/a dir; rm -rf /"])
+
+        self.assertEqual(result, (0, "ok", ""))
+        self.assertEqual(
+            handler._client.exec_calls,
+            [("mkdir -p '/scratch/alice/a dir; rm -rf /'", 300)]
+        )
+
+    def test_execute_enforces_output_limit(self):
+        ssh_handler = importlib.import_module("server.ssh_handler")
+        handler = ssh_handler.SSHHandler("cluster.example", "alice", max_output_bytes=1)
+
+        with self.assertRaises(ssh_handler.RemoteCommandError):
+            handler._read_limited(FakeStream(b"too much"), "stdout")
+
+    def test_slurm_uses_structured_commands_and_rejects_injected_identifiers(self):
+        slurm_interface = importlib.import_module("server.slurm_interface")
+        ssh = FakeSSH()
+        slurm = slurm_interface.SlurmInterface(ssh)
+
+        job_id = slurm.submit_job("/scratch/alice/job script.sh", job_name="qc_job-1")
+        cancelled = slurm.cancel_job("12345")
+
+        self.assertEqual(job_id, "12345")
+        self.assertTrue(cancelled)
+        self.assertEqual(
+            ssh.calls,
+            [
+                ["sbatch", "--job-name=qc_job-1", "/scratch/alice/job script.sh"],
+                ["scancel", "12345"],
+            ],
+        )
+        with self.assertRaises(ValueError):
+            slurm.cancel_job("12345; rm -rf /")
+
+    def test_file_transfer_creates_remote_directory_with_structured_command(self):
+        file_transfer = importlib.import_module("server.file_transfer")
+
+        class FakeSftp:
+            def stat(self, path):
+                raise FileNotFoundError()
+
+            def put(self, local_path, remote_path, callback=None):
+                self.put_call = (local_path, remote_path, callback)
+
+        class FakeClient:
+            def __init__(self):
+                self.sftp = FakeSftp()
+
+            def open_sftp(self):
+                return self.sftp
+
+        ssh = FakeSSH()
+        ssh._client = FakeClient()
+        transfer = file_transfer.FileTransfer(ssh)
+
+        self.assertTrue(transfer.upload("local.inp", "/scratch/alice/a dir/job.inp"))
+        self.assertEqual(ssh.calls, [["mkdir", "-p", "/scratch/alice/a dir"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject unknown SSH host keys by default and support explicit known_hosts configuration
- add timeouts, output limits, and argv-style remote command execution
- update Slurm/file-transfer remote commands to use structured execution and validate scheduler identifiers
- document host key handling and add focused Python security tests

Closes #47

## Verification
- npm ci
- npm run compile
- npm run lint
- npm run typecheck
- npm run format:check
- npm run test:unit
- npm run test:integration
- python3 -m py_compile server/ssh_handler.py server/slurm_interface.py server/file_transfer.py
- python3 -m unittest tests.python.test_remote_security -v

## Notes
- npm audit --audit-level=moderate reports an existing Mocha/serialize-javascript advisory requiring npm audit fix --force with a breaking dependency change; left out of scope for this SSH hardening PR.