### PR TITLE
feat(core): introduce OpenQCStructure as single source-of-truth DTO

### DIFF
--- a/src/structures/OpenQCStructure.ts
+++ b/src/structures/OpenQCStructure.ts
@@ -1,0 +1,138 @@
+/**
+ * OpenQCStructure - Single source-of-truth DTO for molecular/crystal structures.
+ *
+ * Every parser, viewer, converter, and agent tool in OpenQC should use this
+ * canonical representation instead of ad-hoc atom arrays or XYZ strings.
+ *
+ * @module structures/OpenQCStructure
+ */
+
+// ---------------------------------------------------------------------------
+// Schema version constant
+// ---------------------------------------------------------------------------
+
+export const OPENQC_STRUCTURE_SCHEMA_VERSION = 'openqc.structure.v1' as const;
+export type OpenQCStructureSchemaVersion = typeof OPENQC_STRUCTURE_SCHEMA_VERSION;
+
+// ---------------------------------------------------------------------------
+// Structure kind
+// ---------------------------------------------------------------------------
+
+export type OpenQCStructureKind =
+  | 'molecule'
+  | 'periodic'
+  | 'surface'
+  | 'trajectory'
+  | 'volumetric';
+
+// ---------------------------------------------------------------------------
+// Atom
+// ---------------------------------------------------------------------------
+
+export interface OpenQCAtom {
+  /** Element symbol (e.g. "Fe", "C"). */
+  element: string;
+  /** Cartesian x coordinate in Angstroms. */
+  x: number;
+  /** Cartesian y coordinate in Angstroms. */
+  y: number;
+  /** Cartesian z coordinate in Angstroms. */
+  z: number;
+  /** Cartesian force x component (optional, eV/Angstrom). */
+  fx?: number;
+  /** Cartesian force y component (optional, eV/Angstrom). */
+  fy?: number;
+  /** Cartesian force z component (optional, eV/Angstrom). */
+  fz?: number;
+  /** Atomic charge (optional). */
+  charge?: number;
+  /** Magnetic moment (optional, mu_B). */
+  magmom?: number;
+  /** Force as a 3-tuple (optional, alternative to fx/fy/fz). */
+  force?: [number, number, number];
+  /** Per-atom label (optional, e.g. "C1"). */
+  label?: string;
+  /** Selective dynamics flags (VASP-style). */
+  selectiveDynamics?: [boolean, boolean, boolean];
+}
+
+// ---------------------------------------------------------------------------
+// Cell / lattice
+// ---------------------------------------------------------------------------
+
+export interface OpenQCCell {
+  /** Lattice vector a in Angstroms. */
+  a: [number, number, number];
+  /** Lattice vector b in Angstroms. */
+  b: [number, number, number];
+  /** Lattice vector c in Angstroms. */
+  c: [number, number, number];
+  /** Periodic boundary condition flags. */
+  pbc: [boolean, boolean, boolean];
+  /** Coordinate mode for atom positions. */
+  coordinateMode?: 'cartesian' | 'fractional';
+}
+
+// ---------------------------------------------------------------------------
+// Bond
+// ---------------------------------------------------------------------------
+
+export interface OpenQCBond {
+  /** Zero-based index of the first atom. */
+  from: number;
+  /** Zero-based index of the second atom. */
+  to: number;
+  /** Bond order (1=single, 2=double, 3=triple). */
+  order?: number;
+  /** Periodic image offset for bonds across cell boundaries. */
+  periodicImage?: [number, number, number];
+}
+
+// ---------------------------------------------------------------------------
+// Structure metadata
+// ---------------------------------------------------------------------------
+
+export interface OpenQCStructureMetadata {
+  /** Charge of the system. */
+  charge?: number;
+  /** Spin multiplicity. */
+  multiplicity?: number;
+  /** Total energy (optional, eV). */
+  energyEv?: number;
+  /** Source file information. */
+  source?: {
+    uri?: string;
+    filename?: string;
+    software?: string;
+    parser?: string;
+  };
+  /** Provenance information. */
+  provenance?: {
+    createdAt: string;
+    openqcVersion?: string;
+    warnings: string[];
+  };
+}
+
+// ---------------------------------------------------------------------------
+// OpenQCStructure (the top-level DTO)
+// ---------------------------------------------------------------------------
+
+export interface OpenQCStructure {
+  /** Schema version for forward-compatible migration. */
+  schemaVersion: OpenQCStructureSchemaVersion;
+  /** Discriminator indicating the type of structure. */
+  kind: OpenQCStructureKind;
+  /** Human-readable name for the structure. */
+  name?: string;
+  /** Atom list -- always Cartesian unless cell.coordinateMode says otherwise. */
+  atoms: OpenQCAtom[];
+  /** Unit cell for periodic systems. Omit for isolated molecules. */
+  cell?: OpenQCCell;
+  /** Optional bond list. */
+  bonds?: OpenQCBond[];
+  /** Frames for trajectory support (each frame is a full OpenQCStructure). */
+  frames?: OpenQCStructure[];
+  /** Arbitrary metadata. */
+  metadata?: OpenQCStructureMetadata;
+}

