### PR TITLE
Make LSP lifecycle workspace-safe

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -519,9 +519,9 @@ function getNonce(): string {
   return text;
 }
 
-export function deactivate() {
+export async function deactivate() {
   if (lspManager) {
-    lspManager.dispose();
+    await lspManager.dispose();
   }
   if (diagnosticsProvider) {
     diagnosticsProvider.dispose();

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -16,8 +16,21 @@ interface LSPServerConfig {
   definition: LSPServerDefinition;
 }
 
+interface LSPClientIdentity {
+  key: string;
+  label: string;
+  workspaceFolder?: vscode.WorkspaceFolder;
+}
+
+interface LSPClientRecord {
+  client: LanguageClient;
+  documents: Set<string>;
+  languageId: string;
+}
+
 export class LSPManager {
-  private clients: Map<string, LanguageClient> = new Map();
+  private clients: Map<string, LSPClientRecord> = new Map();
+  private startingClients: Map<string, Promise<void>> = new Map();
   private fileTypeDetector: FileTypeDetector;
   private config: vscode.WorkspaceConfiguration;
   private discovery: LSPDiscovery;
@@ -41,7 +54,11 @@ export class LSPManager {
     }
 
     const languageId = serverConfig.definition.languageId;
-    if (this.clients.has(languageId)) {
+    const identity = this.getClientIdentity(languageId, document);
+    const documentKey = this.getDocumentKey(document);
+    const existingRecord = this.clients.get(identity.key);
+    if (existingRecord) {
+      existingRecord.documents.add(documentKey);
       return; // LSP already running
     }
 
@@ -49,18 +66,48 @@ export class LSPManager {
       return;
     }
 
+    const pendingStart = this.startingClients.get(identity.key);
+    if (pendingStart) {
+      await pendingStart;
+      const startedRecord = this.clients.get(identity.key);
+      if (startedRecord) {
+        startedRecord.documents.add(documentKey);
+      }
+      return;
+    }
+
+    const startPromise = this.startClient(software, serverConfig, document, identity, documentKey);
+    this.startingClients.set(identity.key, startPromise);
     try {
-      const client = await this.createLanguageClient(software, serverConfig, document);
+      await startPromise;
+    } finally {
+      this.startingClients.delete(identity.key);
+    }
+  }
+
+  private async startClient(
+    software: QuantumChemistrySoftware,
+    serverConfig: LSPServerConfig,
+    document: vscode.TextDocument,
+    identity: LSPClientIdentity,
+    documentKey: string
+  ): Promise<void> {
+    try {
+      const client = await this.createLanguageClient(software, serverConfig, document, identity);
       if (client) {
-        this.clients.set(languageId, client);
         await client.start();
+        this.clients.set(identity.key, {
+          client,
+          documents: new Set([documentKey]),
+          languageId: serverConfig.definition.languageId,
+        });
         vscode.window.showInformationMessage(`${software} Language Server started`);
       }
     } catch (error) {
       console.error(`Error starting ${software} Language Server:`, error);
       vscode.window.showErrorMessage(`Failed to start ${software} Language Server: ${error}`);
       // Clean up the client if it was added
-      this.clients.delete(languageId);
+      this.clients.delete(identity.key);
     }
   }
 
@@ -76,20 +123,22 @@ export class LSPManager {
     }
 
     const languageId = definition.languageId;
-    const client = this.clients.get(languageId);
-    if (client) {
-      try {
-        // Check if client is running before stopping
-        if (client.needsStop()) {
-          await client.stop();
-        }
-      } catch (error) {
-        console.error(`Error stopping ${software} Language Server:`, error);
-        vscode.window.showWarningMessage(`Error stopping ${software} Language Server: ${error}`);
-      } finally {
-        // Always remove from clients map to allow restart
-        this.clients.delete(languageId);
-      }
+    const identity = this.getClientIdentity(languageId, document);
+    const record = this.clients.get(identity.key);
+    if (!record) {
+      return;
+    }
+
+    record.documents.delete(this.getDocumentKey(document));
+    if (record.documents.size > 0) {
+      return;
+    }
+
+    try {
+      await this.stopClientRecord(identity.key, record);
+    } catch (error) {
+      console.error(`Error stopping ${software} Language Server:`, error);
+      vscode.window.showWarningMessage(`Error stopping ${software} Language Server: ${error}`);
     }
   }
 
@@ -114,7 +163,8 @@ export class LSPManager {
   private async createLanguageClient(
     software: QuantumChemistrySoftware,
     config: LSPServerConfig,
-    document: vscode.TextDocument
+    document: vscode.TextDocument,
+    identity: LSPClientIdentity
   ): Promise<LanguageClient | undefined> {
     try {
       // Verify the LSP executable exists
@@ -136,18 +186,37 @@ export class LSPManager {
         transport: TransportKind.stdio,
       };
 
+      const watcherPattern = this.createWatcherPattern(config.definition);
+      const fileEvents = identity.workspaceFolder
+        ? vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(identity.workspaceFolder, watcherPattern)
+          )
+        : vscode.workspace.createFileSystemWatcher(watcherPattern);
+
+      const documentSelector = identity.workspaceFolder
+        ? [
+            {
+              scheme: document.uri.scheme || 'file',
+              language: config.definition.languageId,
+              pattern: this.createWorkspaceDocumentPattern(
+                identity.workspaceFolder,
+                watcherPattern
+              ),
+            },
+          ]
+        : [{ scheme: document.uri.scheme || 'file', language: config.definition.languageId }];
+
       const clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: config.definition.languageId }],
+        documentSelector,
+        workspaceFolder: identity.workspaceFolder,
         synchronize: {
-          fileEvents: vscode.workspace.createFileSystemWatcher(
-            this.createWatcherPattern(config.definition)
-          ),
+          fileEvents,
         },
       };
 
       return new LanguageClient(
-        `openqc-${software.toLowerCase()}`,
-        `OpenQC ${software} Language Server`,
+        `openqc-${software.toLowerCase()}-${this.sanitizeClientId(identity.key)}`,
+        `OpenQC ${software} Language Server${identity.label ? ` (${identity.label})` : ''}`,
         serverOptions,
         clientOptions
       );
@@ -204,19 +273,61 @@ export class LSPManager {
     return `**/{${filePatterns.join(',')}}`;
   }
 
-  dispose(): void {
-    const stopPromises = Array.from(this.clients.entries()).map(async ([languageId, client]) => {
+  private createWorkspaceDocumentPattern(
+    workspaceFolder: vscode.WorkspaceFolder,
+    watcherPattern: string
+  ): string {
+    const workspacePath = workspaceFolder.uri.fsPath.replace(/\\/g, '/').replace(/\/+$/, '');
+    return `${workspacePath}/${watcherPattern}`;
+  }
+
+  private getClientIdentity(languageId: string, document: vscode.TextDocument): LSPClientIdentity {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (workspaceFolder) {
+      return {
+        key: `${languageId}:workspace:${this.uriToString(workspaceFolder.uri)}`,
+        label: workspaceFolder.name,
+        workspaceFolder,
+      };
+    }
+
+    return {
+      key: `${languageId}:document:${this.getDocumentKey(document)}`,
+      label: '',
+    };
+  }
+
+  private getDocumentKey(document: vscode.TextDocument): string {
+    return this.uriToString(document.uri) || document.fileName;
+  }
+
+  private uriToString(uri: vscode.Uri): string {
+    return typeof uri.toString === 'function' ? uri.toString() : uri.fsPath;
+  }
+
+  private sanitizeClientId(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  }
+
+  private async stopClientRecord(clientKey: string, record: LSPClientRecord): Promise<void> {
+    try {
+      if (record.client.needsStop()) {
+        await record.client.stop();
+      }
+    } finally {
+      this.clients.delete(clientKey);
+    }
+  }
+
+  async dispose(): Promise<void> {
+    const stopPromises = Array.from(this.clients.entries()).map(async ([clientKey, record]) => {
       try {
-        if (client.needsStop()) {
-          await client.stop();
-        }
+        await this.stopClientRecord(clientKey, record);
       } catch (error) {
-        console.error(`Error stopping ${languageId} Language Server during dispose:`, error);
+        console.error(`Error stopping ${record.languageId} Language Server during dispose:`, error);
       }
     });
 
-    Promise.all(stopPromises).then(() => {
-      this.clients.clear();
-    });
+    await Promise.all(stopPromises);
   }
 }

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -44,6 +44,7 @@ jest.mock('vscode', () => ({
         return defaultValue;
       }),
     })),
+    getWorkspaceFolder: jest.fn(),
     createFileSystemWatcher: jest.fn(() => ({
       onDidCreate: jest.fn(),
       onDidChange: jest.fn(),
@@ -51,6 +52,10 @@ jest.mock('vscode', () => ({
       dispose: jest.fn(),
     })),
   },
+  RelativePattern: jest.fn().mockImplementation((base: any, pattern: string) => ({
+    base,
+    pattern,
+  })),
 }));
 
 // Mock child_process
@@ -87,6 +92,8 @@ describe('LSPManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    const vscode = require('vscode');
+    vscode.workspace.getWorkspaceFolder.mockReturnValue(undefined);
     mockDiscovery = {
       fetchLSPRepositories: jest.fn().mockResolvedValue(LSPDiscovery.getDefaultDefinitions()),
     };
@@ -108,8 +115,8 @@ describe('LSPManager', () => {
     }));
   });
 
