### PR TITLE
refactor(language-features): gate local providers by mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,6 +459,16 @@
     "configuration": {
       "title": "OpenQC",
       "properties": {
+        "openqc.languageFeatures.mode": {
+          "type": "string",
+          "enum": [
+            "lsp",
+            "local",
+            "hybrid"
+          ],
+          "default": "lsp",
+          "description": "Controls ownership of OpenQC language features. 'lsp' uses external language servers only, 'local' uses built-in parser providers without auto-starting LSP, and 'hybrid' keeps LSP ownership while avoiding duplicate local diagnostics."
+        },
         "openqc.lsp.cp2k.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { createParser } from './parsers';
 import { registerFormatConversionCommands } from './commands/formatConversionCommands';
 import { renderResultsWebviewHtml } from './webviews/resultsWebview';
 import { Logger, LogLevel } from './utils/Logger';
+import { getLanguageFeaturePolicy, readLanguageFeatureMode } from './languageFeatures';
 
 let lspManager: LSPManager;
 let structureViewer: StructureViewer;
@@ -45,6 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   logger.info('OpenQC-VSCode extension activated');
+  const languageFeaturePolicy = getLanguageFeaturePolicy(readLanguageFeatureMode());
 
   // Set sidebar enabled context
   vscode.commands.executeCommand('setContext', 'openqc.sidebar.enabled', true);
@@ -72,10 +74,6 @@ export function activate(context: vscode.ExtensionContext) {
   // Set converter enabled context
   vscode.commands.executeCommand('setContext', 'openqc.converterEnabled', true);
 
-  // Initialize LSP providers
-  completionProvider = new CompletionProvider();
-  hoverProvider = new HoverProvider();
-  definitionProvider = new DefinitionProvider();
   diagnosticsProvider = new DiagnosticsProvider();
 
   registerFormatConversionCommands(context);
@@ -84,37 +82,51 @@ export function activate(context: vscode.ExtensionContext) {
   const languageIds = ['cp2k', 'vasp', 'gaussian', 'orca', 'qe', 'gamess', 'nwchem'];
 
   // Register language providers
-  const disposables = [
-    // Completion provider
-    vscode.languages.registerCompletionItemProvider(
-      languageIds,
-      completionProvider,
-      '=',
-      ' ',
-      '\n'
-    ),
+  const disposables: vscode.Disposable[] = [];
 
-    // Hover provider
-    vscode.languages.registerHoverProvider(languageIds, hoverProvider),
+  if (languageFeaturePolicy.registerLocalProviders) {
+    completionProvider = new CompletionProvider();
+    hoverProvider = new HoverProvider();
+    definitionProvider = new DefinitionProvider();
 
-    // Definition provider
-    vscode.languages.registerDefinitionProvider(languageIds, definitionProvider),
+    disposables.push(
+      // Completion provider
+      vscode.languages.registerCompletionItemProvider(
+        languageIds,
+        completionProvider,
+        '=',
+        ' ',
+        '\n'
+      ),
 
-    // Validation on document change
-    vscode.workspace.onDidChangeTextDocument(event => {
-      diagnosticsProvider.validateDocument(event.document);
-    }),
+      // Hover provider
+      vscode.languages.registerHoverProvider(languageIds, hoverProvider),
 
-    // Validation on document save
-    vscode.workspace.onDidSaveTextDocument(document => {
-      diagnosticsProvider.validateDocument(document);
-    }),
+      // Definition provider
+      vscode.languages.registerDefinitionProvider(languageIds, definitionProvider)
+    );
+  }
 
-    // Clear diagnostics on document close
-    vscode.workspace.onDidCloseTextDocument(document => {
-      diagnosticsProvider.clearDiagnostics(document);
-    }),
+  if (languageFeaturePolicy.registerLocalDiagnostics) {
+    disposables.push(
+      // Validation on document change
+      vscode.workspace.onDidChangeTextDocument(event => {
+        diagnosticsProvider.validateDocument(event.document);
+      }),
 
+      // Validation on document save
+      vscode.workspace.onDidSaveTextDocument(document => {
+        diagnosticsProvider.validateDocument(document);
+      }),
+
+      // Clear diagnostics on document close
+      vscode.workspace.onDidCloseTextDocument(document => {
+        diagnosticsProvider.clearDiagnostics(document);
+      })
+    );
+  }
+
+  disposables.push(
     // Visualization commands
     vscode.commands.registerCommand('openqc.visualizeStructure', async () => {
       const editor = vscode.window.activeTextEditor;
@@ -188,7 +200,11 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('openqc.validate', async () => {
       const editor = vscode.window.activeTextEditor;
       if (editor) {
-        await diagnosticsProvider.validateDocument(editor.document);
+        if (languageFeaturePolicy.validateWithLocalDiagnostics) {
+          await diagnosticsProvider.validateDocument(editor.document);
+        } else {
+          await lspManager.startLSPForDocument(editor.document);
+        }
         vscode.window.showInformationMessage('Input file validated');
       }
     }),
@@ -336,9 +352,13 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Auto-start LSP on document open
     vscode.workspace.onDidOpenTextDocument(async document => {
-      await lspManager.startLSPForDocument(document);
-      // Also validate the document
-      if (fileTypeDetector.detectSoftware(document)) {
+      if (languageFeaturePolicy.autoStartLsp) {
+        await lspManager.startLSPForDocument(document);
+      }
+      if (
+        languageFeaturePolicy.validateWithLocalDiagnostics &&
+        fileTypeDetector.detectSoftware(document)
+      ) {
         await diagnosticsProvider.validateDocument(document);
       }
     }),
@@ -346,9 +366,11 @@ export function activate(context: vscode.ExtensionContext) {
     // Clean up LSP on document close
     vscode.workspace.onDidCloseTextDocument(async document => {
       await lspManager.stopLSPForDocument(document);
-      diagnosticsProvider.clearDiagnostics(document);
-    }),
-  ];
+      if (languageFeaturePolicy.registerLocalDiagnostics) {
+        diagnosticsProvider.clearDiagnostics(document);
+      }
+    })
+  );
 
   // Register ASE commands
   registerMigrationCommands(context);

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+
+export const LANGUAGE_FEATURE_MODES = ['lsp', 'local', 'hybrid'] as const;
+
+export type LanguageFeatureMode = (typeof LANGUAGE_FEATURE_MODES)[number];
+
+export interface LanguageFeaturePolicy {
+  mode: LanguageFeatureMode;
+  autoStartLsp: boolean;
+  registerLocalProviders: boolean;
+  registerLocalDiagnostics: boolean;
+  validateWithLocalDiagnostics: boolean;
+}
+
+const DEFAULT_LANGUAGE_FEATURE_MODE: LanguageFeatureMode = 'lsp';
+
+export function isLanguageFeatureMode(value: unknown): value is LanguageFeatureMode {
+  return typeof value === 'string' && (LANGUAGE_FEATURE_MODES as readonly string[]).includes(value);
+}
+
+export function normalizeLanguageFeatureMode(value: unknown): LanguageFeatureMode {
+  return isLanguageFeatureMode(value) ? value : DEFAULT_LANGUAGE_FEATURE_MODE;
+}
+
+export function readLanguageFeatureMode(): LanguageFeatureMode {
+  const config = vscode.workspace.getConfiguration('openqc.languageFeatures');
+  return normalizeLanguageFeatureMode(config.get<unknown>('mode', DEFAULT_LANGUAGE_FEATURE_MODE));
+}
+
+export function getLanguageFeaturePolicy(mode: LanguageFeatureMode): LanguageFeaturePolicy {
+  if (mode === 'local') {
+    return {
+      mode,
+      autoStartLsp: false,
+      registerLocalProviders: true,
+      registerLocalDiagnostics: true,
+      validateWithLocalDiagnostics: true,
+    };
+  }
+
+  return {
+    mode,
+    autoStartLsp: true,
+    registerLocalProviders: false,
+    registerLocalDiagnostics: false,
+    validateWithLocalDiagnostics: false,
+  };
+}

--- a/tests/unit/languageFeatures.test.ts
+++ b/tests/unit/languageFeatures.test.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+import {
+  getLanguageFeaturePolicy,
+  normalizeLanguageFeatureMode,
+  readLanguageFeatureMode,
+} from '../../src/languageFeatures';
+
+describe('language feature mode', () => {
+  it('normalizes supported modes', () => {
+    expect(normalizeLanguageFeatureMode('lsp')).toBe('lsp');
+    expect(normalizeLanguageFeatureMode('local')).toBe('local');
+    expect(normalizeLanguageFeatureMode('hybrid')).toBe('hybrid');
+  });
+
+  it('falls back to lsp for invalid or missing modes', () => {
+    expect(normalizeLanguageFeatureMode('invalid')).toBe('lsp');
+    expect(normalizeLanguageFeatureMode(undefined)).toBe('lsp');
+    expect(normalizeLanguageFeatureMode(42)).toBe('lsp');
+  });
+
+  it('reads openqc.languageFeatures.mode from VS Code configuration', () => {
+    const get = jest.fn().mockReturnValue('local');
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({ get });
+
+    expect(readLanguageFeatureMode()).toBe('local');
+    expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith('openqc.languageFeatures');
+    expect(get).toHaveBeenCalledWith('mode', 'lsp');
+  });
+
+  it('defaults configuration reads to lsp when the configured value is invalid', () => {
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+      get: jest.fn().mockReturnValue('always-local'),
+    });
+
+    expect(readLanguageFeatureMode()).toBe('lsp');
+  });
+});
+
+describe('language feature registration policy', () => {
+  it('makes LSP the default owner in lsp mode', () => {
+    expect(getLanguageFeaturePolicy('lsp')).toEqual({
+      mode: 'lsp',
+      autoStartLsp: true,
+      registerLocalProviders: false,
+      registerLocalDiagnostics: false,
+      validateWithLocalDiagnostics: false,
+    });
+  });
+
+  it('preserves local provider behavior in local mode without LSP auto-start', () => {
+    expect(getLanguageFeaturePolicy('local')).toEqual({
+      mode: 'local',
+      autoStartLsp: false,
+      registerLocalProviders: true,
+      registerLocalDiagnostics: true,
+      validateWithLocalDiagnostics: true,
+    });
+  });
+
+  it('keeps hybrid conservative to avoid duplicate diagnostics and providers', () => {
+    expect(getLanguageFeaturePolicy('hybrid')).toEqual({
+      mode: 'hybrid',
+      autoStartLsp: true,
+      registerLocalProviders: false,
+      registerLocalDiagnostics: false,
+      validateWithLocalDiagnostics: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add openqc.languageFeatures.mode with lsp/local/hybrid options
- Make LSP the default owner of language features and gate local providers/diagnostics by mode
- Add focused tests for mode normalization and registration policy

Closes #98

## Validation
- npm ci
- npm run compile
- npm run typecheck
- npm run test:unit -- extension
- npm run ci:pr
