### PR TITLE
refactor: KISS improvements to FileTypeDetector, QEParser, and CP2KParser

### DIFF
--- a/src/managers/FileTypeDetector.ts
+++ b/src/managers/FileTypeDetector.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 export type QuantumChemistrySoftware =
@@ -71,9 +72,8 @@ export class FileTypeDetector {
    * @returns Detected software name, or null when no supported format matches.
    */
   detectSoftware(document: vscode.TextDocument): QuantumChemistrySoftware | null {
-    const filename = document.fileName;
-    const basename = filename.split('/').pop()?.split('\\').pop() || '';
-    const extension = basename.includes('.') ? basename.slice(basename.lastIndexOf('.')) : '';
+    const basename = path.basename(document.fileName);
+    const extension = path.extname(basename);
     const content = document.getText();
 
     // Check filename matches first

--- a/src/parsers/CP2KParser.ts
+++ b/src/parsers/CP2KParser.ts
@@ -21,6 +21,20 @@ export class CP2KParser extends BaseParser {
   private parsedResult: ParseResult | null = null;
   private sectionInfos: Map<string, CP2KSectionInfo> = new Map();
 
+  /** Attach a closed section to its parent (if any) or the top-level sections array. */
+  private attachSection(
+    sectionStack: CP2KSectionInfo[],
+    closedSection: ParsedSection,
+    sections: ParsedSection[]
+  ): void {
+    const parent = sectionStack[sectionStack.length - 1];
+    if (parent) {
+      (parent.subsections ??= []).push(closedSection);
+    } else {
+      sections.push(closedSection);
+    }
+  }
+
   parseInput(): ParseResult {
     if (this.parsedResult) {
       return this.parsedResult;
@@ -53,15 +67,7 @@ export class CP2KParser extends BaseParser {
           if (sectionStack.length > 0) {
             const closedSection = sectionStack.pop()!;
             closedSection.endLine = i;
-
-            if (sectionStack.length > 0) {
-              if (!sectionStack[sectionStack.length - 1].subsections) {
-                sectionStack[sectionStack.length - 1].subsections = [];
-              }
-              sectionStack[sectionStack.length - 1].subsections!.push(closedSection);
-            } else {
-              sections.push(closedSection);
-            }
+            this.attachSection(sectionStack, closedSection, sections);
           }
         } else {
           // Extract element name for KIND and XC_FUNCTIONAL sections
@@ -109,15 +115,7 @@ export class CP2KParser extends BaseParser {
     while (sectionStack.length > 0) {
       const section = sectionStack.pop()!;
       section.endLine = this.lines.length - 1;
-
-      if (sectionStack.length > 0) {
-        if (!sectionStack[sectionStack.length - 1].subsections) {
-          sectionStack[sectionStack.length - 1].subsections = [];
-        }
-        sectionStack[sectionStack.length - 1].subsections!.push(section);
-      } else {
-        sections.push(section);
-      }
+      this.attachSection(sectionStack, section, sections);
 
       errors.push({
         message: `Section ${section.name} not properly closed`,

--- a/src/parsers/QEParser.ts
+++ b/src/parsers/QEParser.ts
@@ -11,6 +11,95 @@ import {
 export class QEParser extends BaseParser {
   private parsedResult: ParseResult | null = null;
 
+  /** Dispatch table for non-namelist section handlers keyed by section prefix. */
+  private readonly sectionHandlers: Array<{
+    prefix: string;
+    handler: (trimmed: string) => ParsedSection;
+  }> = [
+    {
+      prefix: 'ATOMIC_SPECIES',
+      handler: (trimmed: string) => ({
+        name: 'ATOMIC_SPECIES',
+        startLine: 0,
+        endLine: 0,
+        parameters: [],
+      }),
+    },
+    {
+      prefix: 'ATOMIC_POSITIONS',
+      handler: (trimmed: string) => {
+        const parts = trimmed.split(/\s+/);
+        return {
+          name: 'ATOMIC_POSITIONS',
+          startLine: 0,
+          endLine: 0,
+          parameters: [
+            {
+              name: 'Units',
+              value: parts[1] || 'alat',
+              line: 0,
+            },
+          ],
+        };
+      },
+    },
+    {
+      prefix: 'K_POINTS',
+      handler: (trimmed: string) => {
+        const parts = trimmed.split(/\s+/);
+        return {
+          name: 'K_POINTS',
+          startLine: 0,
+          endLine: 0,
+          parameters: [
+            {
+              name: 'Type',
+              value: parts[1] || 'automatic',
+              line: 0,
+            },
+          ],
+        };
+      },
+    },
+    {
+      prefix: 'CELL_PARAMETERS',
+      handler: (trimmed: string) => {
+        const parts = trimmed.split(/\s+/);
+        return {
+          name: 'CELL_PARAMETERS',
+          startLine: 0,
+          endLine: 0,
+          parameters: [
+            {
+              name: 'Units',
+              value: parts[1] || 'alat',
+              line: 0,
+            },
+          ],
+        };
+      },
+    },
+  ];
+
+  /** Finalize and push the current section onto the sections array. */
+  private finalizeSection(sections: ParsedSection[], section: ParsedSection | null): void {
+    if (section) {
+      sections.push(section);
+    }
+  }
+
+  /** Find a matching handler for the given trimmed line, or return null. */
+  private findSectionHandler(
+    trimmed: string
+  ): { handler: (trimmed: string) => ParsedSection; line: string } | null {
+    for (const entry of this.sectionHandlers) {
+      if (trimmed.startsWith(entry.prefix)) {
+        return { handler: entry.handler, line: trimmed };
+      }
+    }
+    return null;
+  }
+
   parseInput(): ParseResult {
     if (this.parsedResult) {
       return this.parsedResult;
@@ -39,7 +128,7 @@ export class QEParser extends BaseParser {
         if (namelistName.startsWith('END')) {
           if (currentSection) {
             currentSection.endLine = i;
-            sections.push(currentSection);
+            this.finalizeSection(sections, currentSection);
             currentSection = null;
           }
           inNamelist = false;
@@ -56,73 +145,26 @@ export class QEParser extends BaseParser {
         const params = this.parseNamelistLine(trimmed, i);
         currentSection.parameters.push(...params);
         parameters.push(...params);
-      } else if (trimmed.startsWith('ATOMIC_SPECIES')) {
-        if (currentSection) {
-          currentSection.endLine = i - 1;
-          sections.push(currentSection);
+      } else {
+        // Check if this line starts a known non-namelist section
+        const match = this.findSectionHandler(trimmed);
+        if (match) {
+          // End the current section before starting a new one
+          if (currentSection) {
+            currentSection.endLine = i - 1;
+            this.finalizeSection(sections, currentSection);
+          }
+          currentSection = match.handler(trimmed);
+          currentSection.startLine = i;
+          currentSection.endLine = i;
+          // Update line numbers in parameters
+          for (const param of currentSection.parameters) {
+            param.line = i;
+          }
+        } else if (currentSection) {
+          // Continue the current section
+          currentSection.endLine = i;
         }
-        currentSection = {
-          name: 'ATOMIC_SPECIES',
-          startLine: i,
-          endLine: i,
-          parameters: [],
-        };
-      } else if (trimmed.startsWith('ATOMIC_POSITIONS')) {
-        if (currentSection) {
-          currentSection.endLine = i - 1;
-          sections.push(currentSection);
-        }
-        const parts = trimmed.split(/\s+/);
-        currentSection = {
-          name: 'ATOMIC_POSITIONS',
-          startLine: i,
-          endLine: i,
-          parameters: [
-            {
-              name: 'Units',
-              value: parts[1] || 'alat',
-              line: i,
-            },
-          ],
-        };
-      } else if (trimmed.startsWith('K_POINTS')) {
-        if (currentSection) {
-          currentSection.endLine = i - 1;
-          sections.push(currentSection);
-        }
-        const parts = trimmed.split(/\s+/);
-        currentSection = {
-          name: 'K_POINTS',
-          startLine: i,
-          endLine: i,
-          parameters: [
-            {
-              name: 'Type',
-              value: parts[1] || 'automatic',
-              line: i,
-            },
-          ],
-        };
-      } else if (trimmed.startsWith('CELL_PARAMETERS')) {
-        if (currentSection) {
-          currentSection.endLine = i - 1;
-          sections.push(currentSection);
-        }
-        const parts = trimmed.split(/\s+/);
-        currentSection = {
-          name: 'CELL_PARAMETERS',
-          startLine: i,
-          endLine: i,
-          parameters: [
-            {
-              name: 'Units',
-              value: parts[1] || 'alat',
-              line: i,
-            },
-          ],
-        };
-      } else if (currentSection) {
-        currentSection.endLine = i;
       }
     }
 


### PR DESCRIPTION
## Summary

Applies KISS (Keep It Simple, Stupid) improvements to three files after PR #65:

### #36 — FileTypeDetector path manipulation
- Replaced manual `split('/').pop()?.split('\\').pop()` with `path.basename()` and `path.extname()`
- More reliable across platforms, clearer intent

### #33 — QEParser excessive if-elif chains  
- Replaced 70-line if-elif chain with a dispatch table of section handlers
- Extracted `finalizeSection()` and `findSectionHandler()` helpers
- Adding new section types now requires a single table entry

### #32 — CP2KParser deep nesting
- Extracted `attachSection()` helper to reduce 4-level nesting in section closing logic
- Eliminates duplicate code between main loop and cleanup while-loop
- Uses nullish coalescing (`??=`) for cleaner subsection initialization

## Verification

- All 562 tests pass
- 98.82% statement coverage maintained
- ESLint, TypeScript typecheck, Prettier format check all pass

Closes #36, #33, #32