-  afterEach(() => {
-    lspManager.dispose();
+  afterEach(async () => {
+    await lspManager.dispose();
   });
 
   describe('startLSPForDocument', () => {
@@ -126,7 +133,7 @@ describe('LSPManager', () => {
 
       expect(mockFunctions.exec).toHaveBeenCalledWith('which gaussian-lsp', expect.any(Function));
       expect(mockFunctions.languageClient).toHaveBeenCalledWith(
-        'openqc-gaussian',
+        expect.stringContaining('openqc-gaussian-'),
         'OpenQC Gaussian Language Server',
         expect.objectContaining({ command: 'gaussian-lsp' }),
         expect.objectContaining({
@@ -149,6 +156,115 @@ describe('LSPManager', () => {
       await lspManager.startLSPForDocument(mockDocument);
       await lspManager.startLSPForDocument(mockDocument);
       expect(mockFunctions.languageClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('should start separate clients for the same language in different workspace folders', async () => {
+      const vscode = require('vscode');
+      const workspaceA = {
+        name: 'workspace-a',
+        index: 0,
+        uri: { fsPath: '/workspace-a', scheme: 'file', toString: () => 'file:///workspace-a' },
+      };
+      const workspaceB = {
+        name: 'workspace-b',
+        index: 1,
+        uri: { fsPath: '/workspace-b', scheme: 'file', toString: () => 'file:///workspace-b' },
+      };
+      const docA = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace-a/file.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace-a/file.com',
+        },
+        fileName: '/workspace-a/file.com',
+      };
+      const docB = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace-b/file.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace-b/file.com',
+        },
+        fileName: '/workspace-b/file.com',
+      };
+      vscode.workspace.getWorkspaceFolder.mockImplementation((uri: any) =>
+        uri.fsPath.startsWith('/workspace-a') ? workspaceA : workspaceB
+      );
+
+      await lspManager.startLSPForDocument(docA);
+      await lspManager.startLSPForDocument(docB);
+
+      expect(mockFunctions.languageClient).toHaveBeenCalledTimes(2);
+      expect(mockFunctions.languageClient).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('workspace-a'),
+        'OpenQC Gaussian Language Server (workspace-a)',
+        expect.any(Object),
+        expect.objectContaining({ workspaceFolder: workspaceA })
+      );
+      expect(mockFunctions.languageClient).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('workspace-b'),
+        'OpenQC Gaussian Language Server (workspace-b)',
+        expect.any(Object),
+        expect.objectContaining({ workspaceFolder: workspaceB })
+      );
+    });
+
+    it('should coalesce concurrent starts for the same language and workspace', async () => {
+      const vscode = require('vscode');
+      const workspaceFolder = {
+        name: 'chemistry',
+        index: 0,
+        uri: { fsPath: '/workspace', scheme: 'file', toString: () => 'file:///workspace' },
+      };
+      vscode.workspace.getWorkspaceFolder.mockReturnValue(workspaceFolder);
+      const mockStop = jest.fn().mockResolvedValue(undefined);
+      let resolveStart: () => void = () => {};
+      const startPromise = new Promise<void>(resolve => {
+        resolveStart = resolve;
+      });
+      mockFunctions.languageClient.mockImplementation(() => ({
+        start: jest.fn().mockReturnValue(startPromise),
+        stop: mockStop,
+        needsStop: jest.fn().mockReturnValue(true),
+      }));
+      const docA = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace/a.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace/a.com',
+        },
+        fileName: '/workspace/a.com',
+      };
+      const docB = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace/b.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace/b.com',
+        },
+        fileName: '/workspace/b.com',
+      };
+
+      const firstStart = lspManager.startLSPForDocument(docA);
+      const secondStart = lspManager.startLSPForDocument(docB);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(mockFunctions.languageClient).toHaveBeenCalledTimes(1);
+
+      resolveStart();
+      await Promise.all([firstStart, secondStart]);
+      await lspManager.stopLSPForDocument(docA);
+
+      expect(mockStop).not.toHaveBeenCalled();
+
+      await lspManager.stopLSPForDocument(docB);
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
     });
 
     it('should handle errors when LSP executable is not found', async () => {
@@ -244,6 +360,105 @@ describe('LSPManager', () => {
       };
       await expect(lspManager.stopLSPForDocument(unknownDoc)).resolves.not.toThrow();
     });
+
+    it('should keep a workspace client running until the last matching document closes', async () => {
+      const vscode = require('vscode');
+      const workspaceFolder = {
+        name: 'chemistry',
+        index: 0,
+        uri: { fsPath: '/workspace', scheme: 'file', toString: () => 'file:///workspace' },
+      };
+      vscode.workspace.getWorkspaceFolder.mockReturnValue(workspaceFolder);
+      const mockStop = jest.fn().mockResolvedValue(undefined);
+      mockFunctions.languageClient.mockImplementation(() => ({
+        start: jest.fn().mockResolvedValue(undefined),
+        stop: mockStop,
+        needsStop: jest.fn().mockReturnValue(true),
+      }));
+      const docA = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace/a.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace/a.com',
+        },
+        fileName: '/workspace/a.com',
+      };
+      const docB = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace/b.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace/b.com',
+        },
+        fileName: '/workspace/b.com',
+      };
+
+      await lspManager.startLSPForDocument(docA);
+      await lspManager.startLSPForDocument(docB);
+      await lspManager.stopLSPForDocument(docA);
+
+      expect(mockStop).not.toHaveBeenCalled();
+
+      await lspManager.stopLSPForDocument(docB);
+
+      expect(mockStop).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop only the client for the closed document workspace', async () => {
+      const vscode = require('vscode');
+      const workspaceA = {
+        name: 'workspace-a',
+        index: 0,
+        uri: { fsPath: '/workspace-a', scheme: 'file', toString: () => 'file:///workspace-a' },
+      };
+      const workspaceB = {
+        name: 'workspace-b',
+        index: 1,
+        uri: { fsPath: '/workspace-b', scheme: 'file', toString: () => 'file:///workspace-b' },
+      };
+      const stopA = jest.fn().mockResolvedValue(undefined);
+      const stopB = jest.fn().mockResolvedValue(undefined);
+      mockFunctions.languageClient
+        .mockImplementationOnce(() => ({
+          start: jest.fn().mockResolvedValue(undefined),
+          stop: stopA,
+          needsStop: jest.fn().mockReturnValue(true),
+        }))
+        .mockImplementationOnce(() => ({
+          start: jest.fn().mockResolvedValue(undefined),
+          stop: stopB,
+          needsStop: jest.fn().mockReturnValue(true),
+        }));
+      const docA = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace-a/file.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace-a/file.com',
+        },
+        fileName: '/workspace-a/file.com',
+      };
+      const docB = {
+        ...mockDocument,
+        uri: {
+          fsPath: '/workspace-b/file.com',
+          scheme: 'file',
+          toString: () => 'file:///workspace-b/file.com',
+        },
+        fileName: '/workspace-b/file.com',
+      };
+      vscode.workspace.getWorkspaceFolder.mockImplementation((uri: any) =>
+        uri.fsPath.startsWith('/workspace-a') ? workspaceA : workspaceB
+      );
+
+      await lspManager.startLSPForDocument(docA);
+      await lspManager.startLSPForDocument(docB);
+      await lspManager.stopLSPForDocument(docA);
+
+      expect(stopA).toHaveBeenCalledTimes(1);
+      expect(stopB).not.toHaveBeenCalled();
+    });
   });
 
   describe('restartLSPForDocument', () => {
@@ -322,8 +537,7 @@ describe('LSPManager', () => {
       };
       await lspManager.startLSPForDocument(gaussianDoc);
       await lspManager.startLSPForDocument(vaspDoc);
-      lspManager.dispose();
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await lspManager.dispose();
       expect(mockStop).toHaveBeenCalledTimes(2);
     });
 
@@ -335,8 +549,7 @@ describe('LSPManager', () => {
         needsStop: jest.fn().mockReturnValue(true),
       }));
       await lspManager.startLSPForDocument(mockDocument);
-      lspManager.dispose();
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await lspManager.dispose();
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('Error stopping'),
         expect.any(Error)


### PR DESCRIPTION
## Summary
- scope language server clients by workspace folder plus language instead of language alone
- keep per-client open document references so closing one document does not stop another workspace/document
- await LSP client shutdown during extension deactivation

## Verification
- npm ci
- npm run ci:pr

Closes #42