### PR TITLE
docs: evaluate ASE integration architecture

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -170,10 +170,15 @@ interface LSPServerDefinition {
 ## Phase 3: ASE Integration & Cross-Code Migration (Weeks 10-15)
 
 ### Objectives
-- **Primary**: Full ASE integration as the "universal intermediate layer"
+- **Primary**: Evaluate ASE as an optional intermediate layer before making it
+  part of the default architecture
 - Cross-code workflow migration (VASP ↔ CP2K ↔ QE ↔ Gaussian ↔ ORCA)
 - Seamless format conversion with ASE Atoms as the bridge
 - Integration with external tools and automated workflows
+
+Architecture note: [ASE Integration Architecture Evaluation](docs/architecture/ASE_INTEGRATION_EVALUATION.md)
+recommends keeping dpdata as the default converter and adding ASE only behind
+specific optional migration workflows.
 
 ### Why ASE?
 ASE (Atomic Simulation Environment) provides:

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -36,12 +36,17 @@ OpenQC-VSCode follows a layered architecture with clear separation of concerns:
 │  ┌──────────────────────────────────────────────────┐  │
 │  │         External Integrations Layer               │  │
 │  │  • dpdata (Python)                                 │  │
-│  │  • ASE (Python)                                    │  │
+│  │  • ASE (Python, optional/future)                    │  │
 │  │  • PyMOL (Python)                                  │  │
 │  │  • AI APIs (OpenAI/Ollama)                         │  │
 │  └──────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────┘
 ```
+
+See [ASE Integration Architecture Evaluation](./ASE_INTEGRATION_EVALUATION.md)
+for the current KISS recommendation: keep the implemented dpdata subprocess
+converter as the default path and add ASE only as an optional capability when a
+specific migration workflow proves it needs `ase.Atoms`.
 
 ## Core Components
 
@@ -84,14 +89,11 @@ src/parsers/
 **Key Classes**:
 ```
 src/converters/
-├── Converter.ts               # Abstract converter
-├── VASPConverter.ts
-├── GaussianConverter.ts
-├── ORCAConverter.ts
-├── UniversalConverter.ts      # Multi-format converter
-└── adapters/
-    ├── DPDataAdapter.ts       # Python integration
-    └── ASEAdapter.ts
+├── FormatConverter.ts         # TypeScript adapter for Python conversion
+└── index.ts
+
+python/
+└── format_converter.py        # dpdata-backed conversion CLI
 ```
 
 ### 3. Visualization

--- a/docs/architecture/ASE_INTEGRATION_EVALUATION.md
+++ b/docs/architecture/ASE_INTEGRATION_EVALUATION.md
@@ -1,0 +1,98 @@
+# ASE Integration Architecture Evaluation
+
+Status: proposed simplification for issue #17
+
+## Context
+
+`PLAN.md` currently describes ASE as a universal intermediate layer for Phase 3
+cross-code migration. The implemented code path is narrower:
+
+- `src/converters/FormatConverter.ts` shells out to `python/format_converter.py`.
+- `python/format_converter.py` imports `dpdata` on demand and does not import ASE.
+- `python/requirements.txt` previously installed ASE even though the default
+  converter does not require it.
+- The architecture overview mentioned a future `ASEAdapter`, but no
+  `src/ase/` or adapter implementation exists in this checkout.
+
+That means the current risk is not an overbuilt ASE runtime yet. The risk is
+architectural drift: docs and dependencies imply that ASE is a core layer before
+there is evidence that users need calculator orchestration or full workflow
+migration inside the VS Code extension.
+
+## Current Usage Scenarios
+
+### Core scenarios
+
+1. Open a supported input file and get syntax, parsing, validation, and
+   visualization in VS Code.
+2. Convert structure files between practical editor-facing formats such as
+   POSCAR, XYZ, PDB, CIF, Gaussian, and ORCA.
+3. Batch-convert files from the command palette or the Python CLI.
+
+These scenarios are already served by TypeScript parsers, visualization code,
+and the dpdata subprocess converter. They do not require ASE as a mandatory
+dependency.
+
+### Advanced scenarios
+
+1. Convert structures through an `ase.Atoms` representation when dpdata cannot
+   preserve enough geometry, cell, constraint, or trajectory information.
+2. Generate inputs for multiple simulation engines from a common structure.
+3. Use ASE calculators to launch jobs and read results back into OpenQC.
+4. Validate migration quality with round-trip tests and reference fixtures.
+
+These scenarios are useful, but they are not essential to the extension's
+current editing and visualization loop. Calculator execution also overlaps with
+job lifecycle and remote execution concerns, so it should not be part of a KISS
+format-conversion baseline.
+
+## Alternatives
+
+| Alternative | What it means | Advantages | Costs and risks |
+|-------------|---------------|------------|-----------------|
+| Keep ASE as mandatory Python backend | Install ASE with the default converter and route conversions through it | Maximum future flexibility, broad chemistry ecosystem | Higher install cost, dependency conflicts, dual-language maintenance before clear demand |
+| Optional ASE plugin path | Keep dpdata as the default converter and enable ASE only for advanced commands or explicitly configured workflows | Small default install, preserves future escape hatch, lets tests prove value before expansion | Requires capability detection and clear UX for optional features |
+| Pure TypeScript baseline | Implement key structure conversions directly in the extension | Simplest deployment, no Python for core flows, easiest packaging | Limited format coverage, duplicated chemistry logic, higher risk for edge cases |
+| Remote conversion service | Send conversion/migration requests to a hosted backend | No local Python dependency, centrally maintained dependencies | Network/privacy concerns, operating cost, credential and availability burden |
+| WebAssembly chemistry backend | Bundle compiled conversion logic into the extension | Local execution without Python, predictable packaging | Significant build complexity, limited ASE reuse, unclear library maturity for target formats |
+
+## Recommendation
+
+Use a two-tier architecture:
+
+1. **Default tier: TypeScript + dpdata subprocess.** Keep the current converter
+   as the only required conversion backend. It is already implemented, easy to
+   reason about, and supports the current user-facing conversion commands.
+2. **Optional tier: ASE capability module.** Add ASE later only for commands
+   that explicitly need `ase.Atoms`, structure manipulation, or migration
+   validation. Gate it behind backend capability checks and optional dependency
+   installation.
+3. **Defer calculator execution.** Do not put ASE calculators into the
+   extension baseline until job execution/lifecycle boundaries are separately
+   designed and tested.
+
+This keeps the current product simple while preserving a path for scientifically
+meaningful ASE features.
+
+## Acceptance Criteria for Future ASE Work
+
+Before introducing an ASE adapter or `src/ase/` module, require:
+
+- A named command or workflow that cannot be implemented well with dpdata or a
+  small TypeScript parser.
+- Fixture-based round-trip tests for each supported source and target format.
+- Capability detection that reports whether Python, dpdata, and ASE are present
+  separately.
+- Documentation that labels ASE as optional and lists the exact features it
+  enables.
+- Telemetry or user research showing demand for migration features beyond basic
+  format conversion.
+
+## Concrete Simplification
+
+- Keep ASE out of the default `python/requirements.txt`.
+- Document ASE as optional future functionality, not an implemented core
+  adapter.
+- Treat Phase 3 ASE work as an evaluation gate: first prove one high-value
+  migration workflow, then add the smallest adapter surface needed for it.
+

--- a/docs/format-conversion.md
+++ b/docs/format-conversion.md
@@ -42,6 +42,13 @@ Or install the core dependency:
 pip install dpdata
 ```
 
+ASE is not required for the current converter. Install it only for future
+advanced structure manipulation or migration experiments:
+
+```bash
+pip install -r python/requirements-ase.txt
+```
+
 ## Usage
 
 ### Command Line
@@ -141,6 +148,7 @@ The converter preserves metadata during conversion:
 ## Future Enhancements
 
 - Support for additional formats (CASTEP, VASP OUTCAR, etc.)
-- Direct integration with ASE for advanced structure operations
+- Optional ASE integration for advanced structure operations; see
+  [ASE Integration Architecture Evaluation](./architecture/ASE_INTEGRATION_EVALUATION.md)
 - Preview of conversion results before saving
 - Custom format templates

--- a/python/requirements-ase.txt
+++ b/python/requirements-ase.txt
@@ -1,0 +1,4 @@
+# Optional ASE dependencies for advanced structure migration experiments.
+# The default format converter currently uses dpdata and does not require ASE.
+
+ase>=3.22.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,8 +4,5 @@
 # Core format conversion library
 dpdata>=0.3.0
 
-# Optional dependencies for enhanced functionality
-ase>=3.22.0  # Atomic Simulation Environment
-
 # Optional for crystallographic formats
 pymatgen>=2022.0.0  # Materials Project library


### PR DESCRIPTION
## Summary
- Add a focused ASE integration architecture evaluation for issue #17
- Document current core vs advanced usage scenarios and compare alternatives
- Recommend keeping dpdata as the default converter while moving ASE to an optional future capability
- Split ASE into an optional requirements file so default converter setup matches the implemented code path

Closes #17

## Verification
- npm ci
- npm run docs:build
- npm run compile
- git diff --check
- npm audit --audit-level=moderate (reports existing mocha/serialize-javascript advisories requiring a breaking force fix)
- pre-commit hook: eslint, typecheck, unit tests, prettier format check