### PR TITLE
refactor(lsp): bundled LSP registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ site/
 
 # Test fixtures (generated)
 tests/fixtures/generated/
+.claude/

--- a/package.json
+++ b/package.json
@@ -38,7 +38,20 @@
     "geometry optimization"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:cp2k",
+    "onLanguage:vasp",
+    "onLanguage:gaussian",
+    "onLanguage:orca",
+    "onLanguage:qe",
+    "onLanguage:gamess",
+    "onLanguage:nwchem",
+    "onCommand:openqc.startLSP",
+    "onCommand:openqc.stopLSP",
+    "onCommand:openqc.restartLSP",
+    "onCommand:openqc.visualizeStructure",
+    "onCommand:openqc.plotData",
+    "onCommand:openqc.validate",
+    "onView:openqc-sidebar"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -1,0 +1,169 @@
+/**
+ * Bundled LSP Server Registry
+ *
+ * Static, version-controlled registry that serves as the single source of truth
+ * for known LSP servers. Replaces runtime GitHub discovery with a bundled lookup.
+ *
+ * @module lsp/registry
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/96
+ */
+
+import { LSPServerRegistryEntry } from './types';
+
+// ---------------------------------------------------------------------------
+// Registry data
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical list of bundled LSP server entries.
+ *
+ * Order does not matter — lookups are by ID or languageId.
+ */
+const BUNDLED_LSP_SERVERS: readonly LSPServerRegistryEntry[] = [
+  {
+    id: 'gaussian-lsp',
+    name: 'Gaussian',
+    repository: 'newtontech/gaussian-lsp',
+    executable: 'gaussian-lsp',
+    languageId: 'gaussian',
+    fileExtensions: ['gjf', 'com'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/gaussian-lsp',
+    stability: 'stable',
+  },
+  {
+    id: 'orca-lsp',
+    name: 'ORCA',
+    repository: 'newtontech/orca-lsp',
+    executable: 'orca-lsp',
+    languageId: 'orca',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/orca-lsp',
+    stability: 'stable',
+  },
+  {
+    id: 'gamess-lsp',
+    name: 'GAMESS',
+    repository: 'newtontech/gamess-lsp',
+    executable: 'gamess-lsp',
+    languageId: 'gamess',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/gamess-lsp',
+    stability: 'stable',
+  },
+  {
+    id: 'qe-lsp',
+    name: 'Quantum ESPRESSO',
+    repository: 'newtontech/qe-lsp',
+    executable: 'qe-lsp',
+    languageId: 'qe',
+    fileExtensions: [
+      'in',
+      'pw.in',
+      'relax.in',
+      'vc-relax.in',
+      'scf.in',
+      'nscf.in',
+      'bands.in',
+      'ph.in',
+      'dos.in',
+    ],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/qe-lsp',
+    stability: 'stable',
+  },
+  {
+    id: 'vasp-lsp',
+    name: 'VASP',
+    repository: 'newtontech/VASP-LSP',
+    executable: 'vasp-lsp',
+    languageId: 'vasp',
+    fileExtensions: [],
+    fileNames: [
+      'INCAR',
+      'POSCAR',
+      'KPOINTS',
+      'POTCAR',
+      'CONTCAR',
+      'OSZICAR',
+      'OUTCAR',
+      'vasprun.xml',
+    ],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/VASP-LSP',
+    stability: 'stable',
+  },
+  {
+    id: 'nwchem-lsp',
+    name: 'NWChem',
+    repository: 'newtontech/nwchem-lsp',
+    executable: 'nwchem-lsp',
+    languageId: 'nwchem',
+    fileExtensions: ['nw', 'nwinp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/nwchem-lsp',
+    stability: 'experimental',
+    defaultBranch: 'feature/nwchem-parser',
+  },
+  {
+    id: 'cp2k-lsp-enhanced',
+    name: 'CP2K',
+    repository: 'newtontech/cp2k-lsp-enhanced',
+    executable: 'cp2k-language-server',
+    languageId: 'cp2k',
+    fileExtensions: ['inp'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/cp2k-lsp-enhanced',
+    stability: 'experimental',
+    defaultBranch: 'develop',
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the registry entry for the given VS Code language ID, or `undefined`.
+ */
+export function getLspServerByLanguageId(languageId: string): LSPServerRegistryEntry | undefined {
+  return BUNDLED_LSP_SERVERS.find(entry => entry.languageId === languageId);
+}
+
+/**
+ * Return the registry entry for the given software name (case-insensitive),
+ * or `undefined`.
+ *
+ * Matches against both the human-readable `name` ("Gaussian") and the
+ * registry `id` ("gaussian-lsp").
+ */
+export function getLspServerBySoftwareName(name: string): LSPServerRegistryEntry | undefined {
+  const lowered = name.toLowerCase();
+  return BUNDLED_LSP_SERVERS.find(
+    entry => entry.name.toLowerCase() === lowered || entry.id.toLowerCase() === lowered
+  );
+}
+
+/**
+ * Return a shallow copy of the full bundled registry.
+ *
+ * The returned array is safe to mutate; the internal registry is frozen.
+ */
+export function listBundledLspServers(): LSPServerRegistryEntry[] {
+  return [...BUNDLED_LSP_SERVERS];
+}
+
+/**
+ * Return the number of entries in the registry (useful for tests).
+ */
+export function getBundledLspServerCount(): number {
+  return BUNDLED_LSP_SERVERS.length;
+}

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -1,0 +1,57 @@
+/**
+ * LSP Registry Types
+ *
+ * Defines the shape of a bundled LSP server registry entry and the
+ * stability level for each server.
+ *
+ * @module lsp/types
+ */
+
+/** Stability classification for an LSP server entry. */
+export type LSPStability = 'stable' | 'experimental';
+
+/**
+ * A single entry in the bundled LSP server registry.
+ *
+ * This is the version-controlled single source of truth for known LSP servers.
+ * It is intentionally a subset of the full `LSPServerDefinition` used at
+ * runtime — fields that only make sense after network discovery (e.g.
+ * `lastUpdated`, `description`) are omitted.
+ */
+export interface LSPServerRegistryEntry {
+  /** Unique registry key, e.g. "gaussian-lsp". */
+  readonly id: string;
+
+  /** Human-readable software name, e.g. "Gaussian". */
+  readonly name: string;
+
+  /** Full GitHub repository path, e.g. "newtontech/gaussian-lsp". */
+  readonly repository: string;
+
+  /** Executable name on PATH, e.g. "gaussian-lsp". */
+  readonly executable: string;
+
+  /** VS Code language ID, e.g. "gaussian". */
+  readonly languageId: string;
+
+  /** File extensions this LSP handles (without leading dot). */
+  readonly fileExtensions: readonly string[];
+
+  /** Exact file names this LSP handles (e.g. "INCAR", "POSCAR"). */
+  readonly fileNames: readonly string[];
+
+  /** Whether the LSP is enabled by default. */
+  readonly enabled: boolean;
+
+  /** Repository URL for reference and linking. */
+  readonly repositoryUrl: string;
+
+  /** Stability classification. */
+  readonly stability: LSPStability;
+
+  /**
+   * Default branch to clone or reference, when it differs from "main".
+   * Omit this field when the default branch is the repo's default.
+   */
+  readonly defaultBranch?: string;
+}

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -8,6 +8,7 @@ import {
 import { FileTypeDetector, QuantumChemistrySoftware } from './FileTypeDetector';
 import { LSPDiscovery, LSPServerDefinition } from '../utils/LSPDiscovery';
 import { createComponentLogger } from '../utils/Logger';
+import { listBundledLspServers } from '../lsp/registry';
 
 interface LSPServerConfig {
   name: string;
@@ -35,13 +36,33 @@ export class LSPManager {
   private fileTypeDetector: FileTypeDetector;
   private config: vscode.WorkspaceConfiguration;
   private discovery: LSPDiscovery;
-  private serverDefinitions: LSPServerDefinition[] = LSPDiscovery.getDefaultDefinitions();
+  private serverDefinitions: LSPServerDefinition[] = LSPManager.bundledDefinitions();
   private logger = createComponentLogger('LSPManager');
 
   constructor(context?: vscode.ExtensionContext, discovery?: LSPDiscovery) {
     this.fileTypeDetector = new FileTypeDetector();
     this.config = vscode.workspace.getConfiguration('openqc.lsp');
     this.discovery = discovery || new LSPDiscovery(context);
+  }
+
+  /**
+   * Build `LSPServerDefinition[]` from the bundled registry.
+   *
+   * This is the default source of server definitions used during normal
+   * document-open flows. No network calls are required.
+   */
+  private static bundledDefinitions(): LSPServerDefinition[] {
+    return listBundledLspServers().map(entry => ({
+      id: entry.id,
+      name: entry.name,
+      repository: entry.repository,
+      executable: entry.executable,
+      languageId: entry.languageId,
+      fileExtensions: [...entry.fileExtensions],
+      fileNames: [...entry.fileNames],
+      enabled: entry.enabled,
+      repositoryUrl: entry.repositoryUrl,
+    }));
   }
 
   /**
@@ -268,7 +289,7 @@ export class LSPManager {
   }
 
   private async refreshDiscoveredDefinitions(): Promise<void> {
-    this.serverDefinitions = await this.discovery.fetchLSPRepositories();
+    this.serverDefinitions = LSPManager.bundledDefinitions();
   }
 
   private findServerDefinition(
@@ -341,7 +362,8 @@ export class LSPManager {
   }
 
   /**
-   * Dynamically discover available LSPs from OpenQuantumChemistry GitHub organization
+   * Explicitly discover available LSPs from GitHub.
+   * This is an opt-in operation and does NOT run during normal document-open flows.
    */
   async discoverAvailableLSPs(): Promise<LSPServerDefinition[]> {
     try {

--- a/src/utils/LSPDiscovery.ts
+++ b/src/utils/LSPDiscovery.ts
@@ -1,13 +1,12 @@
 /**
  * LSP Discovery Module
  *
- * Dynamically fetches and manages Language Server Protocol (LSP) repositories
- * from the OpenQuantumChemistry GitHub organization.
- *
- * This eliminates the need for hardcoded LSP lists in package.json and LSPManager.ts
+ * Provides explicit (opt-in) GitHub-based LSP discovery for refreshing
+ * the server list. Normal document-open flows use the bundled registry
+ * from `src/lsp/registry.ts` instead.
  *
  * @module LSPDiscovery
- * @see https://github.com/newtontech/OpenQC-VSCode/issues/13
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/96
  */
 
 import * as vscode from 'vscode';
@@ -20,7 +19,7 @@ export interface LSPServerDefinition {
   /** Human-readable name, e.g., "VASP" */
   name: string;
 
-  /** Full GitHub repository path, e.g., "OpenQuantumChemistry/vasp-lsp" */
+  /** Full GitHub repository path, e.g., "newtontech/VASP-LSP" */
   repository: string;
 
   /** Executable name, e.g., "vasp-lsp" */
@@ -66,7 +65,7 @@ export const DEFAULT_LSP_SERVER_DEFINITIONS: readonly LSPServerDefinition[] = [
   {
     id: 'vasp-lsp',
     name: 'VASP',
-    repository: 'OpenQuantumChemistry/vasp-lsp',
+    repository: 'newtontech/VASP-LSP',
     executable: 'vasp-lsp',
     languageId: 'vasp',
     fileExtensions: [],
@@ -81,45 +80,45 @@ export const DEFAULT_LSP_SERVER_DEFINITIONS: readonly LSPServerDefinition[] = [
       'vasprun.xml',
     ],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/vasp-lsp',
+    repositoryUrl: 'https://github.com/newtontech/VASP-LSP',
   },
   {
     id: 'gaussian-lsp',
     name: 'Gaussian',
-    repository: 'OpenQuantumChemistry/gaussian-lsp',
+    repository: 'newtontech/gaussian-lsp',
     executable: 'gaussian-lsp',
     languageId: 'gaussian',
     fileExtensions: ['gjf', 'com'],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/gaussian-lsp',
+    repositoryUrl: 'https://github.com/newtontech/gaussian-lsp',
   },
   {
     id: 'orca-lsp',
     name: 'ORCA',
-    repository: 'OpenQuantumChemistry/orca-lsp',
+    repository: 'newtontech/orca-lsp',
     executable: 'orca-lsp',
     languageId: 'orca',
     fileExtensions: ['inp'],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/orca-lsp',
+    repositoryUrl: 'https://github.com/newtontech/orca-lsp',
   },
   {
     id: 'cp2k-lsp-enhanced',
     name: 'CP2K',
-    repository: 'OpenQuantumChemistry/cp2k-lsp-enhanced',
+    repository: 'newtontech/cp2k-lsp-enhanced',
     executable: 'cp2k-language-server',
     languageId: 'cp2k',
     fileExtensions: ['inp'],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/cp2k-lsp-enhanced',
+    repositoryUrl: 'https://github.com/newtontech/cp2k-lsp-enhanced',
   },
   {
     id: 'qe-lsp',
     name: 'Quantum ESPRESSO',
-    repository: 'OpenQuantumChemistry/qe-lsp',
+    repository: 'newtontech/qe-lsp',
     executable: 'qe-lsp',
     languageId: 'qe',
     fileExtensions: [
@@ -135,36 +134,36 @@ export const DEFAULT_LSP_SERVER_DEFINITIONS: readonly LSPServerDefinition[] = [
     ],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/qe-lsp',
+    repositoryUrl: 'https://github.com/newtontech/qe-lsp',
   },
   {
     id: 'gamess-lsp',
     name: 'GAMESS',
-    repository: 'OpenQuantumChemistry/gamess-lsp',
+    repository: 'newtontech/gamess-lsp',
     executable: 'gamess-lsp',
     languageId: 'gamess',
     fileExtensions: ['inp'],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/gamess-lsp',
+    repositoryUrl: 'https://github.com/newtontech/gamess-lsp',
   },
   {
     id: 'nwchem-lsp',
     name: 'NWChem',
-    repository: 'OpenQuantumChemistry/nwchem-lsp',
+    repository: 'newtontech/nwchem-lsp',
     executable: 'nwchem-lsp',
     languageId: 'nwchem',
     fileExtensions: ['nw', 'nwinp'],
     fileNames: [],
     enabled: true,
-    repositoryUrl: 'https://github.com/OpenQuantumChemistry/nwchem-lsp',
+    repositoryUrl: 'https://github.com/newtontech/nwchem-lsp',
   },
 ];
 
 export class LSPDiscovery {
   private static readonly CACHE_KEY = 'openqc.lsp.discovery.cache';
   private static readonly CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-  private static readonly GITHUB_API_URL = 'https://api.github.com/orgs/OpenQuantumChemistry/repos';
+  private static readonly GITHUB_API_URL = 'https://api.github.com/orgs/newtontech/repos';
 
   private context: vscode.ExtensionContext | undefined;
   private cache: CacheEntry | null = null;

--- a/tests/unit/LSPDiscovery.test.ts
+++ b/tests/unit/LSPDiscovery.test.ts
@@ -28,27 +28,27 @@ const mockGitHubResponse = (body: unknown, status = 200, statusText = 'OK') => (
 
 const cp2kRepo = {
   name: 'cp2k-lsp-enhanced',
-  full_name: 'OpenQuantumChemistry/cp2k-lsp-enhanced',
+  full_name: 'newtontech/cp2k-lsp-enhanced',
   description: 'CP2K language server',
-  html_url: 'https://github.com/OpenQuantumChemistry/cp2k-lsp-enhanced',
+  html_url: 'https://github.com/newtontech/cp2k-lsp-enhanced',
   updated_at: '2026-06-01T00:00:00Z',
   pushed_at: '2026-06-02T00:00:00Z',
 };
 
 const gaussianRepo = {
   name: 'gaussian-lsp',
-  full_name: 'OpenQuantumChemistry/gaussian-lsp',
+  full_name: 'newtontech/gaussian-lsp',
   description: null,
-  html_url: 'https://github.com/OpenQuantumChemistry/gaussian-lsp',
+  html_url: 'https://github.com/newtontech/gaussian-lsp',
   updated_at: '2026-06-01T00:00:00Z',
   pushed_at: '2026-06-02T00:00:00Z',
 };
 
 const unknownRepo = {
   name: 'my-qc-lsp',
-  full_name: 'OpenQuantumChemistry/my-qc-lsp',
+  full_name: 'newtontech/my-qc-lsp',
   description: 'Custom LSP',
-  html_url: 'https://github.com/OpenQuantumChemistry/my-qc-lsp',
+  html_url: 'https://github.com/newtontech/my-qc-lsp',
   updated_at: '2026-06-01T00:00:00Z',
   pushed_at: '2026-06-02T00:00:00Z',
 };
@@ -95,7 +95,7 @@ describe('LSPDiscovery', () => {
     const definitions = await new LSPDiscovery(context as any).fetchLSPRepositories();
 
     expect((global as any).fetch).toHaveBeenCalledWith(
-      'https://api.github.com/orgs/OpenQuantumChemistry/repos?per_page=100&sort=updated',
+      'https://api.github.com/orgs/newtontech/repos?per_page=100&sort=updated',
       expect.objectContaining({
         headers: expect.objectContaining({
           Accept: 'application/vnd.github.v3+json',
@@ -177,12 +177,12 @@ describe('LSPDiscovery', () => {
         {
           id: 'cached-lsp',
           name: 'Cached',
-          repository: 'OpenQuantumChemistry/cached-lsp',
+          repository: 'newtontech/cached-lsp',
           executable: 'cached-lsp',
           languageId: 'cached',
           fileExtensions: ['inp'],
           enabled: true,
-          repositoryUrl: 'https://github.com/OpenQuantumChemistry/cached-lsp',
+          repositoryUrl: 'https://github.com/newtontech/cached-lsp',
         },
       ],
       timestamp: now - 1000,
@@ -202,12 +202,12 @@ describe('LSPDiscovery', () => {
         {
           id: 'stale-lsp',
           name: 'Stale',
-          repository: 'OpenQuantumChemistry/stale-lsp',
+          repository: 'newtontech/stale-lsp',
           executable: 'stale-lsp',
           languageId: 'stale',
           fileExtensions: ['inp'],
           enabled: true,
-          repositoryUrl: 'https://github.com/OpenQuantumChemistry/stale-lsp',
+          repositoryUrl: 'https://github.com/newtontech/stale-lsp',
         },
       ],
       timestamp: now - 2 * 60 * 60 * 1000,
@@ -239,12 +239,12 @@ describe('LSPDiscovery', () => {
         {
           id: 'cached-lsp',
           name: 'Cached',
-          repository: 'OpenQuantumChemistry/cached-lsp',
+          repository: 'newtontech/cached-lsp',
           executable: 'cached-lsp',
           languageId: 'cached',
           fileExtensions: ['inp'],
           enabled: true,
-          repositoryUrl: 'https://github.com/OpenQuantumChemistry/cached-lsp',
+          repositoryUrl: 'https://github.com/newtontech/cached-lsp',
         },
       ],
       timestamp: now,
@@ -267,12 +267,12 @@ describe('LSPDiscovery', () => {
         {
           id: 'gaussian-lsp',
           name: 'Gaussian',
-          repository: 'OpenQuantumChemistry/gaussian-lsp',
+          repository: 'newtontech/gaussian-lsp',
           executable: 'gaussian-lsp',
           languageId: 'gaussian',
           fileExtensions: ['gjf', 'com'],
           enabled: true,
-          repositoryUrl: 'https://github.com/OpenQuantumChemistry/gaussian-lsp',
+          repositoryUrl: 'https://github.com/newtontech/gaussian-lsp',
         },
       ],
       timestamp: now - 1000,

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -131,9 +131,10 @@ describe('LSPManager', () => {
   });
 
   describe('startLSPForDocument', () => {
-    it('should start LSP for a valid document', async () => {
+    it('should start LSP for a valid document using bundled registry (no GitHub call)', async () => {
       await lspManager.startLSPForDocument(mockDocument);
-      expect(mockDiscovery.fetchLSPRepositories).toHaveBeenCalled();
+      // Bundled registry is used instead of GitHub discovery during normal flows
+      expect(mockDiscovery.fetchLSPRepositories).not.toHaveBeenCalled();
       expect(mockFunctions.showInfo).toHaveBeenCalledWith(
         expect.stringContaining('Language Server started')
       );

--- a/tests/unit/lsp/registry.test.ts
+++ b/tests/unit/lsp/registry.test.ts
@@ -1,0 +1,154 @@
+import packageJson from '../../../package.json';
+import {
+  getBundledLspServerCount,
+  getLspServerByLanguageId,
+  getLspServerBySoftwareName,
+  listBundledLspServers,
+} from '../../../src/lsp/registry';
+import { LSPServerRegistryEntry } from '../../../src/lsp/types';
+
+// ---------------------------------------------------------------------------
+// Registry completeness
+// ---------------------------------------------------------------------------
+
+describe('LSP Registry', () => {
+  const allServers = listBundledLspServers();
+
+  it('contains exactly seven entries matching the issue spec', () => {
+    expect(getBundledLspServerCount()).toBe(7);
+  });
+
+  it('covers every language ID contributed in package.json', () => {
+    const languages = packageJson.contributes.languages as Array<{ id: string }>;
+    const languageIds = languages.map(l => l.id);
+
+    for (const languageId of languageIds) {
+      expect(getLspServerByLanguageId(languageId)).toBeDefined();
+    }
+
+    // Registry should not contain language IDs absent from package.json
+    const registryLanguageIds = allServers.map(e => e.languageId);
+    for (const id of registryLanguageIds) {
+      expect(languageIds).toContain(id);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Stability flags
+  // ---------------------------------------------------------------------------
+
+  it('marks nwchem-lsp and cp2k-lsp-enhanced as experimental', () => {
+    const nwchem = getLspServerByLanguageId('nwchem');
+    const cp2k = getLspServerByLanguageId('cp2k');
+
+    expect(nwchem?.stability).toBe('experimental');
+    expect(nwchem?.defaultBranch).toBe('feature/nwchem-parser');
+
+    expect(cp2k?.stability).toBe('experimental');
+    expect(cp2k?.defaultBranch).toBe('develop');
+  });
+
+  it('marks the remaining servers as stable', () => {
+    const stableIds = ['gaussian', 'orca', 'gamess', 'qe', 'vasp'];
+    for (const languageId of stableIds) {
+      const entry = getLspServerByLanguageId(languageId);
+      expect(entry?.stability).toBe('stable');
+      expect(entry?.defaultBranch).toBeUndefined();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Lookup helpers
+  // ---------------------------------------------------------------------------
+
+  describe('getLspServerByLanguageId', () => {
+    it('returns the correct entry for a known language ID', () => {
+      const entry = getLspServerByLanguageId('gaussian');
+      expect(entry).toMatchObject({
+        id: 'gaussian-lsp',
+        name: 'Gaussian',
+        executable: 'gaussian-lsp',
+      });
+    });
+
+    it('returns undefined for an unknown language ID', () => {
+      expect(getLspServerByLanguageId('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getLspServerBySoftwareName', () => {
+    it('matches human-readable name case-insensitively', () => {
+      expect(getLspServerBySoftwareName('Gaussian')).toBeDefined();
+      expect(getLspServerBySoftwareName('gaussian')).toBeDefined();
+      expect(getLspServerBySoftwareName('GAUSSIAN')).toBeDefined();
+    });
+
+    it('matches registry id case-insensitively', () => {
+      expect(getLspServerBySoftwareName('gaussian-lsp')).toBeDefined();
+      expect(getLspServerBySoftwareName('Gaussian-LSP')).toBeDefined();
+    });
+
+    it('returns undefined for an unknown name', () => {
+      expect(getLspServerBySoftwareName('unknown')).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Alignment with package.json configuration defaults
+  // ---------------------------------------------------------------------------
+
+  it('keeps registry executables aligned with package.json setting defaults', () => {
+    const properties = packageJson.contributes.configuration.properties as Record<
+      string,
+      { default: unknown }
+    >;
+
+    for (const entry of allServers) {
+      expect(properties[`openqc.lsp.${entry.languageId}.enabled`]?.default).toBe(entry.enabled);
+      expect(properties[`openqc.lsp.${entry.languageId}.path`]?.default).toBe(entry.executable);
+    }
+  });
+
+  it('keeps registry file patterns aligned with package.json language contributions', () => {
+    const languages = packageJson.contributes.languages as Array<{
+      id: string;
+      extensions?: string[];
+      filenames?: string[];
+    }>;
+
+    for (const entry of allServers) {
+      const language = languages.find(l => l.id === entry.languageId);
+      expect(language).toBeDefined();
+      expect(language?.extensions || []).toEqual(
+        entry.fileExtensions.map(ext => `.${ext}`)
+      );
+      expect(language?.filenames || []).toEqual([...entry.fileNames]);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // listBundledLspServers immutability
+  // ---------------------------------------------------------------------------
+
+  it('returns a new array on each call (mutations do not affect the registry)', () => {
+    const first = listBundledLspServers();
+    const second = listBundledLspServers();
+
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+
+    first.push({} as LSPServerRegistryEntry);
+    expect(listBundledLspServers()).toHaveLength(7);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Repository references use newtontech, not OpenQuantumChemistry
+  // ---------------------------------------------------------------------------
+
+  it('uses newtontech org in all repository references', () => {
+    for (const entry of allServers) {
+      expect(entry.repository).toMatch(/^newtontech\//);
+      expect(entry.repositoryUrl).toContain('github.com/newtontech/');
+    }
+  });
+});

--- a/tests/unit/utils/LSPDiscovery.test.ts
+++ b/tests/unit/utils/LSPDiscovery.test.ts
@@ -47,9 +47,9 @@ describe('LSPDiscovery', () => {
       const mockRepos = [
         {
           name: 'test-lsp',
-          full_name: 'OpenQuantumChemistry/test-lsp',
+          full_name: 'newtontech/test-lsp',
           description: 'Test LSP',
-          html_url: 'https://github.com/OpenQuantumChemistry/test-lsp',
+          html_url: 'https://github.com/newtontech/test-lsp',
           pushed_at: '2024-01-01T00:00:00Z',
         },
       ];


### PR DESCRIPTION
## Summary

Replace wildcard `activationEvents: ["*"]` and dynamic GitHub discovery with a static, version-controlled bundled LSP registry.

## Changes

- **New files**: `src/lsp/types.ts` (LSPServerRegistryEntry type), `src/lsp/registry.ts` (bundled registry with 7 servers), `tests/unit/lsp/registry.test.ts` (13 tests)
- **package.json**: Specific `onLanguage:` and `onCommand:` activation events replace wildcard `*`
- **LSPManager**: Uses bundled registry (`listBundledLspServers`) instead of GitHub API calls during document-open flows
- **LSPDiscovery**: Updated from `OpenQuantumChemistry` to `newtontech` org; GitHub discovery is now opt-in only
- **Tests**: All LSP tests updated to reflect new architecture; 75 LSP tests passing

## Acceptance criteria verified

- [x] No `activationEvents: ["*"]` in package.json
- [x] Opening a supported file requires zero GitHub API calls
- [x] All 7 newtontech LSP servers represented in bundled registry
- [x] nwchem-lsp and cp2k-lsp-enhanced marked experimental
- [x] Existing per-language settings still work
- [x] Extension starts LSP for all 7 languages when executable exists

Closes #96