### PR TITLE
fix: resolve ESLint parsing error and missing provider instances

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,9 @@ import { renderResultsWebviewHtml } from './webviews/resultsWebview';
 let lspManager: LSPManager;
 let structureViewer: StructureViewer;
 let dataPlotter: DataPlotter;
+let completionProvider: CompletionProvider;
+let hoverProvider: HoverProvider;
+let definitionProvider: DefinitionProvider;
 let diagnosticsProvider: DiagnosticsProvider;
 let fileTypeDetector: FileTypeDetector;
 let moleculeProvider: MoleculeTreeProvider;
@@ -61,6 +64,9 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand('setContext', 'openqc.converterEnabled', true);
 
   // Initialize LSP providers
+  completionProvider = new CompletionProvider();
+  hoverProvider = new HoverProvider();
+  definitionProvider = new DefinitionProvider();
   diagnosticsProvider = new DiagnosticsProvider();
 
   registerFormatConversionCommands(context);
@@ -340,9 +346,6 @@ export function activate(context: vscode.ExtensionContext) {
   registerAICommands(context);
   registerExportCommands(context);
 
-  console.log('OpenQC-VSCode: All providers registered successfully!');
-}
-
   // Show Converter Panel command
   context.subscriptions.push(
     vscode.commands.registerCommand('openqc.showConverterPanel', () => {
@@ -351,6 +354,8 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(...disposables);
+
+  console.log('OpenQC-VSCode: All providers registered successfully!');
 }
 
 export async function deactivate() {


### PR DESCRIPTION
## Problem

ESLint parsing error at `src/extension.ts:354` caused CI failure on master.

## Root Cause

Two issues in `src/extension.ts`:

1. **Orphaned code outside function scope (ESLint parsing error):** The `activate()` function was prematurely closed at line 344, but lines 346-354 contained orphaned code — a `showConverterPanel` command registration, a `context.subscriptions.push(...disposables)` call, and a duplicate closing brace — all sitting at module top level and referencing function-scoped variables (`context`, `disposables`).

2. **Missing provider instances (TypeScript errors):** The imported `CompletionProvider`, `HoverProvider`, and `DefinitionProvider` classes were never instantiated. The `disposables` array referenced undefined names (`completionProvider`, `hoverProvider`, `definitionProvider`), causing `TS2552` errors.

## Fix

- Moved `showConverterPanel` command registration and `context.subscriptions.push(...disposables)` inside the `activate()` function
- Removed the duplicate closing brace
- Added module-level variable declarations for the three LSP providers
- Instantiated all three providers alongside the existing `DiagnosticsProvider`

## Verification

- `npm run lint` passes with zero errors
- `npx tsc --noEmit` passes with zero errors
- All 783 unit tests pass

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>