### PR TITLE
Unify LSP discovery with manager configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,11 @@
           "INCAR",
           "POSCAR",
           "KPOINTS",
-          "POTCAR"
+          "POTCAR",
+          "CONTCAR",
+          "OSZICAR",
+          "OUTCAR",
+          "vasprun.xml"
         ],
         "configuration": "./language-configurations/vasp.json"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
   fileTypeDetector = new FileTypeDetector();
 
   // Initialize LSP Manager
-  lspManager = new LSPManager();
+  lspManager = new LSPManager(context);
 
   // Initialize visualization providers
   structureViewer = new StructureViewer(context.extensionUri);

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -6,22 +6,27 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 import { FileTypeDetector, QuantumChemistrySoftware } from './FileTypeDetector';
+import { LSPDiscovery, LSPServerDefinition } from '../utils/LSPDiscovery';
 
 interface LSPServerConfig {
   name: string;
   enabled: boolean;
   path: string;
   args: string[];
+  definition: LSPServerDefinition;
 }
 
 export class LSPManager {
   private clients: Map<string, LanguageClient> = new Map();
   private fileTypeDetector: FileTypeDetector;
   private config: vscode.WorkspaceConfiguration;
+  private discovery: LSPDiscovery;
+  private serverDefinitions: LSPServerDefinition[] = LSPDiscovery.getDefaultDefinitions();
 
-  constructor() {
+  constructor(context?: vscode.ExtensionContext, discovery?: LSPDiscovery) {
     this.fileTypeDetector = new FileTypeDetector();
     this.config = vscode.workspace.getConfiguration('openqc.lsp');
+    this.discovery = discovery || new LSPDiscovery(context);
   }
 
   async startLSPForDocument(document: vscode.TextDocument): Promise<void> {
@@ -30,12 +35,16 @@ export class LSPManager {
       return;
     }
 
-    const languageId = this.getLanguageId(software);
+    const serverConfig = await this.getServerConfig(software);
+    if (!serverConfig) {
+      return;
+    }
+
+    const languageId = serverConfig.definition.languageId;
     if (this.clients.has(languageId)) {
       return; // LSP already running
     }
 
-    const serverConfig = this.getServerConfig(software);
     if (!serverConfig.enabled) {
       return;
     }
@@ -61,7 +70,12 @@ export class LSPManager {
       return;
     }
 
-    const languageId = this.getLanguageId(software);
+    const definition = this.findServerDefinition(software);
+    if (!definition) {
+      return;
+    }
+
+    const languageId = definition.languageId;
     const client = this.clients.get(languageId);
     if (client) {
       try {
@@ -123,10 +137,10 @@ export class LSPManager {
       };
 
       const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: this.getLanguageId(software) }],
+        documentSelector: [{ scheme: 'file', language: config.definition.languageId }],
         synchronize: {
           fileEvents: vscode.workspace.createFileSystemWatcher(
-            `**/*.{${this.getExtensions(software).join(',')}}`
+            this.createWatcherPattern(config.definition)
           ),
         },
       };
@@ -143,40 +157,51 @@ export class LSPManager {
     }
   }
 
-  private getServerConfig(software: QuantumChemistrySoftware): LSPServerConfig {
-    const softwareKey = software.toLowerCase();
+  private async getServerConfig(
+    software: QuantumChemistrySoftware
+  ): Promise<LSPServerConfig | undefined> {
+    await this.refreshDiscoveredDefinitions();
+
+    const definition = this.findServerDefinition(software);
+    if (!definition) {
+      return undefined;
+    }
+
+    const softwareKey = definition.languageId;
     return {
-      name: `${software} LSP`,
-      enabled: this.config.get<boolean>(`${softwareKey}.enabled`, true),
-      path: this.config.get<string>(`${softwareKey}.path`, `${softwareKey}-lsp`),
+      name: `${definition.name} LSP`,
+      enabled: this.config.get<boolean>(`${softwareKey}.enabled`, definition.enabled),
+      path: this.config.get<string>(`${softwareKey}.path`, definition.executable),
       args: ['--stdio'],
+      definition,
     };
   }
 
-  private getLanguageId(software: QuantumChemistrySoftware): string {
-    const mapping: Record<QuantumChemistrySoftware, string> = {
-      CP2K: 'cp2k',
-      VASP: 'vasp',
-      Gaussian: 'gaussian',
-      ORCA: 'orca',
-      'Quantum ESPRESSO': 'qe',
-      GAMESS: 'gamess',
-      NWChem: 'nwchem',
-    };
-    return mapping[software];
+  private async refreshDiscoveredDefinitions(): Promise<void> {
+    this.serverDefinitions = await this.discovery.fetchLSPRepositories();
   }
 
-  private getExtensions(software: QuantumChemistrySoftware): string[] {
-    const mapping: Record<QuantumChemistrySoftware, string[]> = {
-      CP2K: ['inp'],
-      VASP: ['INCAR', 'POSCAR', 'KPOINTS', 'POTCAR'],
-      Gaussian: ['gjf', 'com'],
-      ORCA: ['inp'],
-      'Quantum ESPRESSO': ['in', 'pw.in', 'relax.in'],
-      GAMESS: ['inp'],
-      NWChem: ['nw'],
-    };
-    return mapping[software];
+  private findServerDefinition(
+    software: QuantumChemistrySoftware
+  ): LSPServerDefinition | undefined {
+    return this.serverDefinitions.find(definition => definition.name === software);
+  }
+
+  private createWatcherPattern(definition: LSPServerDefinition): string {
+    const filePatterns = [
+      ...definition.fileExtensions.map(extension => `*.${extension}`),
+      ...(definition.fileNames || []),
+    ];
+
+    if (filePatterns.length === 0) {
+      return '**/*';
+    }
+
+    if (filePatterns.length === 1) {
+      return `**/${filePatterns[0]}`;
+    }
+
+    return `**/{${filePatterns.join(',')}}`;
   }
 
   dispose(): void {

--- a/src/utils/LSPDiscovery.ts
+++ b/src/utils/LSPDiscovery.ts
@@ -61,6 +61,105 @@ interface CacheEntry {
   timestamp: number;
 }
 
+export const DEFAULT_LSP_SERVER_DEFINITIONS: readonly LSPServerDefinition[] = [
+  {
+    id: 'vasp-lsp',
+    name: 'VASP',
+    repository: 'OpenQuantumChemistry/vasp-lsp',
+    executable: 'vasp-lsp',
+    languageId: 'vasp',
+    fileExtensions: [],
+    fileNames: [
+      'INCAR',
+      'POSCAR',
+      'KPOINTS',
+      'POTCAR',
+      'CONTCAR',
+      'OSZICAR',
+      'OUTCAR',
+      'vasprun.xml',
+    ],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/vasp-lsp',
+  },
+  {
+    id: 'gaussian-lsp',
+    name: 'Gaussian',
+    repository: 'OpenQuantumChemistry/gaussian-lsp',
+    executable: 'gaussian-lsp',
+    languageId: 'gaussian',
+    fileExtensions: ['gjf', 'com'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/gaussian-lsp',
+  },
+  {
+    id: 'orca-lsp',
+    name: 'ORCA',
+    repository: 'OpenQuantumChemistry/orca-lsp',
+    executable: 'orca-lsp',
+    languageId: 'orca',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/orca-lsp',
+  },
+  {
+    id: 'cp2k-lsp-enhanced',
+    name: 'CP2K',
+    repository: 'OpenQuantumChemistry/cp2k-lsp-enhanced',
+    executable: 'cp2k-language-server',
+    languageId: 'cp2k',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/cp2k-lsp-enhanced',
+  },
+  {
+    id: 'qe-lsp',
+    name: 'Quantum ESPRESSO',
+    repository: 'OpenQuantumChemistry/qe-lsp',
+    executable: 'qe-lsp',
+    languageId: 'qe',
+    fileExtensions: [
+      'in',
+      'pw.in',
+      'relax.in',
+      'vc-relax.in',
+      'scf.in',
+      'nscf.in',
+      'bands.in',
+      'ph.in',
+      'dos.in',
+    ],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/qe-lsp',
+  },
+  {
+    id: 'gamess-lsp',
+    name: 'GAMESS',
+    repository: 'OpenQuantumChemistry/gamess-lsp',
+    executable: 'gamess-lsp',
+    languageId: 'gamess',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/gamess-lsp',
+  },
+  {
+    id: 'nwchem-lsp',
+    name: 'NWChem',
+    repository: 'OpenQuantumChemistry/nwchem-lsp',
+    executable: 'nwchem-lsp',
+    languageId: 'nwchem',
+    fileExtensions: ['nw', 'nwinp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/OpenQuantumChemistry/nwchem-lsp',
+  },
+];
+
 export class LSPDiscovery {
   private static readonly CACHE_KEY = 'openqc.lsp.discovery.cache';
   private static readonly CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -73,83 +172,7 @@ export class LSPDiscovery {
    * Known LSP to language mappings
    * These are used when auto-detecting from repository names
    */
-  private static readonly KNOWN_MAPPINGS: Record<
-    string,
-    {
-      name: string;
-      languageId: string;
-      extensions: string[];
-      fileNames?: string[];
-    }
-  > = {
-    'vasp-lsp': {
-      name: 'VASP',
-      languageId: 'vasp',
-      extensions: [],
-      fileNames: [
-        'INCAR',
-        'POSCAR',
-        'KPOINTS',
-        'POTCAR',
-        'CONTCAR',
-        'OSZICAR',
-        'OUTCAR',
-        'vasprun.xml',
-      ],
-    },
-    'gaussian-lsp': {
-      name: 'Gaussian',
-      languageId: 'gaussian',
-      extensions: ['gjf', 'com'],
-      fileNames: [],
-    },
-    'orca-lsp': {
-      name: 'ORCA',
-      languageId: 'orca',
-      extensions: ['inp'],
-      fileNames: [],
-    },
-    'cp2k-lsp': {
-      name: 'CP2K',
-      languageId: 'cp2k',
-      extensions: ['inp'],
-      fileNames: [],
-    },
-    'cp2k-lsp-enhanced': {
-      name: 'CP2K',
-      languageId: 'cp2k',
-      extensions: ['inp'],
-      fileNames: [],
-    },
-    'qe-lsp': {
-      name: 'Quantum ESPRESSO',
-      languageId: 'qe',
-      extensions: [
-        'in',
-        'pw.in',
-        'relax.in',
-        'vc-relax.in',
-        'scf.in',
-        'nscf.in',
-        'bands.in',
-        'ph.in',
-        'dos.in',
-      ],
-      fileNames: [],
-    },
-    'gamess-lsp': {
-      name: 'GAMESS',
-      languageId: 'gamess',
-      extensions: ['inp'],
-      fileNames: [],
-    },
-    'nwchem-lsp': {
-      name: 'NWChem',
-      languageId: 'nwchem',
-      extensions: ['nw', 'nwinp'],
-      fileNames: [],
-    },
-  };
+  private static readonly KNOWN_MAPPINGS = LSPDiscovery.createKnownMappings();
 
   constructor(context?: vscode.ExtensionContext) {
     this.context = context;
@@ -202,6 +225,49 @@ export class LSPDiscovery {
     }
   }
 
+  static getDefaultDefinitions(): LSPServerDefinition[] {
+    return DEFAULT_LSP_SERVER_DEFINITIONS.map(definition => ({
+      ...definition,
+      fileExtensions: [...definition.fileExtensions],
+      fileNames: definition.fileNames ? [...definition.fileNames] : undefined,
+    }));
+  }
+
+  private static createKnownMappings(): Record<
+    string,
+    {
+      name: string;
+      languageId: string;
+      extensions: string[];
+      fileNames?: string[];
+      executable: string;
+    }
+  > {
+    const mappings: Record<
+      string,
+      {
+        name: string;
+        languageId: string;
+        extensions: string[];
+        fileNames?: string[];
+        executable: string;
+      }
+    > = {};
+
+    for (const definition of DEFAULT_LSP_SERVER_DEFINITIONS) {
+      mappings[definition.id] = {
+        name: definition.name,
+        languageId: definition.languageId,
+        extensions: [...definition.fileExtensions],
+        fileNames: definition.fileNames ? [...definition.fileNames] : undefined,
+        executable: definition.executable,
+      };
+    }
+
+    mappings['cp2k-lsp'] = { ...mappings['cp2k-lsp-enhanced'] };
+    return mappings;
+  }
+
   /**
    * Fetch repositories from GitHub API
    */
@@ -235,7 +301,7 @@ export class LSPDiscovery {
       id: repo.name,
       name: mapping.name,
       repository: repo.full_name,
-      executable: this.getExecutableName(repo.name),
+      executable: mapping.executable,
       languageId: mapping.languageId,
       fileExtensions: mapping.extensions,
       fileNames: mapping.fileNames,
@@ -254,6 +320,7 @@ export class LSPDiscovery {
     languageId: string;
     extensions: string[];
     fileNames?: string[];
+    executable: string;
   } {
     // Remove '-lsp' suffix and convert to title case
     const baseName = repoName.replace(/-lsp(-enhanced)?$/, '');
@@ -267,98 +334,15 @@ export class LSPDiscovery {
       languageId: baseName.toLowerCase(),
       extensions: ['inp'], // Default extension
       fileNames: [],
+      executable: repoName,
     };
-  }
-
-  /**
-   * Get executable name from repository name
-   */
-  private getExecutableName(repoName: string): string {
-    if (repoName === 'cp2k-lsp-enhanced' || repoName === 'cp2k-lsp') {
-      return 'cp2k-language-server';
-    }
-
-    // Use repo name as executable (e.g., "vasp-lsp" -> "vasp-lsp").
-    return repoName;
   }
 
   /**
    * Get fallback definitions when API fails
    */
   private getFallbackDefinitions(): LSPServerDefinition[] {
-    return [
-      {
-        id: 'vasp-lsp',
-        name: 'VASP',
-        repository: 'OpenQuantumChemistry/vasp-lsp',
-        executable: 'vasp-lsp',
-        languageId: 'vasp',
-        fileExtensions: [],
-        fileNames: ['INCAR', 'POSCAR', 'KPOINTS', 'POTCAR'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/vasp-lsp',
-      },
-      {
-        id: 'gaussian-lsp',
-        name: 'Gaussian',
-        repository: 'OpenQuantumChemistry/gaussian-lsp',
-        executable: 'gaussian-lsp',
-        languageId: 'gaussian',
-        fileExtensions: ['gjf', 'com'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/gaussian-lsp',
-      },
-      {
-        id: 'orca-lsp',
-        name: 'ORCA',
-        repository: 'OpenQuantumChemistry/orca-lsp',
-        executable: 'orca-lsp',
-        languageId: 'orca',
-        fileExtensions: ['inp'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/orca-lsp',
-      },
-      {
-        id: 'cp2k-lsp-enhanced',
-        name: 'CP2K',
-        repository: 'OpenQuantumChemistry/cp2k-lsp-enhanced',
-        executable: 'cp2k-language-server',
-        languageId: 'cp2k',
-        fileExtensions: ['inp'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/cp2k-lsp-enhanced',
-      },
-      {
-        id: 'qe-lsp',
-        name: 'Quantum ESPRESSO',
-        repository: 'OpenQuantumChemistry/qe-lsp',
-        executable: 'qe-lsp',
-        languageId: 'qe',
-        fileExtensions: ['in', 'pw.in', 'relax.in'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/qe-lsp',
-      },
-      {
-        id: 'gamess-lsp',
-        name: 'GAMESS',
-        repository: 'OpenQuantumChemistry/gamess-lsp',
-        executable: 'gamess-lsp',
-        languageId: 'gamess',
-        fileExtensions: ['inp'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/gamess-lsp',
-      },
-      {
-        id: 'nwchem-lsp',
-        name: 'NWChem',
-        repository: 'OpenQuantumChemistry/nwchem-lsp',
-        executable: 'nwchem-lsp',
-        languageId: 'nwchem',
-        fileExtensions: ['nw', 'nwinp'],
-        enabled: true,
-        repositoryUrl: 'https://github.com/OpenQuantumChemistry/nwchem-lsp',
-      },
-    ];
+    return LSPDiscovery.getDefaultDefinitions();
   }
 
   /**

--- a/tests/unit/LSPDiscovery.test.ts
+++ b/tests/unit/LSPDiscovery.test.ts
@@ -1,3 +1,4 @@
+import packageJson from '../../package.json';
 import { LSPDiscovery, LSPServerDefinition } from '../../src/utils/LSPDiscovery';
 
 type MockContext = {
@@ -115,6 +116,49 @@ describe('LSPDiscovery', () => {
       'openqc.lsp.discovery.cache',
       expect.objectContaining({ data: definitions, timestamp: now })
     );
+  });
+
+  it('keeps canonical LSP defaults aligned with contributed configuration defaults', () => {
+    const properties = packageJson.contributes.configuration.properties as Record<
+      string,
+      { default: unknown }
+    >;
+
+    for (const definition of LSPDiscovery.getDefaultDefinitions()) {
+      expect(properties[`openqc.lsp.${definition.languageId}.enabled`]?.default).toBe(
+        definition.enabled
+      );
+      expect(properties[`openqc.lsp.${definition.languageId}.path`]?.default).toBe(
+        definition.executable
+      );
+    }
+  });
+
+  it('keeps canonical LSP defaults aligned with contributed language patterns', () => {
+    const languages = packageJson.contributes.languages as Array<{
+      id: string;
+      extensions?: string[];
+      filenames?: string[];
+    }>;
+
+    for (const definition of LSPDiscovery.getDefaultDefinitions()) {
+      const language = languages.find(candidate => candidate.id === definition.languageId);
+
+      expect(language).toBeDefined();
+      expect(language?.extensions || []).toEqual(
+        definition.fileExtensions.map(extension => `.${extension}`)
+      );
+      expect(language?.filenames || []).toEqual(definition.fileNames || []);
+    }
+  });
+
+  it('returns cloned canonical defaults to avoid shared-state drift', () => {
+    const first = LSPDiscovery.getDefaultDefinitions();
+    const second = LSPDiscovery.getDefaultDefinitions();
+
+    first[0].fileExtensions.push('mutated');
+
+    expect(second[0].fileExtensions).not.toContain('mutated');
   });
 
   it('uses fresh persisted cache without calling GitHub', async () => {

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -1,4 +1,5 @@
 import { LSPManager } from '../../src/managers/LSPManager';
+import { LSPDiscovery } from '../../src/utils/LSPDiscovery';
 
 // Mock functions object - declared with var for hoisting compatibility
 const mockFunctions: {
@@ -82,10 +83,14 @@ jest.mock('vscode-languageclient/node', () => ({
 describe('LSPManager', () => {
   let lspManager: LSPManager;
   let mockDocument: any;
+  let mockDiscovery: Pick<LSPDiscovery, 'fetchLSPRepositories'>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    lspManager = new LSPManager();
+    mockDiscovery = {
+      fetchLSPRepositories: jest.fn().mockResolvedValue(LSPDiscovery.getDefaultDefinitions()),
+    };
+    lspManager = new LSPManager(undefined, mockDiscovery as LSPDiscovery);
     mockDocument = {
       uri: { fsPath: '/test/file.com' },
       fileName: '/test/file.com',
@@ -110,8 +115,23 @@ describe('LSPManager', () => {
   describe('startLSPForDocument', () => {
     it('should start LSP for a valid document', async () => {
       await lspManager.startLSPForDocument(mockDocument);
+      expect(mockDiscovery.fetchLSPRepositories).toHaveBeenCalled();
       expect(mockFunctions.showInfo).toHaveBeenCalledWith(
         expect.stringContaining('Language Server started')
+      );
+    });
+
+    it('should use discovery defaults for executable path and watcher patterns', async () => {
+      await lspManager.startLSPForDocument(mockDocument);
+
+      expect(mockFunctions.exec).toHaveBeenCalledWith('which gaussian-lsp', expect.any(Function));
+      expect(mockFunctions.languageClient).toHaveBeenCalledWith(
+        'openqc-gaussian',
+        'OpenQC Gaussian Language Server',
+        expect.objectContaining({ command: 'gaussian-lsp' }),
+        expect.objectContaining({
+          documentSelector: [{ scheme: 'file', language: 'gaussian' }],
+        })
       );
     });
 
@@ -138,6 +158,25 @@ describe('LSPManager', () => {
       await lspManager.startLSPForDocument(mockDocument);
       expect(mockFunctions.showError).toHaveBeenCalledWith(
         expect.stringContaining('Failed to start')
+      );
+    });
+
+    it('should preserve user executable path overrides over discovery defaults', async () => {
+      const vscode = require('vscode');
+      vscode.workspace.getConfiguration.mockReturnValueOnce({
+        get: jest.fn((key: string, defaultValue?: any) => {
+          if (key === 'gaussian.enabled') return true;
+          if (key === 'gaussian.path') return '/opt/openqc/custom-gaussian-lsp';
+          return defaultValue;
+        }),
+      });
+      lspManager = new LSPManager(undefined, mockDiscovery as LSPDiscovery);
+
+      await lspManager.startLSPForDocument(mockDocument);
+
+      expect(mockFunctions.exec).toHaveBeenCalledWith(
+        'which /opt/openqc/custom-gaussian-lsp',
+        expect.any(Function)
       );
     });
 


### PR DESCRIPTION
## Summary
- expose canonical LSP server definitions from LSPDiscovery and reuse them for fallback/dynamic mapping
- have LSPManager resolve language IDs, executable defaults, and watcher patterns from discovery metadata while preserving user path/enabled overrides
- add drift tests for package.json contributed LSP config and language patterns

Closes #43

## Validation
- npm run ci:pr
- npm audit --audit-level=moderate (reports existing mocha/serialize-javascript advisory requiring breaking force fix)