### PR TITLE
refactor(lsp): resolve server commands without shell checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,7 +467,31 @@
         "openqc.lsp.cp2k.path": {
           "type": "string",
           "default": "cp2k-language-server",
-          "description": "Path to CP2K Language Server executable"
+          "description": "Path to CP2K Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.cp2k.command instead."
+        },
+        "openqc.lsp.cp2k.command": {
+          "type": "string",
+          "default": "cp2k-language-server",
+          "description": "Command to start the CP2K Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.cp2k.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the CP2K Language Server"
+        },
+        "openqc.lsp.cp2k.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the CP2K Language Server process"
         },
         "openqc.lsp.vasp.enabled": {
           "type": "boolean",
@@ -477,7 +501,31 @@
         "openqc.lsp.vasp.path": {
           "type": "string",
           "default": "vasp-lsp",
-          "description": "Path to VASP Language Server executable"
+          "description": "Path to VASP Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.vasp.command instead."
+        },
+        "openqc.lsp.vasp.command": {
+          "type": "string",
+          "default": "vasp-lsp",
+          "description": "Command to start the VASP Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.vasp.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the VASP Language Server"
+        },
+        "openqc.lsp.vasp.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the VASP Language Server process"
         },
         "openqc.lsp.gaussian.enabled": {
           "type": "boolean",
@@ -487,7 +535,31 @@
         "openqc.lsp.gaussian.path": {
           "type": "string",
           "default": "gaussian-lsp",
-          "description": "Path to Gaussian Language Server executable"
+          "description": "Path to Gaussian Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.gaussian.command instead."
+        },
+        "openqc.lsp.gaussian.command": {
+          "type": "string",
+          "default": "gaussian-lsp",
+          "description": "Command to start the Gaussian Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.gaussian.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the Gaussian Language Server"
+        },
+        "openqc.lsp.gaussian.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the Gaussian Language Server process"
         },
         "openqc.lsp.orca.enabled": {
           "type": "boolean",
@@ -497,7 +569,31 @@
         "openqc.lsp.orca.path": {
           "type": "string",
           "default": "orca-lsp",
-          "description": "Path to ORCA Language Server executable"
+          "description": "Path to ORCA Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.orca.command instead."
+        },
+        "openqc.lsp.orca.command": {
+          "type": "string",
+          "default": "orca-lsp",
+          "description": "Command to start the ORCA Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.orca.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the ORCA Language Server"
+        },
+        "openqc.lsp.orca.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the ORCA Language Server process"
         },
         "openqc.lsp.qe.enabled": {
           "type": "boolean",
@@ -507,7 +603,31 @@
         "openqc.lsp.qe.path": {
           "type": "string",
           "default": "qe-lsp",
-          "description": "Path to Quantum ESPRESSO Language Server executable"
+          "description": "Path to Quantum ESPRESSO Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.qe.command instead."
+        },
+        "openqc.lsp.qe.command": {
+          "type": "string",
+          "default": "qe-lsp",
+          "description": "Command to start the Quantum ESPRESSO Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.qe.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the Quantum ESPRESSO Language Server"
+        },
+        "openqc.lsp.qe.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the Quantum ESPRESSO Language Server process"
         },
         "openqc.lsp.gamess.enabled": {
           "type": "boolean",
@@ -517,7 +637,31 @@
         "openqc.lsp.gamess.path": {
           "type": "string",
           "default": "gamess-lsp",
-          "description": "Path to GAMESS Language Server executable"
+          "description": "Path to GAMESS Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.gamess.command instead."
+        },
+        "openqc.lsp.gamess.command": {
+          "type": "string",
+          "default": "gamess-lsp",
+          "description": "Command to start the GAMESS Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.gamess.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the GAMESS Language Server"
+        },
+        "openqc.lsp.gamess.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the GAMESS Language Server process"
         },
         "openqc.lsp.nwchem.enabled": {
           "type": "boolean",
@@ -527,7 +671,31 @@
         "openqc.lsp.nwchem.path": {
           "type": "string",
           "default": "nwchem-lsp",
-          "description": "Path to NWChem Language Server executable"
+          "description": "Path to NWChem Language Server executable (deprecated: use command instead)",
+          "deprecationMessage": "Use openqc.lsp.nwchem.command instead."
+        },
+        "openqc.lsp.nwchem.command": {
+          "type": "string",
+          "default": "nwchem-lsp",
+          "description": "Command to start the NWChem Language Server (executable name or absolute path)"
+        },
+        "openqc.lsp.nwchem.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the NWChem Language Server"
+        },
+        "openqc.lsp.nwchem.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the NWChem Language Server process"
         },
         "openqc.sidebar.autoRefresh": {
           "type": "boolean",
@@ -622,13 +790,21 @@
         },
         "openqc.locale": {
           "type": "string",
-          "enum": ["en", "zh-CN"],
+          "enum": [
+            "en",
+            "zh-CN"
+          ],
           "default": "en",
           "description": "Display language for OpenQC extension"
         },
         "openqc.logging.level": {
           "type": "string",
-          "enum": ["debug", "info", "warn", "error"],
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
           "default": "info",
           "description": "Set the logging level for OpenQC extension"
         },

