### PR TITLE
ci: tighten VS Code extension automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "extension"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,38 @@ name: CI
 on:
   push:
     branches: [main, master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'tests/**'
+      - 'syntaxes/**'
+      - 'language-configurations/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main, master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/**'
+      - 'tests/**'
+      - 'syntaxes/**'
+      - 'language-configurations/**'
+      - '.github/workflows/ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     strategy:
       matrix:
@@ -24,6 +49,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -53,6 +79,7 @@ jobs:
   lsp-integration-test:
     name: LSP Integration Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout OpenQC-VSCode
@@ -123,6 +150,7 @@ jobs:
   build-and-package:
     name: Build and Package
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [test, lsp-integration-test]
 
     steps:
@@ -134,6 +162,7 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Adds a small, meaningful GitHub Actions improvement set for the VS Code extension repo:

- Adds Dependabot coverage for npm dependencies and GitHub Actions.
- Adds explicit read-only workflow permissions to CI.
- Adds concurrency cancellation so stale CI runs are cancelled when new commits are pushed.
- Adds path filters so CI runs for extension code, tests, syntax/language config, package, and workflow changes rather than every documentation-only change.
- Adds job timeouts and a package-lock cache path for more predictable CI behavior.

## Why this is useful

This repo already has a real CI workflow for compile/lint/tests/LSP integration/package generation, so I did not add redundant heavy workflows. The changes focus on dependency maintenance, least-privilege permissions, and reducing stale/low-signal CI runs.

## Validation

Not run locally from this connector session. The PR is workflow/config only and should be validated by GitHub Actions on the branch.