### PR TITLE
refactor: collapse duplicate StructureConverter methods

### DIFF
--- a/src/visualizers/StructureConverter.ts
+++ b/src/visualizers/StructureConverter.ts
@@ -8,6 +8,7 @@
  */
 
 import { VASPParser, POSCARData } from '../parsers/VASPParser';
+import { QuantumChemistrySoftware } from '../managers/FileTypeDetector';
 import { Atom, MolecularStructure } from './types';
 import { Molecule3D } from './Molecule3D';
 
@@ -93,12 +94,7 @@ export class StructureConverter {
    * @returns MolecularStructure for rendering
    */
   public fromGaussian(content: string, filename?: string): MolecularStructure {
-    const atoms = this.molecule3D.parseAtoms(content, 'Gaussian');
-
-    return {
-      atoms,
-      name: filename || 'Gaussian Input',
-    };
+    return this.fromSoftware(content, 'Gaussian', filename || 'Gaussian Input');
   }
 
   /**
@@ -109,12 +105,7 @@ export class StructureConverter {
    * @returns MolecularStructure for rendering
    */
   public fromORCA(content: string, filename?: string): MolecularStructure {
-    const atoms = this.molecule3D.parseAtoms(content, 'ORCA');
-
-    return {
-      atoms,
-      name: filename || 'ORCA Input',
-    };
+    return this.fromSoftware(content, 'ORCA', filename || 'ORCA Input');
   }
 
   /**
@@ -125,12 +116,7 @@ export class StructureConverter {
    * @returns MolecularStructure for rendering
    */
   public fromCP2K(content: string, filename?: string): MolecularStructure {
-    const atoms = this.molecule3D.parseAtoms(content, 'CP2K');
-
-    return {
-      atoms,
-      name: filename || 'CP2K Input',
-    };
+    return this.fromSoftware(content, 'CP2K', filename || 'CP2K Input');
   }
 
   /**
@@ -141,12 +127,24 @@ export class StructureConverter {
    * @returns MolecularStructure for rendering
    */
   public fromQuantumEspresso(content: string, filename?: string): MolecularStructure {
-    const atoms = this.molecule3D.parseAtoms(content, 'Quantum ESPRESSO');
+    return this.fromSoftware(content, 'Quantum ESPRESSO', filename || 'QE Input');
+  }
 
-    return {
-      atoms,
-      name: filename || 'QE Input',
-    };
+  /**
+   * Shared conversion for Molecule3D-based software parsers
+   *
+   * @param content - File content
+   * @param software - Software name passed to Molecule3D.parseAtoms
+   * @param defaultName - Fallback structure name when no filename provided
+   * @returns MolecularStructure for rendering
+   */
+  private fromSoftware(
+    content: string,
+    software: QuantumChemistrySoftware,
+    defaultName: string
+  ): MolecularStructure {
+    const atoms = this.molecule3D.parseAtoms(content, software);
+    return { atoms, name: defaultName };
   }
 
   /**


### PR DESCRIPTION
## Summary

Eliminates duplicated `fromGaussian`/`fromORCA`/`fromCP2K`/`fromQuantumEspresso` implementations in `StructureConverter.ts` by extracting a shared `fromSoftware()` private helper.

Addresses #37.

### Changes

- **`src/visualizers/StructureConverter.ts`**: Extract `fromSoftware(content, software, defaultName)` private method. Each public `from*` method now delegates to it with the correct software name and fallback filename. Public API is unchanged.

### Why

All four methods had identical bodies:
```typescript
const atoms = this.molecule3D.parseAtoms(content, '<Software>');
return { atoms, name: filename || '<Default Name>' };
```

Only the software name string and default filename differed. The `fromSoftware` helper captures this pattern once, reducing maintenance burden and future copy-paste drift.

### Test plan
- [x] All 550 unit tests pass
- [x] Coverage: functions 99.21% > 95%
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)