--- a/src/structures/converters.ts
+++ b/src/structures/converters.ts
@@ -1,0 +1,412 @@
+/**
+ * Conversion utilities to/from OpenQCStructure.
+ *
+ * Provides:
+ * - `openQCStructureToXYZ`  -- backward-compatible XYZ string output.
+ * - `xyzToOpenQCStructure`  -- parse XYZ text into the canonical DTO.
+ * - `molecularStructureToOpenQCStructure` -- adapt existing MolecularStructure.
+ *
+ * @module structures/converters
+ */
+
+import type {
+  OpenQCStructure,
+  OpenQCAtom,
+  OpenQCCell,
+  OpenQCStructureKind,
+} from './OpenQCStructure';
+import { OPENQC_STRUCTURE_SCHEMA_VERSION } from './OpenQCStructure';
+import type { Atom, MolecularStructure, LatticeVectors } from '../visualizers/types';
+import { validateOpenQCStructure } from './validation';
+
+// ---------------------------------------------------------------------------
+// XYZ <-> OpenQCStructure
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an OpenQCStructure to an XYZ-format string.
+ *
+ * This is the backward-compatible path used by the existing 3Dmol/NGL
+ * viewers that expect an XYZ string.
+ *
+ * @param structure - The canonical structure DTO.
+ * @returns XYZ string (atom-count header, comment line, then atom lines).
+ */
+export function openQCStructureToXYZ(structure: OpenQCStructure): string {
+  const atoms = structure.atoms;
+  const name = structure.name ?? 'OpenQCStructure';
+  const lines: string[] = [String(atoms.length), name];
+
+  for (const atom of atoms) {
+    const element = atom.element.padEnd(2);
+    const x = atom.x.toFixed(6);
+    const y = atom.y.toFixed(6);
+    const z = atom.z.toFixed(6);
+    lines.push(`${element} ${x} ${y} ${z}`);
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Parse an XYZ-format string into an OpenQCStructure.
+ *
+ * @param content  - XYZ file content.
+ * @param options  - Optional overrides for kind, name, and source metadata.
+ * @returns An OpenQCStructure of kind 'molecule'.
+ * @throws Error if the XYZ content is malformed.
+ */
+export function xyzToOpenQCStructure(
+  content: string,
+  options?: {
+    kind?: OpenQCStructureKind;
+    name?: string;
+    sourceSoftware?: string;
+  }
+): OpenQCStructure {
+  const lines = content.split('\n');
+
+  if (lines.length < 3) {
+    throw new Error('Invalid XYZ format: file too short');
+  }
+
+  const numAtoms = parseInt(lines[0].trim(), 10);
+  if (isNaN(numAtoms) || numAtoms <= 0) {
+    throw new Error('Invalid XYZ format: first line must be a positive integer (atom count)');
+  }
+
+  const comment = lines[1].trim();
+  const atoms: OpenQCAtom[] = [];
+
+  for (let i = 2; i < Math.min(lines.length, numAtoms + 2); i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) {
+      continue;
+    }
+
+    const element = parts[0];
+    const x = parseFloat(parts[1]);
+    const y = parseFloat(parts[2]);
+    const z = parseFloat(parts[3]);
+
+    if (isNaN(x) || isNaN(y) || isNaN(z)) {
+      continue;
+    }
+
+    atoms.push({ element, x, y, z });
+  }
+
+  if (atoms.length === 0) {
+    throw new Error('Invalid XYZ format: no valid atom lines found');
+  }
+
+  const structure: OpenQCStructure = {
+    schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+    kind: options?.kind ?? 'molecule',
+    name: options?.name ?? (comment || 'XYZ Structure'),
+    atoms,
+    metadata: {
+      source: {
+        software: options?.sourceSoftware,
+        parser: 'xyz',
+      },
+      provenance: {
+        createdAt: new Date().toISOString(),
+        warnings: [],
+      },
+    },
+  };
+
+  return structure;
+}
+
+// ---------------------------------------------------------------------------
+// MolecularStructure (existing visualizer type) <-> OpenQCStructure
+// ---------------------------------------------------------------------------
+
+function latticeVectorsToCell(lattice: LatticeVectors): OpenQCCell {
+  return {
+    a: lattice.a,
+    b: lattice.b,
+    c: lattice.c,
+    pbc: [true, true, true],
+  };
+}
+
+function cellToLatticeVectors(cell: OpenQCCell): LatticeVectors {
+  return {
+    a: cell.a,
+    b: cell.b,
+    c: cell.c,
+  };
+}
+
+/**
+ * Convert the existing `MolecularStructure` (from `visualizers/types`) into
+ * the canonical `OpenQCStructure`.
+ *
+ * @param ms      - The legacy molecular structure.
+ * @param options - Optional overrides for kind and source metadata.
+ * @returns An OpenQCStructure.
+ */
+export function molecularStructureToOpenQCStructure(
+  ms: MolecularStructure,
+  options?: {
+    kind?: OpenQCStructureKind;
+    sourceSoftware?: string;
+    sourceParser?: string;
+  }
+): OpenQCStructure {
+  const hasLattice = ms.lattice !== undefined;
+  const kind: OpenQCStructureKind = options?.kind ?? (hasLattice ? 'periodic' : 'molecule');
+
+  const atoms: OpenQCAtom[] = ms.atoms.map(a => ({
+    element: a.element,
+    x: a.x,
+    y: a.y,
+    z: a.z,
+  }));
+
+  const structure: OpenQCStructure = {
+    schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+    kind,
+    name: ms.name,
+    atoms,
+    metadata: {
+      source: {
+        software: options?.sourceSoftware,
+        parser: options?.sourceParser,
+      },
+      provenance: {
+        createdAt: new Date().toISOString(),
+        warnings: [],
+      },
+    },
+  };
+
+  if (hasLattice && ms.lattice) {
+    structure.cell = latticeVectorsToCell(ms.lattice);
+  }
+
+  if (ms.bonds && ms.bonds.length > 0) {
+    structure.bonds = ms.bonds.map(b => ({
+      from: b.atomIndex1,
+      to: b.atomIndex2,
+      order: b.order,
+    }));
+  }
+
+  return structure;
+}
+
+/**
+ * Convert an OpenQCStructure back to the legacy `MolecularStructure`.
+ *
+ * This is the compatibility adapter that existing viewer code can use
+ * while it has not yet been migrated to the new DTO.
+ *
+ * @param structure - The canonical structure DTO.
+ * @returns A MolecularStructure compatible with the existing visualizers.
+ */
+export function openQCStructureToMolecularStructure(
+  structure: OpenQCStructure
+): MolecularStructure {
+  const atoms: Atom[] = structure.atoms.map(a => ({
+    element: a.element,
+    x: a.x,
+    y: a.y,
+    z: a.z,
+  }));
+
+  const ms: MolecularStructure = {
+    atoms,
+    name: structure.name,
+  };
+
+  if (structure.cell) {
+    ms.lattice = cellToLatticeVectors(structure.cell);
+  }
+
+  if (structure.bonds && structure.bonds.length > 0) {
+    ms.bonds = structure.bonds.map(b => ({
+      atomIndex1: b.from,
+      atomIndex2: b.to,
+      length: 0,
+      order: b.order,
+    }));
+  }
+
+  return ms;
+}
+
+// ---------------------------------------------------------------------------
+// POSCAR <-> OpenQCStructure
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a VASP POSCAR content string into an OpenQCStructure.
+ *
+ * @param content - POSCAR file content.
+ * @param filename - Optional filename for metadata.
+ * @returns An OpenQCStructure of kind 'periodic' (or 'molecule' if no lattice).
+ * @throws Error if the POSCAR content cannot be parsed.
+ */
+export function poscarToOpenQCStructure(
+  content: string,
+  filename?: string
+): OpenQCStructure {
+  const lines = content.split('\n');
+
+  if (lines.length < 8) {
+    throw new Error('Invalid POSCAR format: too few lines');
+  }
+
+  const comment = lines[0].trim();
+  const scale = parseFloat(lines[1].trim());
+  const scaleF = isNaN(scale) ? 1.0 : scale;
+
+  // Lattice vectors
+  const parseVec = (line: string): [number, number, number] => {
+    const parts = line.trim().split(/\s+/);
+    return [
+      parseFloat(parts[0]) * scaleF,
+      parseFloat(parts[1]) * scaleF,
+      parseFloat(parts[2]) * scaleF,
+    ];
+  };
+
+  const a = parseVec(lines[2]);
+  const b = parseVec(lines[3]);
+  const c = parseVec(lines[4]);
+
+  // Atom types and counts
+  const typeLine = lines[5].trim().split(/\s+/);
+  const countLine = lines[6].trim().split(/\s+/).map(Number);
+
+  // Determine if types are on line 5 or not (older POSCAR format)
+  const hasElementNames = typeLine.every(t => /^[A-Za-z]+$/.test(t));
+  const elementNames = hasElementNames ? typeLine : countLine.map((_, i) => `El${i + 1}`);
+  const atomCounts = hasElementNames ? countLine : typeLine.map(Number);
+
+  // Coordinate mode
+  const modeLine = lines[7].trim().toLowerCase();
+  const isSelective = modeLine.startsWith('s');
+  const isDirect =
+    modeLine.startsWith('d') ||
+    (!isSelective && !modeLine.startsWith('c') && modeLine !== '');
+  const coordLine = isSelective || isDirect || modeLine.startsWith('c') ? 8 : 7;
+  const coordinateMode = isDirect ? 'fractional' : 'cartesian';
+
+  const cell: OpenQCCell = {
+    a,
+    b,
+    c,
+    pbc: [true, true, true],
+    coordinateMode,
+  };
+
+  // Parse atoms
+  const atoms: OpenQCAtom[] = [];
+  let lineIdx = coordLine;
+
+  for (let i = 0; i < elementNames.length; i++) {
+    const element = elementNames[i];
+    const count = atomCounts[i];
+
+    for (let j = 0; j < count; j++) {
+      if (lineIdx >= lines.length) {
+        break;
+      }
+      const parts = lines[lineIdx].trim().split(/\s+/);
+      lineIdx++;
+
+      if (parts.length < 3) {
+        continue;
+      }
+
+      const x = parseFloat(parts[0]);
+      const y = parseFloat(parts[1]);
+      const z = parseFloat(parts[2]);
+
+      const atom: OpenQCAtom = { element, x, y, z };
+
+      // Selective dynamics flags
+      if (isSelective && parts.length >= 6) {
+        const parseFlag = (s: string): boolean => s.toUpperCase().startsWith('T');
+        atom.selectiveDynamics = [parseFlag(parts[3]), parseFlag(parts[4]), parseFlag(parts[5])];
+      }
+
+      atoms.push(atom);
+    }
+  }
+
+  const structure: OpenQCStructure = {
+    schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+    kind: 'periodic',
+    name: filename ?? (comment || 'POSCAR'),
+    atoms,
+    cell,
+    metadata: {
+      source: {
+        filename,
+        software: 'vasp',
+        parser: 'poscar',
+      },
+      provenance: {
+        createdAt: new Date().toISOString(),
+        warnings: [],
+      },
+    },
+  };
+
+  return structure;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: create a minimal valid OpenQCStructure
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal valid OpenQCStructure from a list of atoms.
+ *
+ * @param atoms - Array of atom data.
+ * @param options - Optional name, kind, and cell.
+ * @returns A valid OpenQCStructure.
+ */
+export function createOpenQCStructure(
+  atoms: Array<{ element: string; x: number; y: number; z: number }>,
+  options?: {
+    name?: string;
+    kind?: OpenQCStructureKind;
+    cell?: OpenQCCell;
+    charge?: number;
+    multiplicity?: number;
+  }
+): OpenQCStructure {
+  const kind = options?.kind ?? (options?.cell ? 'periodic' : 'molecule');
+  const structure: OpenQCStructure = {
+    schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+    kind,
+    name: options?.name,
+    atoms: atoms.map(a => ({ element: a.element, x: a.x, y: a.y, z: a.z })),
+    metadata: {
+      charge: options?.charge,
+      multiplicity: options?.multiplicity,
+      provenance: {
+        createdAt: new Date().toISOString(),
+        warnings: [],
+      },
+    },
+  };
+
+  if (options?.cell) {
+    structure.cell = options.cell;
+  }
+
+  return structure;
+}

--- a/src/structures/fixtures.ts
+++ b/src/structures/fixtures.ts
@@ -1,0 +1,105 @@
+/**
+ * Reusable test fixtures for OpenQCStructure.
+ *
+ * Provides sample structures that tests and development tools can import
+ * instead of duplicating inline data.
+ *
+ * @module structures/fixtures
+ */
+
+import type { OpenQCStructure, OpenQCAtom, OpenQCCell } from './OpenQCStructure';
+import { OPENQC_STRUCTURE_SCHEMA_VERSION } from './OpenQCStructure';
+
+// ---------------------------------------------------------------------------
+// Water molecule (molecule-only, no cell)
+// ---------------------------------------------------------------------------
+
+export const WATER_ATOMS: OpenQCAtom[] = [
+  { element: 'O', x: 0.0, y: 0.0, z: 0.1173 },
+  { element: 'H', x: 0.0, y: 0.7572, z: -0.4692 },
+  { element: 'H', x: 0.0, y: -0.7572, z: -0.4692 },
+];
+
+export const WATER_STRUCTURE: OpenQCStructure = {
+  schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+  kind: 'molecule',
+  name: 'Water',
+  atoms: WATER_ATOMS,
+  metadata: {
+    charge: 0,
+    multiplicity: 1,
+    source: { software: 'test', parser: 'fixture' },
+    provenance: {
+      createdAt: '2025-01-01T00:00:00.000Z',
+      warnings: [],
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Silicon crystal (periodic, with cell)
+// ---------------------------------------------------------------------------
+
+export const SILICON_CELL: OpenQCCell = {
+  a: [5.43, 0.0, 0.0],
+  b: [0.0, 5.43, 0.0],
+  c: [0.0, 0.0, 5.43],
+  pbc: [true, true, true],
+  coordinateMode: 'fractional',
+};
+
+export const SILICON_ATOMS: OpenQCAtom[] = [
+  { element: 'Si', x: 0.0, y: 0.0, z: 0.0 },
+  { element: 'Si', x: 0.25, y: 0.25, z: 0.25 },
+];
+
+export const SILICON_STRUCTURE: OpenQCStructure = {
+  schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+  kind: 'periodic',
+  name: 'Silicon',
+  atoms: SILICON_ATOMS,
+  cell: SILICON_CELL,
+  metadata: {
+    source: { software: 'vasp', parser: 'poscar' },
+    provenance: {
+      createdAt: '2025-01-01T00:00:00.000Z',
+      warnings: [],
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// POSCAR-like content string (for testing poscarToOpenQCStructure)
+// ---------------------------------------------------------------------------
+
+export const SI_POSCAR_CONTENT = `Silicon
+5.43
+1.0 0.0 0.0
+0.0 1.0 0.0
+0.0 0.0 1.0
+Si
+2
+Direct
+0.00 0.00 0.00
+0.25 0.25 0.25
+`;
+
+// ---------------------------------------------------------------------------
+// XYZ content strings
+// ---------------------------------------------------------------------------
+
+export const WATER_XYZ_CONTENT = `3
+Water molecule
+O   0.000000  0.000000  0.117300
+H   0.000000  0.757200 -0.469200
+H   0.000000 -0.757200 -0.469200
+`;
+
+export const METHANE_XYZ_CONTENT = `5
+Methane
+C   0.000000  0.000000  0.000000
+H   0.627600  0.627600  0.627600
+H  -0.627600 -0.627600  0.627600
+H  -0.627600  0.627600 -0.627600
+H   0.627600 -0.627600 -0.627600
+`;

--- a/src/structures/index.ts
+++ b/src/structures/index.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenQC Structures module.
+ *
+ * Re-exports the canonical DTO types, validation, and conversion utilities.
+ *
+ * @module structures
+ */
+
+export {
+  OPENQC_STRUCTURE_SCHEMA_VERSION,
+  type OpenQCStructure,
+  type OpenQCStructureKind,
+  type OpenQCAtom,
+  type OpenQCCell,
+  type OpenQCBond,
+  type OpenQCStructureMetadata,
+  type OpenQCStructureSchemaVersion,
+} from './OpenQCStructure';
+
+export {
+  validateOpenQCStructure,
+  type ValidationResult,
+} from './validation';
+
+export {
+  openQCStructureToXYZ,
+  xyzToOpenQCStructure,
+  molecularStructureToOpenQCStructure,
+  openQCStructureToMolecularStructure,
+  poscarToOpenQCStructure,
+  createOpenQCStructure,
+} from './converters';

--- a/src/structures/validation.ts
+++ b/src/structures/validation.ts
@@ -1,0 +1,263 @@
+/**
+ * Runtime validation for OpenQCStructure DTOs.
+ *
+ * Provides a `validateOpenQCStructure` function that returns structured
+ * diagnostics so callers can fail fast with clear error messages.
+ *
+ * @module structures/validation
+ */
+
+import type {
+  OpenQCStructure,
+  OpenQCAtom,
+  OpenQCCell,
+  OpenQCStructureKind,
+  OpenQCStructureSchemaVersion,
+} from './OpenQCStructure';
+import { OPENQC_STRUCTURE_SCHEMA_VERSION } from './OpenQCStructure';
+
+// ---------------------------------------------------------------------------
+// Validation result
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const VALID_KINDS: ReadonlySet<string> = new Set<string>([
+  'molecule',
+  'periodic',
+  'surface',
+  'trajectory',
+  'volumetric',
+]);
+
+const VALID_SCHEMA_VERSIONS: ReadonlySet<string> = new Set<string>([
+  OPENQC_STRUCTURE_SCHEMA_VERSION,
+]);
+
+function isValidNumber(value: unknown): value is number {
+  return typeof value === 'number' && isFinite(value) && !isNaN(value);
+}
+
+function isFiniteTuple3(value: unknown): value is [number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    isValidNumber(value[0]) &&
+    isValidNumber(value[1]) &&
+    isValidNumber(value[2])
+  );
+}
+
+function validateAtom(atom: unknown, index: number, errors: string[], warnings: string[]): void {
+  if (typeof atom !== 'object' || atom === null) {
+    errors.push(`Atom ${index}: must be an object`);
+    return;
+  }
+
+  const a = atom as Record<string, unknown>;
+
+  // element
+  if (typeof a.element !== 'string' || a.element.trim().length === 0) {
+    errors.push(`Atom ${index}: missing or empty element symbol`);
+  }
+
+  // coordinates
+  if (!isValidNumber(a.x)) {
+    errors.push(`Atom ${index}: x coordinate is missing or not a finite number`);
+  }
+  if (!isValidNumber(a.y)) {
+    errors.push(`Atom ${index}: y coordinate is missing or not a finite number`);
+  }
+  if (!isValidNumber(a.z)) {
+    errors.push(`Atom ${index}: z coordinate is missing or not a finite number`);
+  }
+
+  // optional force tuple vs individual components
+  if (a.force !== undefined && !isFiniteTuple3(a.force)) {
+    errors.push(`Atom ${index}: force must be a 3-tuple of finite numbers`);
+  }
+  if (a.selectiveDynamics !== undefined) {
+    if (
+      !Array.isArray(a.selectiveDynamics) ||
+      a.selectiveDynamics.length !== 3 ||
+      a.selectiveDynamics.some(v => typeof v !== 'boolean')
+    ) {
+      errors.push(`Atom ${index}: selectiveDynamics must be a 3-tuple of booleans`);
+    }
+  }
+}
+
+function validateCell(cell: unknown, errors: string[]): void {
+  if (typeof cell !== 'object' || cell === null) {
+    errors.push('cell must be an object');
+    return;
+  }
+
+  const c = cell as Record<string, unknown>;
+
+  for (const key of ['a', 'b', 'c'] as const) {
+    if (!isFiniteTuple3(c[key])) {
+      errors.push(`cell.${key} must be a 3-tuple of finite numbers`);
+    }
+  }
+
+  if (
+    !Array.isArray(c.pbc) ||
+    c.pbc.length !== 3 ||
+    (c.pbc as unknown[]).some(v => typeof v !== 'boolean')
+  ) {
+    errors.push('cell.pbc must be a 3-tuple of booleans');
+  }
+
+  if (c.coordinateMode !== undefined) {
+    if (c.coordinateMode !== 'cartesian' && c.coordinateMode !== 'fractional') {
+      errors.push('cell.coordinateMode must be "cartesian" or "fractional"');
+    }
+  }
+
+  // Warn about zero-length lattice vectors (degenerate cell)
+  for (const key of ['a', 'b', 'c'] as const) {
+    if (isFiniteTuple3(c[key])) {
+      const v = c[key] as [number, number, number];
+      const len = Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+      if (len === 0) {
+        errors.push(`cell.${key} has zero length -- degenerate lattice vector`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate an OpenQCStructure at runtime.
+ *
+ * Returns a {@link ValidationResult} with `valid`, `errors`, and `warnings`.
+ * A structure is considered valid when `errors` is empty.
+ *
+ * @param structure - The DTO to validate.
+ * @param options   - Optional flags.
+ * @param options.checkOverlap - Warn when two atoms are closer than tolerance (default true).
+ * @param options.overlapTolerance - Overlap distance threshold in Angstroms (default 0.01).
+ */
+export function validateOpenQCStructure(
+  structure: unknown,
+  options?: { checkOverlap?: boolean; overlapTolerance?: number }
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const { checkOverlap = true, overlapTolerance = 0.01 } = options ?? {};
+
+  if (typeof structure !== 'object' || structure === null) {
+    return { valid: false, errors: ['structure must be a non-null object'], warnings };
+  }
+
+  const s = structure as Record<string, unknown>;
+
+  // schemaVersion
+  if (typeof s.schemaVersion !== 'string') {
+    errors.push('schemaVersion is required and must be a string');
+  } else if (!VALID_SCHEMA_VERSIONS.has(s.schemaVersion)) {
+    errors.push(
+      `Unsupported schemaVersion "${s.schemaVersion}". Supported: ${[...VALID_SCHEMA_VERSIONS].join(', ')}`
+    );
+  }
+
+  // kind
+  if (typeof s.kind !== 'string') {
+    errors.push('kind is required and must be a string');
+  } else if (!VALID_KINDS.has(s.kind)) {
+    errors.push(
+      `Invalid kind "${s.kind}". Must be one of: ${[...VALID_KINDS].join(', ')}`
+    );
+  }
+
+  // atoms
+  if (!Array.isArray(s.atoms)) {
+    errors.push('atoms is required and must be an array');
+  } else if (s.atoms.length === 0) {
+    errors.push('atoms array must not be empty');
+  } else {
+    (s.atoms as unknown[]).forEach((atom, i) => validateAtom(atom, i, errors, warnings));
+  }
+
+  // cell (optional but must be valid when present)
+  if (s.cell !== undefined) {
+    validateCell(s.cell, errors);
+  }
+
+  // bonds (optional)
+  if (s.bonds !== undefined) {
+    if (!Array.isArray(s.bonds)) {
+      errors.push('bonds must be an array when provided');
+    } else {
+      (s.bonds as unknown[]).forEach((bond, i) => {
+        if (typeof bond !== 'object' || bond === null) {
+          errors.push(`Bond ${i}: must be an object`);
+          return;
+        }
+        const b = bond as Record<string, unknown>;
+        if (typeof b.from !== 'number' || typeof b.to !== 'number') {
+          errors.push(`Bond ${i}: "from" and "to" must be numbers`);
+        }
+        if (b.order !== undefined && typeof b.order !== 'number') {
+          errors.push(`Bond ${i}: "order" must be a number when provided`);
+        }
+      });
+    }
+  }
+
+  // frames (optional)
+  if (s.frames !== undefined) {
+    if (!Array.isArray(s.frames)) {
+      errors.push('frames must be an array when provided');
+    }
+    // Recursively validate each frame (lightweight -- one level deep to avoid
+    // deep recursion on malformed data).
+    (s.frames as unknown[]).forEach((frame, i) => {
+      if (typeof frame !== 'object' || frame === null) {
+        errors.push(`Frame ${i}: must be an object`);
+      } else {
+        const f = frame as Record<string, unknown>;
+        if (!Array.isArray(f.atoms) || (f.atoms as unknown[]).length === 0) {
+          warnings.push(`Frame ${i}: has no atoms`);
+        }
+      }
+    });
+  }
+
+  // metadata (optional)
+  if (s.metadata !== undefined) {
+    if (typeof s.metadata !== 'object' || s.metadata === null) {
+      errors.push('metadata must be an object when provided');
+    }
+  }
+
+  // Duplicate-atom proximity check (warning only)
+  if (checkOverlap && Array.isArray(s.atoms) && s.atoms.length > 1) {
+    const atoms = s.atoms as OpenQCAtom[];
+    for (let i = 0; i < atoms.length; i++) {
+      for (let j = i + 1; j < atoms.length; j++) {
+        const dx = atoms[i].x - atoms[j].x;
+        const dy = atoms[i].y - atoms[j].y;
+        const dz = atoms[i].z - atoms[j].z;
+        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (dist < overlapTolerance) {
+          warnings.push(`Atoms ${i} and ${j} are very close (${dist.toFixed(4)} A)`);
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}

--- a/tests/unit/structures/OpenQCStructure.conversion.test.ts
+++ b/tests/unit/structures/OpenQCStructure.conversion.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Unit tests for OpenQCStructure conversion utilities.
+ */
+
+import {
+  openQCStructureToXYZ,
+  xyzToOpenQCStructure,
+  molecularStructureToOpenQCStructure,
+  openQCStructureToMolecularStructure,
+  poscarToOpenQCStructure,
+  createOpenQCStructure,
+} from '../../../src/structures/converters';
+import { OPENQC_STRUCTURE_SCHEMA_VERSION } from '../../../src/structures/OpenQCStructure';
+import {
+  WATER_XYZ_CONTENT,
+  METHANE_XYZ_CONTENT,
+  SI_POSCAR_CONTENT,
+  WATER_STRUCTURE,
+  SILICON_STRUCTURE,
+} from '../../../src/structures/fixtures';
+import type { MolecularStructure } from '../../../src/visualizers/types';
+
+// ============================================================================
+// openQCStructureToXYZ
+// ============================================================================
+
+describe('openQCStructureToXYZ', () => {
+  it('converts a water structure to XYZ format', () => {
+    const xyz = openQCStructureToXYZ(WATER_STRUCTURE);
+
+    const lines = xyz.trim().split('\n');
+    expect(lines[0]).toBe('3');
+    expect(lines[1]).toBe('Water');
+    expect(lines.length).toBe(5); // 3 atoms + header + comment
+    expect(lines[2].trim().split(/\s+/)[0]).toBe('O');
+  });
+
+  it('uses "OpenQCStructure" as default comment when name is undefined', () => {
+    const noName = { ...WATER_STRUCTURE, name: undefined };
+    const xyz = openQCStructureToXYZ(noName);
+    expect(xyz.split('\n')[1]).toBe('OpenQCStructure');
+  });
+
+  it('formats coordinates to 6 decimal places', () => {
+    const xyz = openQCStructureToXYZ(WATER_STRUCTURE);
+    const atomLine = xyz.split('\n')[2].trim();
+    const parts = atomLine.split(/\s+/);
+    // x coordinate should have 6 decimal places
+    expect(parts[1]).toMatch(/^\d+\.\d{6}$/);
+  });
+});
+
+// ============================================================================
+// xyzToOpenQCStructure
+// ============================================================================
+
+describe('xyzToOpenQCStructure', () => {
+  it('parses a water XYZ string', () => {
+    const structure = xyzToOpenQCStructure(WATER_XYZ_CONTENT);
+
+    expect(structure.schemaVersion).toBe(OPENQC_STRUCTURE_SCHEMA_VERSION);
+    expect(structure.kind).toBe('molecule');
+    expect(structure.atoms).toHaveLength(3);
+    expect(structure.atoms[0].element).toBe('O');
+    expect(structure.atoms[1].element).toBe('H');
+    expect(structure.atoms[2].element).toBe('H');
+    expect(structure.name).toBe('Water molecule');
+  });
+
+  it('parses a methane XYZ string', () => {
+    const structure = xyzToOpenQCStructure(METHANE_XYZ_CONTENT);
+
+    expect(structure.atoms).toHaveLength(5);
+    expect(structure.atoms[0].element).toBe('C');
+  });
+
+  it('throws on too-short content', () => {
+    expect(() => xyzToOpenQCStructure('1\n')).toThrow('file too short');
+  });
+
+  it('throws on non-numeric atom count', () => {
+    expect(() => xyzToOpenQCStructure('abc\ntest\nH 0 0 0\n')).toThrow(
+      'positive integer'
+    );
+  });
+
+  it('throws on zero atom count', () => {
+    expect(() => xyzToOpenQCStructure('0\ntest\n')).toThrow('positive integer');
+  });
+
+  it('throws when no valid atoms found', () => {
+    // Atom count says 1 but the line is malformed
+    expect(() => xyzToOpenQCStructure('1\ntest\nbad line\n')).toThrow(
+      'no valid atom lines'
+    );
+  });
+
+  it('passes through source metadata', () => {
+    const structure = xyzToOpenQCStructure(WATER_XYZ_CONTENT, {
+      sourceSoftware: 'gaussian',
+      name: 'Custom Name',
+    });
+    expect(structure.name).toBe('Custom Name');
+    expect(structure.metadata?.source?.software).toBe('gaussian');
+    expect(structure.metadata?.source?.parser).toBe('xyz');
+  });
+
+  it('round-trips through XYZ conversion', () => {
+    const original = WATER_STRUCTURE;
+    const xyz = openQCStructureToXYZ(original);
+    const restored = xyzToOpenQCStructure(xyz);
+
+    expect(restored.atoms).toHaveLength(original.atoms.length);
+    for (let i = 0; i < original.atoms.length; i++) {
+      expect(restored.atoms[i].element).toBe(original.atoms[i].element);
+      expect(Math.abs(restored.atoms[i].x - original.atoms[i].x)).toBeLessThan(1e-5);
+      expect(Math.abs(restored.atoms[i].y - original.atoms[i].y)).toBeLessThan(1e-5);
+      expect(Math.abs(restored.atoms[i].z - original.atoms[i].z)).toBeLessThan(1e-5);
+    }
+  });
+});
+
+// ============================================================================
+// molecularStructureToOpenQCStructure
+// ============================================================================
+
+describe('molecularStructureToOpenQCStructure', () => {
+  it('converts a simple molecule-only MolecularStructure', () => {
+    const ms: MolecularStructure = {
+      atoms: [
+        { element: 'H', x: 0, y: 0, z: 0 },
+        { element: 'H', x: 0.74, y: 0, z: 0 },
+      ],
+      name: 'H2',
+    };
+
+    const structure = molecularStructureToOpenQCStructure(ms);
+
+    expect(structure.kind).toBe('molecule');
+    expect(structure.atoms).toHaveLength(2);
+    expect(structure.atoms[0].element).toBe('H');
+    expect(structure.name).toBe('H2');
+    expect(structure.cell).toBeUndefined();
+  });
+
+  it('converts a periodic MolecularStructure with lattice', () => {
+    const ms: MolecularStructure = {
+      atoms: [
+        { element: 'Si', x: 0, y: 0, z: 0 },
+        { element: 'Si', x: 1.3575, y: 1.3575, z: 1.3575 },
+      ],
+      name: 'Si',
+      lattice: {
+        a: [5.43, 0, 0],
+        b: [0, 5.43, 0],
+        c: [0, 0, 5.43],
+      },
+    };
+
+    const structure = molecularStructureToOpenQCStructure(ms);
+
+    expect(structure.kind).toBe('periodic');
+    expect(structure.cell).toBeDefined();
+    expect(structure.cell?.a).toEqual([5.43, 0, 0]);
+    expect(structure.cell?.pbc).toEqual([true, true, true]);
+  });
+
+  it('converts bonds correctly', () => {
+    const ms: MolecularStructure = {
+      atoms: [
+        { element: 'C', x: 0, y: 0, z: 0 },
+        { element: 'O', x: 1.13, y: 0, z: 0 },
+      ],
+      bonds: [
+        { atomIndex1: 0, atomIndex2: 1, length: 1.13, order: 2 },
+      ],
+    };
+
+    const structure = molecularStructureToOpenQCStructure(ms);
+
+    expect(structure.bonds).toHaveLength(1);
+    expect(structure.bonds![0].from).toBe(0);
+    expect(structure.bonds![0].to).toBe(1);
+    expect(structure.bonds![0].order).toBe(2);
+  });
+
+  it('passes source metadata through', () => {
+    const ms: MolecularStructure = {
+      atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+    };
+
+    const structure = molecularStructureToOpenQCStructure(ms, {
+      sourceSoftware: 'cp2k',
+      sourceParser: 'cp2k-coord',
+    });
+
+    expect(structure.metadata?.source?.software).toBe('cp2k');
+    expect(structure.metadata?.source?.parser).toBe('cp2k-coord');
+  });
+});
+
+// ============================================================================
+// openQCStructureToMolecularStructure
+// ============================================================================
+
+describe('openQCStructureToMolecularStructure', () => {
+  it('converts a molecule OpenQCStructure back to MolecularStructure', () => {
+    const ms = openQCStructureToMolecularStructure(WATER_STRUCTURE);
+
+    expect(ms.atoms).toHaveLength(3);
+    expect(ms.atoms[0].element).toBe('O');
+    expect(ms.name).toBe('Water');
+    expect(ms.lattice).toBeUndefined();
+  });
+
+  it('converts a periodic OpenQCStructure with cell', () => {
+    const ms = openQCStructureToMolecularStructure(SILICON_STRUCTURE);
+
+    expect(ms.lattice).toBeDefined();
+    expect(ms.lattice?.a).toEqual([5.43, 0, 0]);
+  });
+
+  it('converts bonds back', () => {
+    const structureWithBonds = {
+      ...WATER_STRUCTURE,
+      bonds: [
+        { from: 0, to: 1, order: 1 },
+        { from: 0, to: 2, order: 1 },
+      ],
+    };
+    const ms = openQCStructureToMolecularStructure(structureWithBonds);
+
+    expect(ms.bonds).toHaveLength(2);
+    expect(ms.bonds![0].atomIndex1).toBe(0);
+    expect(ms.bonds![0].atomIndex2).toBe(1);
+  });
+
+  it('round-trips molecule data through both converters', () => {
+    const original: MolecularStructure = {
+      atoms: [
+        { element: 'N', x: 0, y: 0, z: 0 },
+        { element: 'H', x: 0.94, y: 0, z: 0 },
+        { element: 'H', x: -0.47, y: 0.81, z: 0 },
+        { element: 'H', x: -0.47, y: -0.81, z: 0 },
+      ],
+      name: 'NH3',
+    };
+
+    const dto = molecularStructureToOpenQCStructure(original);
+    const restored = openQCStructureToMolecularStructure(dto);
+
+    expect(restored.atoms).toHaveLength(original.atoms.length);
+    expect(restored.name).toBe('NH3');
+    for (let i = 0; i < original.atoms.length; i++) {
+      expect(restored.atoms[i].element).toBe(original.atoms[i].element);
+    }
+  });
+});
+
+// ============================================================================
+// poscarToOpenQCStructure
+// ============================================================================
+
+describe('poscarToOpenQCStructure', () => {
+  it('parses a silicon POSCAR', () => {
+    const structure = poscarToOpenQCStructure(SI_POSCAR_CONTENT, 'POSCAR');
+
+    expect(structure.kind).toBe('periodic');
+    expect(structure.name).toBe('POSCAR');
+    expect(structure.atoms).toHaveLength(2);
+    expect(structure.atoms[0].element).toBe('Si');
+    expect(structure.atoms[1].element).toBe('Si');
+    expect(structure.cell).toBeDefined();
+    expect(structure.cell?.a).toEqual([5.43, 0, 0]);
+    expect(structure.cell?.coordinateMode).toBe('fractional');
+    expect(structure.metadata?.source?.software).toBe('vasp');
+  });
+
+  it('throws on too-short POSCAR content', () => {
+    expect(() => poscarToOpenQCStructure('short')).toThrow('too few lines');
+  });
+
+  it('handles selective dynamics flags', () => {
+    const poscarWithSD = `Test SD
+1.0
+5.0 0.0 0.0
+0.0 5.0 0.0
+0.0 0.0 5.0
+Si
+1
+Selective dynamics
+0.0 0.0 0.0 T T F
+`;
+
+    const structure = poscarToOpenQCStructure(poscarWithSD);
+    expect(structure.atoms[0].selectiveDynamics).toEqual([true, true, false]);
+  });
+});
+
+// ============================================================================
+// createOpenQCStructure
+// ============================================================================
+
+describe('createOpenQCStructure', () => {
+  it('creates a minimal molecule structure', () => {
+    const structure = createOpenQCStructure([
+      { element: 'H', x: 0, y: 0, z: 0 },
+      { element: 'H', x: 0.74, y: 0, z: 0 },
+    ]);
+
+    expect(structure.schemaVersion).toBe(OPENQC_STRUCTURE_SCHEMA_VERSION);
+    expect(structure.kind).toBe('molecule');
+    expect(structure.atoms).toHaveLength(2);
+    expect(structure.cell).toBeUndefined();
+  });
+
+  it('creates a periodic structure when cell is provided', () => {
+    const structure = createOpenQCStructure(
+      [{ element: 'Si', x: 0, y: 0, z: 0 }],
+      {
+        kind: 'periodic',
+        cell: {
+          a: [5.43, 0, 0],
+          b: [0, 5.43, 0],
+          c: [0, 0, 5.43],
+          pbc: [true, true, true],
+        },
+      }
+    );
+
+    expect(structure.kind).toBe('periodic');
+    expect(structure.cell).toBeDefined();
+  });
+
+  it('infers periodic kind from cell presence when kind not specified', () => {
+    const structure = createOpenQCStructure(
+      [{ element: 'Si', x: 0, y: 0, z: 0 }],
+      {
+        cell: {
+          a: [5.43, 0, 0],
+          b: [0, 5.43, 0],
+          c: [0, 0, 5.43],
+          pbc: [true, true, true],
+        },
+      }
+    );
+
+    expect(structure.kind).toBe('periodic');
+  });
+
+  it('sets charge and multiplicity in metadata', () => {
+    const structure = createOpenQCStructure(
+      [{ element: 'H', x: 0, y: 0, z: 0 }],
+      { charge: 1, multiplicity: 2 }
+    );
+
+    expect(structure.metadata?.charge).toBe(1);
+    expect(structure.metadata?.multiplicity).toBe(2);
+  });
+
+  it('sets the name', () => {
+    const structure = createOpenQCStructure(
+      [{ element: 'H', x: 0, y: 0, z: 0 }],
+      { name: 'Test molecule' }
+    );
+
+    expect(structure.name).toBe('Test molecule');
+  });
+});

--- a/tests/unit/structures/OpenQCStructure.validation.test.ts
+++ b/tests/unit/structures/OpenQCStructure.validation.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for OpenQCStructure validation.
+ */
+
+import { validateOpenQCStructure } from '../../../src/structures/validation';
+import { OPENQC_STRUCTURE_SCHEMA_VERSION } from '../../../src/structures/OpenQCStructure';
+import {
+  WATER_STRUCTURE,
+  SILICON_STRUCTURE,
+} from '../../../src/structures/fixtures';
+
+describe('validateOpenQCStructure', () => {
+  // -----------------------------------------------------------------------
+  // Valid structures
+  // -----------------------------------------------------------------------
+
+  describe('valid structures', () => {
+    it('accepts a valid molecule structure (water)', () => {
+      const result = validateOpenQCStructure(WATER_STRUCTURE);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('accepts a valid periodic structure (silicon)', () => {
+      const result = validateOpenQCStructure(SILICON_STRUCTURE);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('accepts a minimal valid structure with just required fields', () => {
+      const minimal = {
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      };
+      const result = validateOpenQCStructure(minimal);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Invalid schema version
+  // -----------------------------------------------------------------------
+
+  describe('schemaVersion validation', () => {
+    it('rejects missing schemaVersion', () => {
+      const result = validateOpenQCStructure({
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('schemaVersion is required and must be a string');
+    });
+
+    it('rejects unknown schemaVersion', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: 'openqc.structure.v99',
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Unsupported schemaVersion'))).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Invalid kind
+  // -----------------------------------------------------------------------
+
+  describe('kind validation', () => {
+    it('rejects missing kind', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('kind is required and must be a string');
+    });
+
+    it('rejects unknown kind', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'unknown_type',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Invalid kind'))).toBe(true);
+    });
+
+    it('accepts all valid kinds', () => {
+      const kinds = ['molecule', 'periodic', 'surface', 'trajectory', 'volumetric'];
+      for (const kind of kinds) {
+        const result = validateOpenQCStructure({
+          schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+          kind,
+          atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+        });
+        expect(result.valid).toBe(true);
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Atom validation
+  // -----------------------------------------------------------------------
+
+  describe('atom validation', () => {
+    it('rejects missing atoms array', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('atoms is required and must be an array');
+    });
+
+    it('rejects empty atoms array', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('atoms array must not be empty');
+    });
+
+    it('rejects atom with missing element', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('missing or empty element'))).toBe(true);
+    });
+
+    it('rejects atom with empty element string', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: '  ', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('missing or empty element'))).toBe(true);
+    });
+
+    it('rejects atom with NaN coordinates', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: NaN, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('x coordinate'))).toBe(true);
+    });
+
+    it('rejects atom with Infinity coordinates', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: Infinity, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('x coordinate'))).toBe(true);
+    });
+
+    it('rejects atom with invalid force tuple', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0, force: [1, 'bad'] as any }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('force must be a 3-tuple'))).toBe(true);
+    });
+
+    it('rejects atom with invalid selectiveDynamics', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0, selectiveDynamics: [true, false, 1] as any }],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('selectiveDynamics'))).toBe(true);
+    });
+
+    it('accepts atom with valid force tuple', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0, force: [0.1, 0.2, 0.3] }],
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it('accepts atom with valid selectiveDynamics', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0, selectiveDynamics: [true, false, true] }],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cell validation
+  // -----------------------------------------------------------------------
+
+  describe('cell validation', () => {
+    it('rejects cell with missing lattice vectors', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'periodic',
+        atoms: [{ element: 'Si', x: 0, y: 0, z: 0 }],
+        cell: { pbc: [true, true, true] },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('cell.a'))).toBe(true);
+      expect(result.errors.some(e => e.includes('cell.b'))).toBe(true);
+      expect(result.errors.some(e => e.includes('cell.c'))).toBe(true);
+    });
+
+    it('rejects cell with zero-length lattice vector', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'periodic',
+        atoms: [{ element: 'Si', x: 0, y: 0, z: 0 }],
+        cell: {
+          a: [0, 0, 0],
+          b: [1, 0, 0],
+          c: [0, 1, 0],
+          pbc: [true, true, true],
+        },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('cell.a has zero length'))).toBe(true);
+    });
+
+    it('rejects cell with invalid pbc', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'periodic',
+        atoms: [{ element: 'Si', x: 0, y: 0, z: 0 }],
+        cell: {
+          a: [1, 0, 0],
+          b: [0, 1, 0],
+          c: [0, 0, 1],
+          pbc: [1, 1, 1] as any,
+        },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('cell.pbc'))).toBe(true);
+    });
+
+    it('rejects cell with invalid coordinateMode', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'periodic',
+        atoms: [{ element: 'Si', x: 0, y: 0, z: 0 }],
+        cell: {
+          a: [1, 0, 0],
+          b: [0, 1, 0],
+          c: [0, 0, 1],
+          pbc: [true, true, true],
+          coordinateMode: 'invalid',
+        },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('coordinateMode'))).toBe(true);
+    });
+
+    it('accepts molecule structure without cell', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Bond validation
+  // -----------------------------------------------------------------------
+
+  describe('bond validation', () => {
+    it('rejects bond with non-number from/to', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }, { element: 'O', x: 1, y: 0, z: 0 }],
+        bonds: [{ from: '0', to: 1 } as any],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('"from" and "to"'))).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Warnings
+  // -----------------------------------------------------------------------
+
+  describe('warnings', () => {
+    it('warns about overlapping atoms by default', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'molecule',
+        atoms: [
+          { element: 'H', x: 0, y: 0, z: 0 },
+          { element: 'H', x: 0.001, y: 0, z: 0 },
+        ],
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.includes('very close'))).toBe(true);
+    });
+
+    it('does not warn about overlapping atoms when checkOverlap is false', () => {
+      const result = validateOpenQCStructure(
+        {
+          schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+          kind: 'molecule',
+          atoms: [
+            { element: 'H', x: 0, y: 0, z: 0 },
+            { element: 'H', x: 0.001, y: 0, z: 0 },
+          ],
+        },
+        { checkOverlap: false }
+      );
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('warns about frame with no atoms', () => {
+      const result = validateOpenQCStructure({
+        schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
+        kind: 'trajectory',
+        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }],
+        frames: [{ atoms: [] }],
+      });
+      expect(result.valid).toBe(true);
+      expect(result.warnings.some(w => w.includes('Frame 0'))).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Non-object input
+  // -----------------------------------------------------------------------
+
+  describe('non-object input', () => {
+    it('rejects null', () => {
+      const result = validateOpenQCStructure(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('non-null object');
+    });
+
+    it('rejects a string', () => {
+      const result = validateOpenQCStructure('not a structure');
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a number', () => {
+      const result = validateOpenQCStructure(42);
+      expect(result.valid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `OpenQCStructure` as the canonical DTO for molecular/crystal structure representation across OpenQC, resolving #72.

### What changed

**New module: `src/structures/`**

| File | Purpose |
|------|---------|
| `OpenQCStructure.ts` | Core interfaces: `OpenQCStructure`, `OpenQCAtom`, `OpenQCCell`, `OpenQCBond`, `OpenQCStructureMetadata` with explicit schema version (`openqc.structure.v1`) |
| `validation.ts` | Runtime validation function returning structured `{ valid, errors, warnings }` diagnostics |
| `converters.ts` | Bidirectional converters: XYZ, MolecularStructure (legacy), POSCAR, plus a `createOpenQCStructure` factory |
| `fixtures.ts` | Reusable test fixtures (water molecule, silicon crystal, POSCAR/XYZ content strings) |
| `index.ts` | Barrel exports |

**New tests: `tests/unit/structures/`**

| File | Coverage |
|------|----------|
| `OpenQCStructure.validation.test.ts` | Schema version, kind, atom, cell, bond, overlap warnings |
| `OpenQCStructure.conversion.test.ts` | XYZ round-trip, MolecularStructure adapter, POSCAR parsing, factory |

### Acceptance criteria from #72

- [x] `OpenQCStructure` and related DTOs exist under `src/structures`
- [x] Existing viewer can still receive XYZ through compatibility conversion path (`openQCStructureToXYZ`)
- [x] VASP/POSCAR structures preserve cell metadata in the DTO
- [x] Molecule-only formats omit `cell` cleanly
- [x] Validation catches missing/invalid atom coordinates, invalid cell vectors, unknown coordinate modes, and empty atom lists
- [x] No existing `openqc.visualizeStructure` behavior regresses

### Verification

- `npm run compile` -- clean
- `npm run typecheck` -- clean
- `npm run lint` -- clean
- `npm run test:unit` -- 919 tests pass (57 new), coverage thresholds met

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)