--- a/src/lsp/commandResolver.ts
+++ b/src/lsp/commandResolver.ts
@@ -1,0 +1,161 @@
+/**
+ * Cross-platform LSP Command Resolver
+ *
+ * Resolves language server startup commands without shell interpolation.
+ * Supports PATH lookups, absolute paths, paths with spaces, and
+ * Python-module-based servers.
+ *
+ * @module lsp/commandResolver
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/97
+ */
+
+import { execFile } from 'child_process';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { LSPServerRegistryEntry } from './types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A fully resolved command that can be passed directly to `LanguageClient`.
+ */
+export type ResolvedLspCommand =
+  | { kind: 'pathOrCommand'; command: string; args: string[]; env?: Record<string, string> }
+  | {
+      kind: 'pythonModule';
+      python: string;
+      module: string;
+      args: string[];
+      env?: Record<string, string>;
+    };
+
+/**
+ * User-configurable overrides read from VS Code settings.
+ */
+export interface LspCommandOverrides {
+  /** Deprecated alias: absolute path or executable name. */
+  path?: string;
+  /** Explicit command (executable name or absolute path). */
+  command?: string;
+  /** Arguments forwarded to the server process. */
+  args?: string[];
+  /** Extra environment variables for the server process. */
+  env?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an LSP startup command by merging registry defaults with
+ * user-provided config overrides.
+ *
+ * Resolution order (last wins):
+ *   1. Registry `executable` (default command name)
+ *   2. Deprecated `openqc.lsp.<id>.path` setting
+ *   3. New `openqc.lsp.<id>.command` setting
+ *
+ * Args come from:
+ *   1. Registry default `['--stdio']` if the registry entry provides no args
+ *   2. User `openqc.lsp.<id>.args` override
+ *
+ * @param entry     - Bundled registry entry (source of defaults).
+ * @param overrides - User settings read from VS Code configuration.
+ */
+export function resolveLspCommand(
+  entry: LSPServerRegistryEntry,
+  overrides: LspCommandOverrides
+): ResolvedLspCommand {
+  const command = overrides.command || overrides.path || entry.executable;
+  const args = overrides.args ?? [...(entry.args ?? ['--stdio'])];
+  const env = overrides.env;
+
+  return {
+    kind: 'pathOrCommand',
+    command,
+    args,
+    env: Object.keys(env || {}).length > 0 ? env : undefined,
+  };
+}
+
+/**
+ * Read user-facing LSP command overrides for the given language ID from
+ * VS Code configuration.
+ *
+ * Looks up:
+ *   - `openqc.lsp.<languageId>.path`   (deprecated)
+ *   - `openqc.lsp.<languageId>.command`
+ *   - `openqc.lsp.<languageId>.args`
+ *   - `openqc.lsp.<languageId>.env`
+ */
+export function readCommandOverrides(
+  config: vscode.WorkspaceConfiguration,
+  languageId: string
+): LspCommandOverrides {
+  return {
+    path: config.get<string | undefined>(`${languageId}.path`, undefined),
+    command: config.get<string | undefined>(`${languageId}.command`, undefined),
+    args: config.get<string[] | undefined>(`${languageId}.args`, undefined),
+    env: config.get<Record<string, string> | undefined>(`${languageId}.env`, undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Executable existence check (cross-platform)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether an executable is resolvable on the current system.
+ *
+ * - On Windows, uses `where <command>`.
+ * - On macOS / Linux, uses `which <command>`.
+ *
+ * Uses `execFile` (not `exec`) so that user-provided paths containing
+ * spaces or special characters are never passed through a shell.
+ *
+ * If `commandOrPath` looks like an absolute or relative path (contains
+ * `path.sep` or starts with `.`), the function checks whether the file
+ * exists using `fs.access` instead of invoking an external tool.
+ *
+ * @param commandOrPath - Executable name on PATH, or an absolute/relative path.
+ * @returns `true` when the executable is reachable, `false` otherwise.
+ */
+export async function isExecutableAvailable(commandOrPath: string): Promise<boolean> {
+  // If the string looks like a path (contains separator or starts with dot),
+  // skip `which`/`where` and check the file directly.
+  if (isFilePathLike(commandOrPath)) {
+    try {
+      const fs = await import('fs');
+      const { promisify } = await import('util');
+      const access = promisify(fs.access);
+      await access(commandOrPath, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+
+  try {
+    await execFileAsync(cmd, [commandOrPath]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isFilePathLike(commandOrPath: string): boolean {
+  return (
+    path.isAbsolute(commandOrPath) ||
+    path.win32.isAbsolute(commandOrPath) ||
+    commandOrPath.includes('/') ||
+    commandOrPath.includes('\\') ||
+    commandOrPath.startsWith('.')
+  );
+}

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -31,6 +31,9 @@ export interface LSPServerRegistryEntry {
   /** Executable name on PATH, e.g. "gaussian-lsp". */
   readonly executable: string;
 
+  /** Default arguments passed to the executable. Defaults to ["--stdio"]. */
+  readonly args?: readonly string[];
+
   /** VS Code language ID, e.g. "gaussian". */
   readonly languageId: string;
 

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -9,12 +9,18 @@ import { FileTypeDetector, QuantumChemistrySoftware } from './FileTypeDetector';
 import { LSPDiscovery, LSPServerDefinition } from '../utils/LSPDiscovery';
 import { createComponentLogger } from '../utils/Logger';
 import { listBundledLspServers } from '../lsp/registry';
+import {
+  resolveLspCommand,
+  readCommandOverrides,
+  isExecutableAvailable,
+  ResolvedLspCommand,
+} from '../lsp/commandResolver';
+import { LSPServerRegistryEntry } from '../lsp/types';
 
 interface LSPServerConfig {
   name: string;
   enabled: boolean;
-  path: string;
-  args: string[];
+  resolvedCommand: ResolvedLspCommand;
   definition: LSPServerDefinition;
 }
 
@@ -193,8 +199,6 @@ export class LSPManager {
 
     try {
       await this.stopLSPForDocument(document);
-      // Add a small delay to ensure the process is fully terminated
-      await new Promise(resolve => setTimeout(resolve, 500));
       await this.startLSPForDocument(document);
     } catch (error) {
       this.logger.error(`Error restarting ${software} Language Server`, error as Error);
@@ -209,23 +213,37 @@ export class LSPManager {
     identity: LSPClientIdentity
   ): Promise<LanguageClient | undefined> {
     try {
-      // Verify the LSP executable exists
-      const { exec } = require('child_process');
-      const { promisify } = require('util');
-      const execAsync = promisify(exec);
+      const resolved = config.resolvedCommand;
 
-      try {
-        await execAsync(`which ${config.path}`);
-      } catch {
+      // Verify the executable is available using a cross-platform check.
+      // For pythonModule kind, check the python binary.
+      const executableToCheck =
+        resolved.kind === 'pythonModule' ? resolved.python : resolved.command;
+
+      const available = await isExecutableAvailable(executableToCheck);
+      if (!available) {
         throw new Error(
-          `LSP executable '${config.path}' not found in PATH. Please install ${software} LSP server.`
+          `LSP executable '${executableToCheck}' not found. Please install ${software} LSP server.`
         );
       }
 
+      let serverCommand: string;
+      let serverArgs: string[];
+      const serverEnv: Record<string, string> | undefined = resolved.env;
+
+      if (resolved.kind === 'pythonModule') {
+        serverCommand = resolved.python;
+        serverArgs = ['-m', resolved.module, ...resolved.args];
+      } else {
+        serverCommand = resolved.command;
+        serverArgs = resolved.args;
+      }
+
       const serverOptions: ServerOptions = {
-        command: config.path,
-        args: config.args,
+        command: serverCommand,
+        args: serverArgs,
         transport: TransportKind.stdio,
+        ...(serverEnv ? { options: { env: { ...process.env, ...serverEnv } } } : {}),
       };
 
       const watcherPattern = this.createWatcherPattern(config.definition);
@@ -278,14 +296,31 @@ export class LSPManager {
       return undefined;
     }
 
-    const softwareKey = definition.languageId;
+    const languageId = definition.languageId;
+    const overrides = readCommandOverrides(this.config, languageId);
+
+    // Find the matching registry entry for command resolution
+    const registryEntry = this.findRegistryEntry(languageId);
+    const resolvedCommand = registryEntry
+      ? resolveLspCommand(registryEntry, overrides)
+      : {
+          kind: 'pathOrCommand' as const,
+          command: overrides.command || overrides.path || definition.executable,
+          args: overrides.args ?? ['--stdio'],
+          env: overrides.env,
+        };
+
     return {
       name: `${definition.name} LSP`,
-      enabled: this.config.get<boolean>(`${softwareKey}.enabled`, definition.enabled),
-      path: this.config.get<string>(`${softwareKey}.path`, definition.executable),
-      args: ['--stdio'],
+      enabled: this.config.get<boolean>(`${languageId}.enabled`, definition.enabled),
+      resolvedCommand,
       definition,
     };
+  }
+
+  private findRegistryEntry(languageId: string): LSPServerRegistryEntry | undefined {
+    const allEntries = listBundledLspServers();
+    return allEntries.find(entry => entry.languageId === languageId);
   }
 
   private async refreshDiscoveredDefinitions(): Promise<void> {

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -7,13 +7,11 @@ const mockFunctions: {
   showInfo: jest.Mock;
   showWarning: jest.Mock;
   showError: jest.Mock;
-  exec: jest.Mock;
   languageClient: jest.Mock;
 } = {
   showInfo: jest.fn(),
   showWarning: jest.fn(),
   showError: jest.fn(),
-  exec: jest.fn(),
   languageClient: jest.fn(),
 };
 
@@ -67,24 +65,14 @@ jest.mock('vscode', () => ({
   })),
 }));
 
-// Mock child_process
-jest.mock('child_process', () => ({
-  exec: (...args: any[]) => mockFunctions.exec(...args),
-}));
-
-// Mock util - promisify should return a function that returns a Promise
-jest.mock('util', () => ({
-  promisify: jest.fn((fn: Function) => {
-    return (...args: any[]) => {
-      return new Promise((resolve, reject) => {
-        fn(...args, (err: any, result: any) => {
-          if (err) reject(err);
-          else resolve(result);
-        });
-      });
-    };
-  }),
-}));
+// Mock the command resolver's isExecutableAvailable to always succeed in tests
+jest.mock('../../src/lsp/commandResolver', () => {
+  const actual = jest.requireActual('../../src/lsp/commandResolver');
+  return {
+    ...actual,
+    isExecutableAvailable: jest.fn().mockResolvedValue(true),
+  };
+});
 
 // Mock vscode-languageclient/node
 jest.mock('vscode-languageclient/node', () => ({
@@ -102,6 +90,9 @@ describe('LSPManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Logger.resetInstance();
+    // Reset the isExecutableAvailable mock to default (true)
+    const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
+    (isExecutableAvailable as jest.Mock).mockResolvedValue(true);
     const vscode = require('vscode');
     vscode.workspace.getWorkspaceFolder.mockReturnValue(undefined);
     mockDiscovery = {
@@ -115,9 +106,6 @@ describe('LSPManager', () => {
       getText: jest.fn().mockReturnValue('%chk=test.chk\n# B3LYP/6-31G(d)\n\n0 1\nH 0 0 0'),
     } as any;
     // Default mock implementations
-    mockFunctions.exec.mockImplementation((cmd: string, callback: Function) => {
-      callback(null, { stdout: '/usr/bin/test' });
-    });
     mockFunctions.languageClient.mockImplementation(() => ({
       start: jest.fn().mockResolvedValue(undefined),
       stop: jest.fn().mockResolvedValue(undefined),
@@ -140,10 +128,12 @@ describe('LSPManager', () => {
       );
     });
 
-    it('should use discovery defaults for executable path and watcher patterns', async () => {
+    it('should use cross-platform command resolution for executable checks', async () => {
+      const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
       await lspManager.startLSPForDocument(mockDocument);
 
-      expect(mockFunctions.exec).toHaveBeenCalledWith('which gaussian-lsp', expect.any(Function));
+      // isExecutableAvailable should be called (from the mocked module)
+      expect(isExecutableAvailable).toHaveBeenCalled();
       expect(mockFunctions.languageClient).toHaveBeenCalledWith(
         expect.stringContaining('openqc-gaussian-'),
         'OpenQC Gaussian Language Server',
@@ -280,9 +270,8 @@ describe('LSPManager', () => {
     });
 
     it('should handle errors when LSP executable is not found', async () => {
-      mockFunctions.exec.mockImplementationOnce((cmd: string, callback: Function) => {
-        callback(new Error('command not found'), null);
-      });
+      const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
+      (isExecutableAvailable as jest.Mock).mockResolvedValueOnce(false);
       await lspManager.startLSPForDocument(mockDocument);
       expect(mockFunctions.showError).toHaveBeenCalledWith(
         expect.stringContaining('Failed to start')
@@ -302,9 +291,37 @@ describe('LSPManager', () => {
 
       await lspManager.startLSPForDocument(mockDocument);
 
-      expect(mockFunctions.exec).toHaveBeenCalledWith(
-        'which /opt/openqc/custom-gaussian-lsp',
-        expect.any(Function)
+      // The resolved command should be the custom path, not the default executable.
+      // The path contains '/' so it is treated as a filesystem path (fs.access check),
+      // but in test environment fs.access will fail since the file doesn't exist.
+      // We need to make execFile succeed OR check the LanguageClient was constructed
+      // with the overridden command.
+      expect(mockFunctions.languageClient).toHaveBeenCalledWith(
+        expect.stringContaining('openqc-gaussian-'),
+        expect.any(String),
+        expect.objectContaining({ command: '/opt/openqc/custom-gaussian-lsp' }),
+        expect.any(Object)
+      );
+    });
+
+    it('should handle paths with spaces in user config', async () => {
+      const vscode = require('vscode');
+      vscode.workspace.getConfiguration.mockReturnValueOnce({
+        get: jest.fn((key: string, defaultValue?: any) => {
+          if (key === 'gaussian.enabled') return true;
+          if (key === 'gaussian.path') return '/opt/my tools/gaussian-lsp';
+          return defaultValue;
+        }),
+      });
+      lspManager = new LSPManager(undefined, mockDiscovery as LSPDiscovery);
+
+      await lspManager.startLSPForDocument(mockDocument);
+
+      expect(mockFunctions.languageClient).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.objectContaining({ command: '/opt/my tools/gaussian-lsp' }),
+        expect.any(Object)
       );
     });
 
@@ -517,7 +534,7 @@ describe('LSPManager', () => {
       );
     });
 
-    it('should wait between stop and start', async () => {
+    it('should not use a fixed delay between stop and start', async () => {
       mockFunctions.languageClient.mockImplementation(() => ({
         start: jest.fn().mockResolvedValue(undefined),
         stop: jest.fn().mockResolvedValue(undefined),
@@ -525,7 +542,10 @@ describe('LSPManager', () => {
       }));
       const startTime = Date.now();
       await lspManager.restartLSPForDocument(mockDocument);
-      expect(Date.now() - startTime).toBeGreaterThanOrEqual(500);
+      const elapsed = Date.now() - startTime;
+      // Should complete well under 500ms since there is no longer a fixed sleep.
+      // Allow generous overhead for test execution but assert no 500ms delay.
+      expect(elapsed).toBeLessThan(500);
     });
   });
 

--- a/tests/unit/lsp/commandResolver.test.ts
+++ b/tests/unit/lsp/commandResolver.test.ts
@@ -1,0 +1,197 @@
+import {
+  resolveLspCommand,
+  readCommandOverrides,
+  isExecutableAvailable,
+} from '../../../src/lsp/commandResolver';
+import { LSPServerRegistryEntry } from '../../../src/lsp/types';
+
+// ---------------------------------------------------------------------------
+// Mock vscode for readCommandOverrides
+// ---------------------------------------------------------------------------
+
+const mockConfigGet = jest.fn();
+
+jest.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: jest.fn(() => ({
+      get: mockConfigGet,
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<LSPServerRegistryEntry> = {}): LSPServerRegistryEntry {
+  return {
+    id: 'gaussian-lsp',
+    name: 'Gaussian',
+    repository: 'newtontech/gaussian-lsp',
+    executable: 'gaussian-lsp',
+    languageId: 'gaussian',
+    fileExtensions: ['gjf', 'com'],
+    fileNames: [],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/gaussian-lsp',
+    stability: 'stable',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveLspCommand
+// ---------------------------------------------------------------------------
+
+describe('resolveLspCommand', () => {
+  const entry = makeEntry();
+
+  it('uses registry executable when no overrides are provided', () => {
+    const result = resolveLspCommand(entry, {});
+    expect(result).toEqual({
+      kind: 'pathOrCommand',
+      command: 'gaussian-lsp',
+      args: ['--stdio'],
+      env: undefined,
+    });
+  });
+
+  it('uses deprecated path override when command is not set', () => {
+    const result = resolveLspCommand(entry, { path: '/opt/custom/gaussian-lsp' });
+    expect(result).toEqual({
+      kind: 'pathOrCommand',
+      command: '/opt/custom/gaussian-lsp',
+      args: ['--stdio'],
+      env: undefined,
+    });
+  });
+
+  it('prefers command over path when both are set', () => {
+    const result = resolveLspCommand(entry, {
+      path: '/opt/old/gaussian-lsp',
+      command: '/opt/new/gaussian-lsp',
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: 'pathOrCommand',
+        command: '/opt/new/gaussian-lsp',
+      })
+    );
+  });
+
+  it('uses custom args when provided', () => {
+    const result = resolveLspCommand(entry, { args: ['--stdio', '--verbose'] });
+    expect(result.args).toEqual(['--stdio', '--verbose']);
+  });
+
+  it('uses registry args before falling back to --stdio', () => {
+    const result = resolveLspCommand(makeEntry({ args: ['serve', '--stdio'] }), {});
+    expect(result.args).toEqual(['serve', '--stdio']);
+  });
+
+  it('passes through env variables', () => {
+    const env = { PYTHONPATH: '/opt/lib', DEBUG: '1' };
+    const result = resolveLspCommand(entry, { env });
+    expect(result.env).toEqual(env);
+  });
+
+  it('omits env when empty or undefined', () => {
+    expect(resolveLspCommand(entry, { env: undefined }).env).toBeUndefined();
+    expect(resolveLspCommand(entry, { env: {} }).env).toBeUndefined();
+  });
+
+  it('handles paths with spaces', () => {
+    const result = resolveLspCommand(entry, { path: '/opt/my tools/gaussian-lsp' });
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: 'pathOrCommand',
+        command: '/opt/my tools/gaussian-lsp',
+      })
+    );
+  });
+
+  it('defaults to --stdio args when no overrides are given', () => {
+    const result = resolveLspCommand(entry, {});
+    expect(result.args).toEqual(['--stdio']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readCommandOverrides
+// ---------------------------------------------------------------------------
+
+describe('readCommandOverrides', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined for all fields when no config is set', () => {
+    mockConfigGet.mockReturnValue(undefined);
+    const vscode = require('vscode');
+    const config = vscode.workspace.getConfiguration('openqc.lsp');
+    const overrides = readCommandOverrides(config, 'gaussian');
+
+    expect(overrides.path).toBeUndefined();
+    expect(overrides.command).toBeUndefined();
+    expect(overrides.args).toBeUndefined();
+    expect(overrides.env).toBeUndefined();
+  });
+
+  it('reads deprecated path setting', () => {
+    mockConfigGet.mockImplementation((key: string) => {
+      if (key === 'gaussian.path') return '/opt/gaussian-lsp';
+      return undefined;
+    });
+    const vscode = require('vscode');
+    const config = vscode.workspace.getConfiguration('openqc.lsp');
+    const overrides = readCommandOverrides(config, 'gaussian');
+    expect(overrides.path).toBe('/opt/gaussian-lsp');
+  });
+
+  it('reads command, args, and env settings', () => {
+    mockConfigGet.mockImplementation((key: string) => {
+      if (key === 'cp2k.command') return '/usr/local/bin/cp2k-language-server';
+      if (key === 'cp2k.args') return ['--stdio', '--log-level', 'debug'];
+      if (key === 'cp2k.env') return { CP2K_ROOT: '/opt/cp2k' };
+      return undefined;
+    });
+    const vscode = require('vscode');
+    const config = vscode.workspace.getConfiguration('openqc.lsp');
+    const overrides = readCommandOverrides(config, 'cp2k');
+
+    expect(overrides.command).toBe('/usr/local/bin/cp2k-language-server');
+    expect(overrides.args).toEqual(['--stdio', '--log-level', 'debug']);
+    expect(overrides.env).toEqual({ CP2K_ROOT: '/opt/cp2k' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isExecutableAvailable
+// ---------------------------------------------------------------------------
+
+describe('isExecutableAvailable', () => {
+  it('returns false for a clearly nonexistent path', async () => {
+    const result = await isExecutableAvailable('/no/such/path/binary');
+    expect(result).toBe(false);
+  });
+
+  it('returns false for a nonexistent relative path', async () => {
+    const result = await isExecutableAvailable('./nonexistent-binary-xyz');
+    expect(result).toBe(false);
+  });
+
+  it('treats Windows-style paths as paths without shell lookup', async () => {
+    const result = await isExecutableAvailable('C:\\no\\such\\binary.exe');
+    expect(result).toBe(false);
+  });
+
+  it('returns false for a nonexistent command on PATH', async () => {
+    const result = await isExecutableAvailable('no-such-executable-xyz-12345');
+    expect(result).toBe(false);
+  });
+
+  it('returns true for node (commonly available on PATH)', async () => {
+    const result = await isExecutableAvailable('node');
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a cross-platform LSP command resolver that avoids shell interpolation
- Add command/args/env settings while preserving deprecated path aliases
- Update LSPManager startup/restart flow and tests for safe command handling

Closes #97

## Validation
- npm run compile
- npm run typecheck
- npm run test:unit -- LSPManager
- npm run test:unit -- commandResolver
- npm run ci:pr
