### PR TITLE
docs: add LSP compatibility matrix for all seven language servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ We support **10+ major computational chemistry packages** with more on the way:
 
 ### LSP Alignment Matrix
 
+> For per-server parser status, diagnostics, completion, hover, formatting, code actions, and build commands, see the **[LSP Compatibility Matrix](docs/LSP_COMPATIBILITY.md)**.
+
 | Format | Standalone LSP | OpenQC role |
 |--------|----------------|-------------|
 | Gaussian | `newtontech/gaussian-lsp` | Extension integration, syntax, visualization entry points |
@@ -40,7 +42,9 @@ We support **10+ major computational chemistry packages** with more on the way:
 | GAMESS (US) | `newtontech/gamess-lsp` | Extension integration, snippets, validation entry points |
 | Quantum ESPRESSO | `newtontech/qe-lsp` | Extension integration and shared UX conventions |
 | CP2K | `newtontech/cp2k-lsp-enhanced` | Extension integration with CP2K parser/linter tooling |
-| VASP / NWChem / others | OpenQC modules or future LSPs | Keep APIs compatible with the same LSP contract |
+| VASP | `newtontech/VASP-LSP` | Extension integration, quick fixes, formatting |
+| NWChem | `newtontech/nwchem-lsp` | Extension integration, inlay hints, semantic highlighting |
+| Others | OpenQC modules or future LSPs | Keep APIs compatible with the same LSP contract |
 
 ### ✅ Fully Supported (Now)
 

--- a/docs/LSP_ALIGNMENT.md
+++ b/docs/LSP_ALIGNMENT.md
@@ -2,6 +2,8 @@
 
 OpenQC is the VS Code product surface for the newtontech computational chemistry LSP family. Standalone LSP repositories remain useful for editor-agnostic language support; OpenQC should integrate them with a consistent VS Code experience.
 
+> **Full feature-by-feature compatibility matrix**: See [LSP_COMPATIBILITY.md](./LSP_COMPATIBILITY.md) for per-server parser status, diagnostics, completion, hover, formatting, code actions, build commands, and integration details.
+
 ## Canonical repositories
 
 | Repository | Domain | OpenQC expectation |
@@ -10,6 +12,8 @@ OpenQC is the VS Code product surface for the newtontech computational chemistry
 | `newtontech/orca-lsp` | ORCA `.inp` | Match diagnostics, completion vocabulary, and sample fixtures |
 | `newtontech/gamess-lsp` | GAMESS `.inp` | Match group/keyword diagnostics, snippets, and fixtures |
 | `newtontech/qe-lsp` | Quantum ESPRESSO `.in` variants | Match diagnostics, completion vocabulary, and file detection |
+| `newtontech/nwchem-lsp` | NWChem `.nw`, `.nwinp` | Match section parsing, diagnostics, and inlay hints |
+| `newtontech/VASP-LSP` | VASP `INCAR`, `POSCAR`, `KPOINTS` | Match parameter validation, quick fixes, and formatting |
 | `newtontech/cp2k-lsp-enhanced` | CP2K `.inp` | Reuse or align with CP2K parser/linter behavior |
 
 ## Alignment rules

