### PR TITLE
chore: apply current prettier formatting

### DIFF
--- a/src/structures/OpenQCStructure.ts
+++ b/src/structures/OpenQCStructure.ts
@@ -18,12 +18,7 @@ export type OpenQCStructureSchemaVersion = typeof OPENQC_STRUCTURE_SCHEMA_VERSIO
 // Structure kind
 // ---------------------------------------------------------------------------
 
-export type OpenQCStructureKind =
-  | 'molecule'
-  | 'periodic'
-  | 'surface'
-  | 'trajectory'
-  | 'volumetric';
+export type OpenQCStructureKind = 'molecule' | 'periodic' | 'surface' | 'trajectory' | 'volumetric';
 
 // ---------------------------------------------------------------------------
 // Atom

--- a/src/structures/converters.ts
+++ b/src/structures/converters.ts
@@ -256,10 +256,7 @@ export function openQCStructureToMolecularStructure(
  * @returns An OpenQCStructure of kind 'periodic' (or 'molecule' if no lattice).
  * @throws Error if the POSCAR content cannot be parsed.
  */
-export function poscarToOpenQCStructure(
-  content: string,
-  filename?: string
-): OpenQCStructure {
+export function poscarToOpenQCStructure(content: string, filename?: string): OpenQCStructure {
   const lines = content.split('\n');
 
   if (lines.length < 8) {
@@ -297,8 +294,7 @@ export function poscarToOpenQCStructure(
   const modeLine = lines[7].trim().toLowerCase();
   const isSelective = modeLine.startsWith('s');
   const isDirect =
-    modeLine.startsWith('d') ||
-    (!isSelective && !modeLine.startsWith('c') && modeLine !== '');
+    modeLine.startsWith('d') || (!isSelective && !modeLine.startsWith('c') && modeLine !== '');
   const coordLine = isSelective || isDirect || modeLine.startsWith('c') ? 8 : 7;
   const coordinateMode = isDirect ? 'fractional' : 'cartesian';
 

--- a/src/structures/index.ts
+++ b/src/structures/index.ts
@@ -17,10 +17,7 @@ export {
   type OpenQCStructureSchemaVersion,
 } from './OpenQCStructure';
 
-export {
-  validateOpenQCStructure,
-  type ValidationResult,
-} from './validation';
+export { validateOpenQCStructure, type ValidationResult } from './validation';
 
 export {
   openQCStructureToXYZ,

--- a/src/structures/validation.ts
+++ b/src/structures/validation.ts
@@ -177,9 +177,7 @@ export function validateOpenQCStructure(
   if (typeof s.kind !== 'string') {
     errors.push('kind is required and must be a string');
   } else if (!VALID_KINDS.has(s.kind)) {
-    errors.push(
-      `Invalid kind "${s.kind}". Must be one of: ${[...VALID_KINDS].join(', ')}`
-    );
+    errors.push(`Invalid kind "${s.kind}". Must be one of: ${[...VALID_KINDS].join(', ')}`);
   }
 
   // atoms

--- a/tests/unit/lsp/registry.test.ts
+++ b/tests/unit/lsp/registry.test.ts
@@ -119,9 +119,7 @@ describe('LSP Registry', () => {
     for (const entry of allServers) {
       const language = languages.find(l => l.id === entry.languageId);
       expect(language).toBeDefined();
-      expect(language?.extensions || []).toEqual(
-        entry.fileExtensions.map(ext => `.${ext}`)
-      );
+      expect(language?.extensions || []).toEqual(entry.fileExtensions.map(ext => `.${ext}`));
       expect(language?.filenames || []).toEqual([...entry.fileNames]);
     }
   });

--- a/tests/unit/structures/OpenQCStructure.conversion.test.ts
+++ b/tests/unit/structures/OpenQCStructure.conversion.test.ts
@@ -79,9 +79,7 @@ describe('xyzToOpenQCStructure', () => {
   });
 
   it('throws on non-numeric atom count', () => {
-    expect(() => xyzToOpenQCStructure('abc\ntest\nH 0 0 0\n')).toThrow(
-      'positive integer'
-    );
+    expect(() => xyzToOpenQCStructure('abc\ntest\nH 0 0 0\n')).toThrow('positive integer');
   });
 
   it('throws on zero atom count', () => {
@@ -90,9 +88,7 @@ describe('xyzToOpenQCStructure', () => {
 
   it('throws when no valid atoms found', () => {
     // Atom count says 1 but the line is malformed
-    expect(() => xyzToOpenQCStructure('1\ntest\nbad line\n')).toThrow(
-      'no valid atom lines'
-    );
+    expect(() => xyzToOpenQCStructure('1\ntest\nbad line\n')).toThrow('no valid atom lines');
   });
 
   it('passes through source metadata', () => {
@@ -171,9 +167,7 @@ describe('molecularStructureToOpenQCStructure', () => {
         { element: 'C', x: 0, y: 0, z: 0 },
         { element: 'O', x: 1.13, y: 0, z: 0 },
       ],
-      bonds: [
-        { atomIndex1: 0, atomIndex2: 1, length: 1.13, order: 2 },
-      ],
+      bonds: [{ atomIndex1: 0, atomIndex2: 1, length: 1.13, order: 2 }],
     };
 
     const structure = molecularStructureToOpenQCStructure(ms);
@@ -315,54 +309,47 @@ describe('createOpenQCStructure', () => {
   });
 
   it('creates a periodic structure when cell is provided', () => {
-    const structure = createOpenQCStructure(
-      [{ element: 'Si', x: 0, y: 0, z: 0 }],
-      {
-        kind: 'periodic',
-        cell: {
-          a: [5.43, 0, 0],
-          b: [0, 5.43, 0],
-          c: [0, 0, 5.43],
-          pbc: [true, true, true],
-        },
-      }
-    );
+    const structure = createOpenQCStructure([{ element: 'Si', x: 0, y: 0, z: 0 }], {
+      kind: 'periodic',
+      cell: {
+        a: [5.43, 0, 0],
+        b: [0, 5.43, 0],
+        c: [0, 0, 5.43],
+        pbc: [true, true, true],
+      },
+    });
 
     expect(structure.kind).toBe('periodic');
     expect(structure.cell).toBeDefined();
   });
 
   it('infers periodic kind from cell presence when kind not specified', () => {
-    const structure = createOpenQCStructure(
-      [{ element: 'Si', x: 0, y: 0, z: 0 }],
-      {
-        cell: {
-          a: [5.43, 0, 0],
-          b: [0, 5.43, 0],
-          c: [0, 0, 5.43],
-          pbc: [true, true, true],
-        },
-      }
-    );
+    const structure = createOpenQCStructure([{ element: 'Si', x: 0, y: 0, z: 0 }], {
+      cell: {
+        a: [5.43, 0, 0],
+        b: [0, 5.43, 0],
+        c: [0, 0, 5.43],
+        pbc: [true, true, true],
+      },
+    });
 
     expect(structure.kind).toBe('periodic');
   });
 
   it('sets charge and multiplicity in metadata', () => {
-    const structure = createOpenQCStructure(
-      [{ element: 'H', x: 0, y: 0, z: 0 }],
-      { charge: 1, multiplicity: 2 }
-    );
+    const structure = createOpenQCStructure([{ element: 'H', x: 0, y: 0, z: 0 }], {
+      charge: 1,
+      multiplicity: 2,
+    });
 
     expect(structure.metadata?.charge).toBe(1);
     expect(structure.metadata?.multiplicity).toBe(2);
   });
 
   it('sets the name', () => {
-    const structure = createOpenQCStructure(
-      [{ element: 'H', x: 0, y: 0, z: 0 }],
-      { name: 'Test molecule' }
-    );
+    const structure = createOpenQCStructure([{ element: 'H', x: 0, y: 0, z: 0 }], {
+      name: 'Test molecule',
+    });
 
     expect(structure.name).toBe('Test molecule');
   });

--- a/tests/unit/structures/OpenQCStructure.validation.test.ts
+++ b/tests/unit/structures/OpenQCStructure.validation.test.ts
@@ -4,10 +4,7 @@
 
 import { validateOpenQCStructure } from '../../../src/structures/validation';
 import { OPENQC_STRUCTURE_SCHEMA_VERSION } from '../../../src/structures/OpenQCStructure';
-import {
-  WATER_STRUCTURE,
-  SILICON_STRUCTURE,
-} from '../../../src/structures/fixtures';
+import { WATER_STRUCTURE, SILICON_STRUCTURE } from '../../../src/structures/fixtures';
 
 describe('validateOpenQCStructure', () => {
   // -----------------------------------------------------------------------
@@ -290,7 +287,10 @@ describe('validateOpenQCStructure', () => {
       const result = validateOpenQCStructure({
         schemaVersion: OPENQC_STRUCTURE_SCHEMA_VERSION,
         kind: 'molecule',
-        atoms: [{ element: 'H', x: 0, y: 0, z: 0 }, { element: 'O', x: 1, y: 0, z: 0 }],
+        atoms: [
+          { element: 'H', x: 0, y: 0, z: 0 },
+          { element: 'O', x: 1, y: 0, z: 0 },
+        ],
         bonds: [{ from: '0', to: 1 } as any],
       });
       expect(result.valid).toBe(false);


### PR DESCRIPTION
## Summary
- Apply current Prettier formatting to files that fail format:check after the Prettier 3.8 bump
- Keep this separate from the LSP command-resolution work for #97

## Validation
- npm run ci:pr
