### PR TITLE
docs: add CoordinateCapable interface and LSP family architecture

### DIFF
--- a/docs/lsp-family-interface.md
+++ b/docs/lsp-family-interface.md
@@ -1,0 +1,71 @@
+# LSP Family Interface
+
+This document describes the code-sharing architecture across the newtontech quantum chemistry LSP family.
+
+## LSP Repositories
+
+| Repository | Language ID | Executable | File Patterns |
+|-----------|-------------|-----------|---------------|
+| [vasp-lsp](https://github.com/OpenQuantumChemistry/vasp-lsp) | `vasp` | `vasp-lsp` | INCAR, POSCAR, KPOINTS, POTCAR, CONTCAR |
+| [gaussian-lsp](https://github.com/OpenQuantumChemistry/gaussian-lsp) | `gaussian` | `gaussian-lsp` | *.gjf, *.com |
+| [orca-lsp](https://github.com/OpenQuantumChemistry/orca-lsp) | `orca` | `orca-lsp` | *.inp |
+| [cp2k-lsp-enhanced](https://github.com/OpenQuantumChemistry/cp2k-lsp-enhanced) | `cp2k` | `cp2k-language-server` | *.inp |
+| [qe-lsp](https://github.com/OpenQuantumChemistry/qe-lsp) | `qe` | `qe-lsp` | *.in, *.pw.in, *.scf.in, etc. |
+| [gamess-lsp](https://github.com/OpenQuantumChemistry/gamess-lsp) | `gamess` | `gamess-lsp` | *.inp |
+| [nwchem-lsp](https://github.com/OpenQuantumChemistry/nwchem-lsp) | `nwchem` | `nwchem-lsp` | *.nw, *.nwinp |
+
+## Discovery and Configuration
+
+`LSPDiscovery` in `src/utils/LSPDiscovery.ts` maintains a canonical list of LSP server definitions. On startup it:
+
+1. Checks workspace/global state cache (1-hour TTL)
+2. Falls back to GitHub API (`/orgs/OpenQuantumChemistry/repos`)
+3. Falls back to hardcoded defaults in `DEFAULT_LSP_SERVER_DEFINITIONS`
+
+Users can override the executable path and enable/disable each LSP via VS Code settings:
+
+```
+openqc.lsp.<languageId>.enabled  (boolean)
+openqc.lsp.<languageId>.path     (string)
+```
+
+## Client Lifecycle
+
+`LSPManager` in `src/managers/LSPManager.ts` manages LSP clients:
+
+- **Workspace-scoped**: One client per language per workspace folder
+- **Deduplication**: Concurrent starts for the same language+workspace are coalesced
+- **Reference counting**: Clients are stopped when the last matching document closes
+- **Graceful disposal**: All clients are stopped on extension deactivation
+
+## Shared Parser Infrastructure
+
+The OpenQC-VSCode extension itself provides shared parsing logic that could inform the individual LSPs:
+
+- **`BaseParser`** (`src/parsers/base.ts`): Abstract parser with shared utilities for comment stripping, key-value parsing, and coordinate extraction
+- **`CoordinateCapable`** interface: Uniform contract for parsers that extract atomic coordinates
+- **`FileTypeDetector`** (`src/managers/FileTypeDetector.ts`): Content-based format detection used to route files to the correct LSP
+
+## Adding a New LSP
+
+To add support for a new quantum chemistry LSP:
+
+1. Add the LSP server definition to `DEFAULT_LSP_SERVER_DEFINITIONS` in `src/utils/LSPDiscovery.ts`
+2. Add language configuration in `package.json` under `contributes.languages`
+3. Add TextMate grammar in `package.json` under `contributes.grammars`
+4. Add LSP settings in `package.json` under `contributes.configuration.properties`
+5. Create a parser in `src/parsers/` extending `BaseParser`
+6. Register the parser in `src/parsers/index.ts` `createParser` function
+7. Add format detection patterns in `FileTypeDetector`
+
+## Cross-LSP Code Sharing Opportunities
+
+The following modules are candidates for extraction into a shared package that all LSPs could consume:
+
+| Module | Current Location | Sharing Potential |
+|--------|-----------------|-------------------|
+| Coordinate parsing | `BaseParser.parseCoordinateLine` | High - all parsers extract xyz coordinates |
+| Comment stripping | `BaseParser.stripComments` | Medium - comment characters vary by format |
+| Keyword validation | Per-parser `validate()` | Medium - common validation patterns |
+| Element data | `src/visualizers/atomicData.ts` | High - CPK colors, covalent/vdW radii |
+| File type detection | `FileTypeDetector` | Medium - content heuristics could be shared |

--- a/src/parsers/base.ts
+++ b/src/parsers/base.ts
@@ -1,6 +1,39 @@
 /**
  * Base parser interface for quantum chemistry input files
+ *
+ * All quantum chemistry parsers (VASP, Gaussian, ORCA, CP2K, QE, GAMESS, NWChem)
+ * extend this class to share common parsing utilities.
+ *
+ * @module parsers/base
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/16
  */
+
+/**
+ * Represents an atom extracted from coordinate section of an input file.
+ * Parsers that support coordinate extraction should implement `CoordinateCapable`.
+ */
+export interface ExtractedAtom {
+  element: string;
+  coords: [number, number, number];
+}
+
+/**
+ * Interface for parsers that can extract atomic coordinates.
+ *
+ * Each parser implements this according to its file format conventions.
+ * This enables `StructureConverter` and `Molecule3D` to consume coordinates
+ * from any parser through a uniform contract.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/16
+ */
+export interface CoordinateCapable {
+  /**
+   * Extract atomic coordinates from the parsed input file.
+   *
+   * @returns Array of atoms with element symbols and xyz coordinates
+   */
+  getExtractedAtoms(): ExtractedAtom[];
+}
 
 export interface ParsedParameter {
   name: string;
@@ -90,5 +123,33 @@ export abstract class BaseParser {
       return { key: parts[0].trim(), value: parts.slice(1).join(' ').trim() };
     }
     return null;
+  }
+
+  /**
+   * Parse a single coordinate line in "Element X Y Z" format.
+   *
+   * Shared utility for parsers that extract coordinates from XYZ-style
+   * coordinate blocks (Gaussian, ORCA, CP2K, GAMESS, NWChem, etc.).
+   *
+   * @param line - Raw coordinate line text
+   * @param startIndex - Column index where coordinates begin (default: 1 for "Element X Y Z")
+   * @returns Extracted atom or null if the line is not a valid coordinate
+   */
+  protected parseCoordinateLine(line: string, startIndex = 1): ExtractedAtom | null {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < startIndex + 3) {
+      return null;
+    }
+
+    const element = parts[0];
+    const x = parseFloat(parts[startIndex]);
+    const y = parseFloat(parts[startIndex + 1]);
+    const z = parseFloat(parts[startIndex + 2]);
+
+    if (isNaN(x) || isNaN(y) || isNaN(z)) {
+      return null;
+    }
+
+    return { element, coords: [x, y, z] };
   }
 }


### PR DESCRIPTION
## Summary

Adds a `CoordinateCapable` interface and shared coordinate parsing helper to the base parser, plus documentation for the LSP family architecture and cross-sharing opportunities.

Addresses #16, References #20.

### Changes

**`src/parsers/base.ts`**
- New `ExtractedAtom` type for uniform coordinate representation
- New `CoordinateCapable` interface for parsers that extract atoms
- New `parseCoordinateLine()` protected helper on `BaseParser` for "Element X Y Z" format parsing
- No breaking changes to existing parser API

**`docs/lsp-family-interface.md`** (new)
- Canonical LSP server table with language IDs, executables, file patterns
- Discovery and configuration architecture
- Client lifecycle (workspace-scoped, deduplication, reference counting)
- Step-by-step guide for adding a new LSP
- Cross-LSP code sharing opportunity analysis

### Test plan
- [x] All 550 unit tests pass
- [x] Coverage: functions 99.2% > 95%
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

References #16, References #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)