### PR TITLE
docs: defer Phase 6 enterprise features

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -302,14 +302,40 @@ ASE (Atomic Simulation Environment) provides:
 
 ---
 
-## Phase 6: Enterprise & Ecosystem (Future)
+## Phase 6: Ecosystem Integrations (Deferred)
 
-### Potential Features
-- [ ] HPC cluster integration (Slurm, PBS job submission)
-- [ ] Collaborative editing (real-time sync)
-- [ ] Database integration (Materials Project, NOMAD)
+Phase 6 is no longer a commitment to build enterprise-only features. The
+current roadmap prioritizes the public researcher workflow: stable parsers,
+visualization, conversion, documentation, examples, and extension packaging.
+
+### Out of Scope Until Demand Is Proven
+- [ ] HPC cluster integration beyond documenting VS Code Remote and task-based workflows
+- [ ] Collaborative editing or real-time sync
 - [ ] Custom plugin API for proprietary formats
-- [ ] Enterprise support and training
+- [ ] Enterprise support and training programs
+- [ ] First-party cloud computing infrastructure
+
+### Still in Scope
+- [ ] Documented local and remote workflow recipes using existing VS Code capabilities
+- [ ] Lightweight links or import/export helpers for public scientific databases when requested
+- [ ] Community contribution guidelines for adding formats, examples, and LSP backends
+- [ ] Extension points that fall naturally out of repeated contributor needs
+
+### Reconsideration Criteria
+Deferred items should only return to the active roadmap when they meet all of
+the following criteria:
+
+1. At least three independent users or organizations request the capability with concrete workflows.
+2. A maintainer can identify a small, testable first increment that does not compete with core parser, visualization, conversion, or documentation work.
+3. The feature can rely on existing standards or external tools instead of creating OpenQC-owned infrastructure.
+4. The maintenance owner, support expectations, and security boundary are documented before implementation starts.
+
+### Rationale
+The Phase 6 items are high-cost and maintenance-heavy relative to the current
+open-source goal. There is no roadmap evidence of committed users, funding, or
+support capacity for real-time collaboration, proprietary plugin APIs, managed
+HPC submission, or enterprise services. OpenQC should integrate with existing
+tools where practical and avoid building features before demonstrated demand.
 
 ---
 
@@ -384,7 +410,7 @@ ASE (Atomic Simulation Environment) provides:
 | Phase 3 | 6 weeks | ASE integration complete | Week 15 |
 | Phase 4 | 4 weeks | AI features live | Week 19 |
 | Phase 5 | 4 weeks | Production-ready release | Week 23 |
-| Phase 6 | Ongoing | Enterprise features | Future |
+| Phase 6 | Deferred | Demand-proven ecosystem integrations | Future |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -221,15 +221,15 @@ OpenQC works out of the box, but you can customize it:
 
 ### Medium Term (v2.5)
 - [ ] Real-time calculation monitoring
-- [ ] Integration with job schedulers (SLURM, PBS)
+- [ ] Remote workflow documentation using existing VS Code capabilities
 - [ ] Parameter templates and wizards
-- [ ] Collaboration features
+- [ ] Community examples for common calculation workflows
 
 ### Long Term (v3.0)
 - [ ] AI-powered parameter optimization
 - [ ] Natural language input generation
 - [ ] Workflow automation
-- [ ] Cloud computing integration
+- [ ] Demand-proven ecosystem integrations from the [roadmap](PLAN.md)
 
 ## Marketplace Release Checklist
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,4 +18,5 @@
 
 - Add conversion between common input formats.
 - Add batch structure preview and image export.
-- Add calculation monitoring integrations for local or cluster workflows.
+- Document calculation workflows that use existing VS Code Remote, tasks, and terminal capabilities.
+- Consider ecosystem integrations only after concrete user demand is documented in the project roadmap.


### PR DESCRIPTION
## Summary
- Reframe Phase 6 as deferred ecosystem integrations rather than committed enterprise features.
- Mark speculative HPC, collaboration, proprietary plugin API, enterprise support, and first-party cloud infrastructure as out of scope until demand is proven.
- Align README and docs roadmap references with the YAGNI decision.

## Validation
- git diff --check
- npm run format:check
- pre-commit hook: lint, typecheck, unit tests, format check
- npm audit --audit-level=moderate reports existing mocha/serialize-javascript advisories requiring a breaking fix, left unchanged for this docs-only PR.

Closes #18