--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -1,0 +1,238 @@
+# LSP Compatibility Matrix
+
+This document provides a detailed feature-by-feature status for each standalone language server in the newtontech computational chemistry LSP family, plus its integration status in OpenQC.
+
+Last updated: 2026-06-08
+
+## Quick Reference
+
+| LSP Server | Version | Domain | File Types | OpenQC Integration |
+|------------|---------|--------|------------|--------------------|
+| [orca-lsp](https://github.com/newtontech/orca-lsp) | 0.5.4 | ORCA | `.inp` | Syntax + Visualization |
+| [gamess-lsp](https://github.com/newtontech/gamess-lsp) | 0.1.0 | GAMESS (US) | `.inp` | Syntax + Visualization |
+| [gaussian-lsp](https://github.com/newtontech/gaussian-lsp) | 0.2.11 | Gaussian | `.gjf`, `.com` | Syntax + Visualization |
+| [nwchem-lsp](https://github.com/newtontech/nwchem-lsp) | 0.5.0 | NWChem | `.nw`, `.nwinp` | Syntax + Visualization |
+| [qe-lsp](https://github.com/newtontech/qe-lsp) | 0.1.0 | Quantum ESPRESSO | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | Syntax + Visualization |
+| [VASP-LSP](https://github.com/newtontech/VASP-LSP) | 0.4.4 | VASP | `INCAR`, `POSCAR`, `KPOINTS` | Syntax + Visualization |
+| [cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | 0.9.1 | CP2K | `.inp` | Syntax + Visualization |
+
+## Feature Matrix
+
+### Core LSP Capabilities
+
+| Feature | orca-lsp | gamess-lsp | gaussian-lsp | nwchem-lsp | qe-lsp | VASP-LSP | cp2k-lsp-enhanced |
+|---------|----------|------------|--------------|------------|--------|----------|--------------------|
+| Parser | Full | Full | Full | Full | Full | Full | Full |
+| Diagnostics | Yes | Yes | Yes | Yes | Yes | Yes | Yes (cp2klint) |
+| Completion | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Hover Docs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Formatting | No | Yes | Yes | Yes | No | Yes | No |
+| Code Actions | Yes (quick fixes) | Yes (quick fixes) | No | Yes (quick fixes) | No | Yes (quick fixes) | No |
+| Document Symbols | No | Yes | No | Yes | No | No | No |
+| Folding Ranges | No | No | No | Yes | No | No | No |
+| Go to Definition | No | Yes | No | Yes | No | No | No |
+| Find References | No | Yes | No | Yes | No | No | No |
+| Rename | No | Yes | No | Yes | No | No | No |
+| Workspace Symbols | No | Yes | No | Yes | No | No | No |
+| Semantic Highlighting | No | No | No | Yes | No | No | No |
+| Inlay Hints | No | No | No | Yes | No | No | No |
+| Snippet Completions | No | Yes | No | No | No | No | No |
+
+### Status Key
+
+- **Full**: Complete, tested parser for the target format.
+- **Yes**: Feature is implemented and active.
+- **No**: Feature is not yet implemented.
+
+## Per-Server Details
+
+### orca-lsp (v0.5.4)
+
+- **Repository**: [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp)
+- **Description**: LSP implementation for ORCA quantum chemistry software
+- **Supported file types**: `.inp` (ORCA input)
+- **Parser status**: Full ORCA input file parsing with method/basis/job-type recognition
+- **Diagnostics**: Invalid keyword detection, parameter validation, missing required sections, memory and parallelization warnings
+- **Completion**: Methods (DFT functionals, wavefunction methods), basis sets (Pople, Karlsruhe, Dunning), job types (SP, OPT, FREQ, etc.), %blocks (%maxcore, %pal, %method, etc.)
+- **Hover**: Context-aware documentation for keywords
+- **Formatting**: Not implemented
+- **Code actions**: Quick fixes for common errors
+- **Test command**: `pytest`
+- **Build/install**: `pip install orca-lsp` / `pip install -e ".[dev]"`
+- **Coverage**: 100% (320 tests)
+- **OpenQC integration**: Syntax highlighting, visualization entry points, molecule preview
+
+### gamess-lsp (v0.1.0)
+
+- **Repository**: [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp)
+- **Description**: LSP implementation for GAMESS (US) input files
+- **Supported file types**: `.inp` (GAMESS input)
+- **Parser status**: Full parser for GAMESS $group/$END blocks
+- **Diagnostics**: Unknown group detection, unclosed section warnings, syntax issues
+- **Completion**: $ groups, keywords, value suggestions after `=`
+- **Hover**: Inline documentation for GAMESS keywords and groups
+- **Formatting**: Automatic formatting with consistent indentation
+- **Code actions**: Add missing $END, suggest corrections for unknown groups, add required keywords (e.g., RUNTYP for $CONTRL)
+- **Document symbols**: Navigation for $ groups and keywords
+- **Go to definition**: Navigate to group or keyword definitions
+- **Find references**: Find all occurrences of groups and keywords
+- **Rename**: Rename groups and keywords across the document
+- **Workspace symbols**: Search for symbols across all open GAMESS files
+- **Snippets**: Templates for common GAMESS calculations (water molecule, DFT optimization, MP2, frequency, TD-DFT, etc.)
+- **Test command**: `pytest`
+- **Build/install**: `pip install gamess-lsp` / `pip install -e ".[dev]"`
+- **OpenQC integration**: Syntax highlighting, snippet support, visualization entry points
+
+### gaussian-lsp (v0.2.11)
+
+- **Repository**: [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp)
+- **Description**: LSP implementation for Gaussian quantum chemistry software
+- **Supported file types**: `.gjf`, `.com` (Gaussian input)
+- **Parser status**: Full parser with route line parsing, periodic table support (118 elements), ModRedundant and ONIOM layer support
+- **Diagnostics**: Error and warning detection for Gaussian keywords
+- **Completion**: Methods (HF, DFT, post-HF, semi-empirical), basis sets (Pople, Dunning), job types
+- **Hover**: Documentation for Gaussian keywords
+- **Formatting**: Consistent file structure formatting
+- **Code actions**: Not implemented
+- **Test command**: `python -m pytest` (Python) / `npm run test:ts` (TypeScript parser)
+- **Build/install**: `pip install gaussian-lsp` / `pip install -e ".[dev]"`
+- **Additional**: Includes a TypeScript parser under `src/parsers` covered by `npm run typecheck` and `npm run test:ts:coverage`
+- **OpenQC integration**: Syntax highlighting, visualization entry points, molecule preview
+
+### nwchem-lsp (v0.5.0)
+
+- **Repository**: [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp)
+- **Description**: LSP implementation for NWChem quantum chemistry software
+- **Supported file types**: `.nw`, `.nwinp` (NWChem input)
+- **Parser status**: Full parser with section-block recognition
+- **Diagnostics**: Unclosed section blocks, unknown basis sets and functionals, invalid task operations, missing required blocks
+- **Completion**: Top-level keywords (geometry, basis, scf, dft, etc.), section-specific keywords, basis sets and DFT functionals, task operations and theories
+- **Hover**: Inline help for all keywords
+- **Formatting**: Automatic code formatting
+- **Code actions**: Add missing `end` keywords, remove unexpected `end` keywords, correct common typos (gemoetry -> geometry), add missing `start` directive
+- **Document symbols**: Outline view and navigation
+- **Folding ranges**: Code folding for sections (v0.5.0)
+- **Go to definition**: Navigate from `end` to section start
+- **Find references**: Navigate to section occurrences (v0.5.0)
+- **Rename**: Rename sections safely (v0.5.0)
+- **Workspace symbols**: Global symbol search across all open documents (v0.4.0)
+- **Semantic highlighting**: Token-based syntax coloring (v0.4.0)
+- **Inlay hints**: Inline information display for units, charge states (v0.4.0)
+- **Test command**: `pytest`
+- **Build/install**: `pip install nwchem-lsp` / `pip install -e ".[dev]"`
+- **OpenQC integration**: Syntax highlighting, visualization entry points, molecule preview
+
+### qe-lsp (v0.1.0)
+
+- **Repository**: [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp)
+- **Description**: LSP implementation for Quantum ESPRESSO
+- **Supported file types**: `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in`
+- **Parser status**: Full namelist parsing and validation, card validation (ATOMIC_SPECIES, ATOMIC_POSITIONS, K_POINTS, CELL_PARAMETERS), pseudopotential and element validation, lattice parameter checking
+- **Diagnostics**: Error and warning detection for QE namelists and cards
+- **Completion**: QE namelists, keywords, and cards
+- **Hover**: Documentation for QE keywords and namelists
+- **Formatting**: Not implemented
+- **Code actions**: Not implemented
+- **Test command**: `python -m pytest`
+- **Build/install**: `pip install qe-lsp` / `pip install -e ".[dev]"`
+- **OpenQC integration**: Syntax highlighting, visualization entry points
+
+### VASP-LSP (v0.4.4)
+
+- **Repository**: [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP)
+- **Description**: LSP implementation for VASP input/output files
+- **Supported file types**: `INCAR`, `POSCAR`, `KPOINTS`
+- **Parser status**: Full parser for all three primary VASP input files
+- **Diagnostics**: Unknown parameter detection, value type checking, range validation, parameter dependency checks, common configuration warnings
+- **Completion**: INCAR parameter names, parameter values (enums, booleans), context-aware suggestions
+- **Hover**: Parameter description, valid values/range, default value, related parameters
+- **Formatting**: INCAR (parameters grouped by category, aligned values), POSCAR (consistent coordinate precision), KPOINTS (normalized grid types)
+- **Code actions**: Add missing SIGMA when ISMEAR >= 0, add missing MAGMOM when ISPIN = 2, add missing LDAU parameters, remove conflicting NPAR/NCORE, fix common tag typos
+- **Test command**: `pytest --cov=src/vasp_lsp --cov-report=term-missing`
+- **Build/install**: `pip install vasp-lsp` / `pip install -e ".[dev]"`
+- **Additional**: Includes VSCode extension in `editors/vscode/`; supports TCP mode for debugging (`vasp-lsp --tcp`)
+- **OpenQC integration**: Syntax highlighting, visualization entry points, structure preview (POSCAR)
+
+### cp2k-lsp-enhanced (v0.9.1)
+
+- **Repository**: [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced)
+- **Description**: Fully validating pure-python CP2K input file tools including preprocessing capabilities
+- **Supported file types**: `.inp` (CP2K input)
+- **Parser status**: Full parser with preprocessing, variable interpolation, @include support, XML-based format specification validation
+- **Diagnostics**: Full validation via `cp2klint` and `cp2k-datafile-lint`; XML-backed syntax checking
+- **Completion**: Keyword and section completion driven by XML specification
+- **Hover**: Contextual help derived from XML specification
+- **Formatting**: Not implemented (conversion to/from JSON/YAML preserves structure)
+- **Code actions**: Not implemented
+- **Additional tools**: `cp2klint` (linter), `fromcp2k` (to JSON/YAML/AiiDA), `tocp2k` (from JSON/YAML), `cp2kgen` (generate variants), `cp2kget` (extract values from restart files)
+- **Test command**: `pytest`
+- **Build/install**: `pip install cp2k-input-tools` (core) / `pip install cp2k-input-tools[lsp]` (with LSP) / `pip install cp2k-input-tools[yaml]` (with YAML)
+- **OpenQC integration**: Syntax highlighting, visualization entry points, CP2K parser/linter tooling alignment
+
+## Build and Test Commands
+
+### Standalone LSP Servers
+
+All servers use the pygls framework and share a common build/test pattern:
+
+| Step | Command |
+|------|---------|
+| Install (user) | `pip install <package-name>` |
+| Install (dev) | `pip install -e ".[dev]"` |
+| Run server | `<server-name>` (stdio) |
+| Run tests | `pytest` |
+| Run with coverage | `pytest --cov --cov-report=term-missing` |
+| Format check | `black --check src/ tests/` |
+| Lint | `ruff check src/ tests/` or `flake8 src/ tests/` |
+| Type check | `mypy src/` |
+
+### OpenQC-VSCode
+
+| Step | Command |
+|------|---------|
+| Install | `npm install` |
+| Compile | `npm run compile` |
+| Lint | `npm run lint` |
+| Type check | `npm run typecheck` |
+| Format check | `npm run format:check` |
+| Unit tests | `npm run test:unit` |
+| Integration tests | `npm run test:integration` |
+| Full CI (PR gate) | `npm run ci:pr` |
+| Package VSIX | `npm run package:vsix` |
+
+## VSCode / OpenQC Integration Status
+
+| LSP Server | Language ID | Syntax Grammar | Snippets | Visualization | Sidebar Integration | Direct LSP Wiring |
+|------------|-------------|----------------|----------|---------------|---------------------|-------------------|
+| orca-lsp | `orca` | Yes | No | Yes (3D molecule) | Yes (Molecules) | OpenQC modules |
+| gamess-lsp | `gamess` | Yes | Yes | Yes (3D molecule) | Yes (Molecules) | OpenQC modules |
+| gaussian-lsp | `gaussian` | Yes | No | Yes (3D molecule) | Yes (Molecules) | OpenQC modules |
+| nwchem-lsp | `nwchem` | Yes | No | Yes (3D molecule) | Yes (Molecules) | OpenQC modules |
+| qe-lsp | `quantum-espresso` | Yes | No | Yes (3D structure) | Yes (Molecules) | OpenQC modules |
+| VASP-LSP | `vasp` (INCAR/POSCAR/KPOINTS) | Yes | No | Yes (3D structure) | Yes (Molecules) | OpenQC modules |
+| cp2k-lsp-enhanced | `cp2k` | Yes | No | Yes (3D molecule) | Yes (Molecules) | OpenQC modules |
+
+### Integration Notes
+
+- **Direct LSP Wiring**: All servers currently integrate through OpenQC's internal modules rather than spawning standalone LSP processes. The long-term goal is to support direct `stdio` connections to each standalone server.
+- **Syntax Grammar**: All formats have TextMate grammars in OpenQC's `syntaxes/` directory.
+- **Visualization**: Formats that carry molecular or crystal structure information (coordinates) support the 3D viewer via the editor toolbar icon.
+- **Sidebar**: The Molecules sidebar tracks parsed structures from supported file types.
+
+## Alignment Rules
+
+1. Keep file extension and language-id decisions consistent across OpenQC and each standalone LSP.
+2. Prefer shared fixtures for parser behavior whenever the format appears in both places.
+3. Document any OpenQC-only behavior, such as visualization commands or sidebar integration.
+4. Track mismatches with the `lsp-alignment` label.
+5. Release notes should state which standalone LSP versions or commit SHAs were smoke tested.
+
+## Smoke Test Checklist
+
+Before a Marketplace release, open one minimal sample for each format and verify:
+
+- [ ] Syntax highlighting activates.
+- [ ] The expected language server or parser path starts.
+- [ ] Diagnostics appear for one intentionally invalid input.
+- [ ] Hover or completion works for one common keyword.
+- [ ] Visualization entry points do not break for molecule or structure-bearing inputs.


### PR DESCRIPTION
## Summary

Adds a comprehensive LSP compatibility matrix to OpenQC-VSCode, the hub repo for the newtontech computational chemistry LSP family.

### New file: `docs/LSP_COMPATIBILITY.md`
- Per-server feature matrix covering parser status, diagnostics, completion, hover, formatting, code actions, document symbols, folding ranges, go-to-definition, find references, rename, workspace symbols, semantic highlighting, inlay hints, and snippet completions
- Detailed per-server sections with supported file types, parser status, diagnostics details, completion capabilities, hover docs, formatting, code actions, test commands, build/install commands, and OpenQC integration status
- Build and test command reference for all seven LSP servers and OpenQC
- VSCode/OpenQC integration status table with language IDs, syntax grammars, snippets, visualization, sidebar integration, and LSP wiring
- Alignment rules and smoke test checklist

### Updated: `docs/LSP_ALIGNMENT.md`
- Added link to the new detailed compatibility matrix
- Added nwchem-lsp and VASP-LSP to the canonical repositories table

### Updated: `README.md`
- LSP Alignment Matrix section now links to the detailed compatibility doc
- All seven LSP servers listed explicitly (was previously grouping VASP/NWChem/others)

### Servers covered
| Server | Version |
|--------|---------|
| orca-lsp | 0.5.4 |
| gamess-lsp | 0.1.0 |
| gaussian-lsp | 0.2.11 |
| nwchem-lsp | 0.5.0 |
| qe-lsp | 0.1.0 |
| VASP-LSP | 0.4.4 |
| cp2k-lsp-enhanced | 0.9.1 |

### Local gates
- lint: pass
- compile: pass
- typecheck: pass
- unit tests: 550 passed, 98.78% line coverage
- format check: pass
- pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)