### PR TITLE
refactor: replace parser switch with registry pattern

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,6 +1,12 @@
 /**
  * OpenQC-VSCode Parsers
  * Input file parsers for quantum chemistry software
+ *
+ * Uses a registry pattern to satisfy the Open/Closed Principle:
+ * adding a new parser only requires calling `registerParser()`,
+ * not modifying this file's switch statement.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/38
  */
 
 export * from './base';
@@ -23,31 +29,57 @@ import { NWChemParser } from './NWChemParser';
 import { QuantumChemistrySoftware } from '../managers/FileTypeDetector';
 
 /**
+ * Parser factory function signature.
+ * Each registered parser provides a factory that accepts (content, filename?) and returns a BaseParser.
+ */
+type ParserFactory = (content: string, filename?: string) => BaseParser;
+
+/**
+ * Internal registry mapping software names to parser factories.
+ * Satisfies Open/Closed Principle: extend by registering new entries, not by editing switch cases.
+ */
+const parserRegistry = new Map<QuantumChemistrySoftware, ParserFactory>();
+
+/**
+ * Register a parser factory for a given software type.
+ *
+ * @param software - Quantum chemistry software identifier
+ * @param factory - Factory function that creates the parser instance
+ */
+export function registerParser(software: QuantumChemistrySoftware, factory: ParserFactory): void {
+  parserRegistry.set(software, factory);
+}
+
+// Register built-in parsers
+registerParser('VASP', (content, filename) => new VASPParser(content, filename || 'INCAR'));
+registerParser('Gaussian', content => new GaussianParser(content));
+registerParser('ORCA', content => new ORCAParser(content));
+registerParser('CP2K', content => new CP2KParser(content));
+registerParser('Quantum ESPRESSO', content => new QEParser(content));
+registerParser('GAMESS', content => new GAMESSParser(content));
+registerParser('NWChem', content => new NWChemParser(content));
+
+/**
  * Create appropriate parser for the given software and content
+ *
+ * Uses the parser registry to look up the factory function.
+ * Throws if no parser has been registered for the given software.
+ *
+ * @param software - Quantum chemistry software identifier
+ * @param content - File content to parse
+ * @param filename - Optional filename hint
+ * @returns Parser instance for the given software
  */
 export function createParser(
   software: QuantumChemistrySoftware,
   content: string,
   filename?: string
 ): BaseParser {
-  switch (software) {
-    case 'VASP':
-      return new VASPParser(content, filename || 'INCAR');
-    case 'Gaussian':
-      return new GaussianParser(content);
-    case 'ORCA':
-      return new ORCAParser(content);
-    case 'CP2K':
-      return new CP2KParser(content);
-    case 'Quantum ESPRESSO':
-      return new QEParser(content);
-    case 'GAMESS':
-      return new GAMESSParser(content);
-    case 'NWChem':
-      return new NWChemParser(content);
-    default:
-      throw new Error(`Unsupported software: ${software}`);
+  const factory = parserRegistry.get(software);
+  if (!factory) {
+    throw new Error(`Unsupported software: ${software}`);
   }
+  return factory(content, filename);
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the OCP-violating `switch` statement in `createParser` with a Map-based registry and `registerParser()` API.

Addresses #38 (Open/Closed Principle violation).

### Problem

The original `createParser` used a switch statement that required modification every time a new parser was added:

```typescript
function createParser(software, content, filename) {
  switch (software) {
    case 'VASP': return new VASPParser(...);
    case 'Gaussian': return new GaussianParser(...);
    // Must edit this function for every new parser
  }
}
```

### Solution

Registry pattern with `registerParser()`:

```typescript
const parserRegistry = new Map<QuantumChemistrySoftware, ParserFactory>();

export function registerParser(software, factory) {
  parserRegistry.set(software, factory);
}

export function createParser(software, content, filename) {
  const factory = parserRegistry.get(software);
  if (!factory) throw new Error(`Unsupported: ${software}`);
  return factory(content, filename);
}
```

Adding a new parser now only requires calling `registerParser()` at module initialization, without modifying existing code.

### Changes

- **`src/parsers/index.ts`**: Replace switch with `parserRegistry` Map and `registerParser()` export
- All 7 built-in parsers registered at module level
- `createParser` delegates to registry lookup
- Public API unchanged: `createParser`, `parseInput`, `validateInput` work identically

### Test plan
- [x] All 550 unit tests pass
- [x] Coverage: functions 99.2% > 95%
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)