### PR TITLE
fix(remote): describe workspace-side LSP startup context

### DIFF
--- a/docs/REMOTE_LSP_SMOKE_TEST.md
+++ b/docs/REMOTE_LSP_SMOKE_TEST.md
@@ -1,0 +1,52 @@
+# Remote LSP Smoke Test
+
+Use this checklist after packaging or installing the OpenQC extension locally. The extension is configured with `extensionKind: ["workspace", "ui"]`, so LSP processes prefer the workspace extension host. In Remote SSH, WSL, Dev Containers, and Codespaces, `openqc.lsp.<language>.command` and deprecated `openqc.lsp.<language>.path` resolve in the workspace-side environment, not on the local desktop.
+
+## Local
+
+1. Open the repository in a local VS Code window.
+2. Install one language server on the local machine or set `openqc.lsp.gaussian.command` to a known local executable.
+3. Open `tests/fixtures/gaussian/water_optimization.com`.
+4. Run `OpenQC: Start Language Server`.
+5. Check the OpenQC output channel for `local extension host` and the resolved command.
+6. If startup fails, confirm the error names the local extension host and the `openqc.lsp.gaussian.command` setting.
+
+## Remote SSH
+
+1. Connect with the VS Code Remote SSH extension.
+2. Open a workspace folder on the SSH host.
+3. Install the selected language server on the SSH host or set `openqc.lsp.<language>.command` to a path that exists on the SSH host.
+4. Open a matching OpenQC fixture from the remote workspace.
+5. Run `OpenQC: Start Language Server`.
+6. Check the OpenQC output channel for `remote extension host (Remote SSH)` and confirm the command is the remote host command.
+7. Temporarily set the command to a missing executable and confirm the startup error says commands and paths resolve in the remote workspace environment.
+
+## WSL
+
+1. Open the repository through `WSL: Open Folder in WSL`.
+2. Install the selected language server inside the WSL distribution or configure `openqc.lsp.<language>.command` to a WSL path.
+3. Open a matching fixture and start the LSP.
+4. Check the output channel for `remote extension host (WSL)`.
+5. Confirm missing executable errors refer to the WSL workspace-side environment.
+
+## Dev Containers
+
+1. Reopen the repository in a dev container.
+2. Install the selected language server in the container image or set `openqc.lsp.<language>.command` to a container path.
+3. Open a matching fixture and start the LSP.
+4. Check the output channel for `remote extension host (Dev Container)`.
+5. Confirm missing executable errors refer to the container workspace-side environment.
+
+## Codespaces
+
+1. Open the repository in GitHub Codespaces.
+2. Install the selected language server in the Codespace or configure `openqc.lsp.<language>.command` to a Codespace path.
+3. Open a matching fixture and start the LSP.
+4. Check the output channel for `remote extension host (Codespaces)`.
+5. Confirm missing executable errors refer to the Codespace workspace-side environment.
+
+## Webview Resource Audit
+
+- `MoleculeViewerWebview`, `DataPlotter`, and `StructureViewer` load bundled JavaScript through `webview.asWebviewUri(...)` with `localResourceRoots` scoped to extension resources.
+- Inline setup, AI, sidebar, and results webviews do not load local extension files.
+- Extension persistence uses VS Code `workspaceState` or `globalState`; no browser `localStorage` or `sessionStorage` use was found.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     "onView:openqc-sidebar"
   ],
   "main": "./out/extension.js",
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
   "contributes": {
     "languages": [
       {
@@ -477,13 +481,13 @@
         "openqc.lsp.cp2k.path": {
           "type": "string",
           "default": "cp2k-language-server",
-          "description": "Path to CP2K Language Server executable (deprecated: use command instead)",
+          "description": "Path to CP2K Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.cp2k.command instead."
         },
         "openqc.lsp.cp2k.command": {
           "type": "string",
           "default": "cp2k-language-server",
-          "description": "Command to start the CP2K Language Server (executable name or absolute path)"
+          "description": "Command to start the CP2K Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.cp2k.args": {
           "type": "array",
@@ -511,13 +515,13 @@
         "openqc.lsp.vasp.path": {
           "type": "string",
           "default": "vasp-lsp",
-          "description": "Path to VASP Language Server executable (deprecated: use command instead)",
+          "description": "Path to VASP Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.vasp.command instead."
         },
         "openqc.lsp.vasp.command": {
           "type": "string",
           "default": "vasp-lsp",
-          "description": "Command to start the VASP Language Server (executable name or absolute path)"
+          "description": "Command to start the VASP Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.vasp.args": {
           "type": "array",
@@ -545,13 +549,13 @@
         "openqc.lsp.gaussian.path": {
           "type": "string",
           "default": "gaussian-lsp",
-          "description": "Path to Gaussian Language Server executable (deprecated: use command instead)",
+          "description": "Path to Gaussian Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.gaussian.command instead."
         },
         "openqc.lsp.gaussian.command": {
           "type": "string",
           "default": "gaussian-lsp",
-          "description": "Command to start the Gaussian Language Server (executable name or absolute path)"
+          "description": "Command to start the Gaussian Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.gaussian.args": {
           "type": "array",
@@ -579,13 +583,13 @@
         "openqc.lsp.orca.path": {
           "type": "string",
           "default": "orca-lsp",
-          "description": "Path to ORCA Language Server executable (deprecated: use command instead)",
+          "description": "Path to ORCA Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.orca.command instead."
         },
         "openqc.lsp.orca.command": {
           "type": "string",
           "default": "orca-lsp",
-          "description": "Command to start the ORCA Language Server (executable name or absolute path)"
+          "description": "Command to start the ORCA Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.orca.args": {
           "type": "array",
@@ -613,13 +617,13 @@
         "openqc.lsp.qe.path": {
           "type": "string",
           "default": "qe-lsp",
-          "description": "Path to Quantum ESPRESSO Language Server executable (deprecated: use command instead)",
+          "description": "Path to Quantum ESPRESSO Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.qe.command instead."
         },
         "openqc.lsp.qe.command": {
           "type": "string",
           "default": "qe-lsp",
-          "description": "Command to start the Quantum ESPRESSO Language Server (executable name or absolute path)"
+          "description": "Command to start the Quantum ESPRESSO Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.qe.args": {
           "type": "array",
@@ -647,13 +651,13 @@
         "openqc.lsp.gamess.path": {
           "type": "string",
           "default": "gamess-lsp",
-          "description": "Path to GAMESS Language Server executable (deprecated: use command instead)",
+          "description": "Path to GAMESS Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.gamess.command instead."
         },
         "openqc.lsp.gamess.command": {
           "type": "string",
           "default": "gamess-lsp",
-          "description": "Command to start the GAMESS Language Server (executable name or absolute path)"
+          "description": "Command to start the GAMESS Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.gamess.args": {
           "type": "array",
@@ -681,13 +685,13 @@
         "openqc.lsp.nwchem.path": {
           "type": "string",
           "default": "nwchem-lsp",
-          "description": "Path to NWChem Language Server executable (deprecated: use command instead)",
+          "description": "Path to NWChem Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side.",
           "deprecationMessage": "Use openqc.lsp.nwchem.command instead."
         },
         "openqc.lsp.nwchem.command": {
           "type": "string",
           "default": "nwchem-lsp",
-          "description": "Command to start the NWChem Language Server (executable name or absolute path)"
+          "description": "Command to start the NWChem Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, and Codespaces, this resolves on the workspace side."
         },
         "openqc.lsp.nwchem.args": {
           "type": "array",

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -16,6 +16,10 @@ import {
   ResolvedLspCommand,
 } from '../lsp/commandResolver';
 import { LSPServerRegistryEntry } from '../lsp/types';
+import {
+  describeExtensionHostContext,
+  getExtensionHostContext,
+} from '../utils/extensionHostContext';
 
 interface LSPServerConfig {
   name: string;
@@ -129,6 +133,7 @@ export class LSPManager {
     identity: LSPClientIdentity,
     documentKey: string
   ): Promise<void> {
+    const hostContextDescription = describeExtensionHostContext();
     try {
       const client = await this.createLanguageClient(software, serverConfig, document, identity);
       if (client) {
@@ -138,12 +143,13 @@ export class LSPManager {
           documents: new Set([documentKey]),
           languageId: serverConfig.definition.languageId,
         });
-        this.logger.info(`${software} Language Server started`);
+        this.logger.info(`${software} Language Server started in ${hostContextDescription}`);
         vscode.window.showInformationMessage(`${software} Language Server started`);
       }
     } catch (error) {
-      this.logger.error(`Failed to start ${software} Language Server`, error as Error);
-      vscode.window.showErrorMessage(`Failed to start ${software} Language Server: ${error}`);
+      const message = `Failed to start ${software} Language Server in ${hostContextDescription}: ${error}`;
+      this.logger.error(message, error as Error);
+      vscode.window.showErrorMessage(message);
       // Clean up the client if it was added
       this.clients.delete(identity.key);
     }
@@ -214,16 +220,29 @@ export class LSPManager {
   ): Promise<LanguageClient | undefined> {
     try {
       const resolved = config.resolvedCommand;
+      const hostContext = getExtensionHostContext();
+      const hostContextDescription = describeExtensionHostContext(hostContext);
+      const commandSummary =
+        resolved.kind === 'pythonModule'
+          ? `${resolved.python} -m ${resolved.module}`
+          : resolved.command;
 
       // Verify the executable is available using a cross-platform check.
       // For pythonModule kind, check the python binary.
       const executableToCheck =
         resolved.kind === 'pythonModule' ? resolved.python : resolved.command;
 
+      this.logger.info(
+        `Starting ${software} Language Server with '${commandSummary}' in ${hostContextDescription}`
+      );
+
       const available = await isExecutableAvailable(executableToCheck);
       if (!available) {
+        const settingKey = `openqc.lsp.${config.definition.languageId}.command`;
         throw new Error(
-          `LSP executable '${executableToCheck}' not found. Please install ${software} LSP server.`
+          `LSP executable '${executableToCheck}' not found in ${hostContext.label}. ` +
+            `Install ${software} LSP server or update ${settingKey} for that environment. ` +
+            hostContext.commandResolution
         );
       }
 

--- a/src/utils/extensionHostContext.ts
+++ b/src/utils/extensionHostContext.ts
@@ -1,0 +1,46 @@
+import * as vscode from 'vscode';
+
+export interface ExtensionHostContext {
+  isRemote: boolean;
+  remoteName: string | undefined;
+  label: string;
+  commandResolution: string;
+}
+
+const REMOTE_LABELS: Record<string, string> = {
+  'ssh-remote': 'Remote SSH',
+  wsl: 'WSL',
+  'dev-container': 'Dev Container',
+  'attached-container': 'Dev Container',
+  codespaces: 'Codespaces',
+};
+
+export function getExtensionHostContext(
+  env: Pick<typeof vscode.env, 'remoteName'> = vscode.env
+): ExtensionHostContext {
+  const remoteName = env.remoteName;
+  if (!remoteName) {
+    return {
+      isRemote: false,
+      remoteName: undefined,
+      label: 'local extension host',
+      commandResolution: 'LSP commands and paths resolve on this machine.',
+    };
+  }
+
+  const remoteLabel = REMOTE_LABELS[remoteName] || remoteName;
+  return {
+    isRemote: true,
+    remoteName,
+    label: `remote extension host (${remoteLabel})`,
+    commandResolution: 'LSP commands and paths resolve in the remote workspace environment.',
+  };
+}
+
+export function describeExtensionHostContext(context = getExtensionHostContext()): string {
+  if (!context.isRemote) {
+    return `${context.label}; ${context.commandResolution}`;
+  }
+
+  return `${context.label}, remoteName=${context.remoteName}; ${context.commandResolution}`;
+}

--- a/tests/mocks/vscode.ts
+++ b/tests/mocks/vscode.ts
@@ -68,6 +68,10 @@ export const commands = {
   registerCommand: jest.fn(() => ({ dispose: jest.fn() })),
 };
 
+export const env = {
+  remoteName: undefined,
+};
+
 export const ViewColumn = {
   One: 1,
   Two: 2,
@@ -113,6 +117,7 @@ export default {
   window,
   workspace,
   commands,
+  env,
   ViewColumn,
   Uri,
   EventEmitter,

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -63,6 +63,9 @@ jest.mock('vscode', () => ({
     base,
     pattern,
   })),
+  env: {
+    remoteName: undefined,
+  },
 }));
 
 // Mock the command resolver's isExecutableAvailable to always succeed in tests
@@ -94,6 +97,7 @@ describe('LSPManager', () => {
     const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
     (isExecutableAvailable as jest.Mock).mockResolvedValue(true);
     const vscode = require('vscode');
+    vscode.env.remoteName = undefined;
     vscode.workspace.getWorkspaceFolder.mockReturnValue(undefined);
     mockDiscovery = {
       fetchLSPRepositories: jest.fn().mockResolvedValue(LSPDiscovery.getDefaultDefinitions()),
@@ -275,6 +279,25 @@ describe('LSPManager', () => {
       await lspManager.startLSPForDocument(mockDocument);
       expect(mockFunctions.showError).toHaveBeenCalledWith(
         expect.stringContaining('Failed to start')
+      );
+    });
+
+    it('should include remote host context in executable startup errors', async () => {
+      const vscode = require('vscode');
+      const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
+      vscode.env.remoteName = 'ssh-remote';
+      (isExecutableAvailable as jest.Mock).mockResolvedValueOnce(false);
+
+      await lspManager.startLSPForDocument(mockDocument);
+
+      expect(mockFunctions.showError).toHaveBeenCalledWith(
+        expect.stringContaining('remote extension host (Remote SSH)')
+      );
+      expect(mockFunctions.showError).toHaveBeenCalledWith(
+        expect.stringContaining('openqc.lsp.gaussian.command')
+      );
+      expect(mockFunctions.showError).toHaveBeenCalledWith(
+        expect.stringContaining('remote workspace environment')
       );
     });
 

--- a/tests/unit/utils/extensionHostContext.test.ts
+++ b/tests/unit/utils/extensionHostContext.test.ts
@@ -1,0 +1,40 @@
+import {
+  describeExtensionHostContext,
+  getExtensionHostContext,
+} from '../../../src/utils/extensionHostContext';
+
+jest.mock('vscode', () => ({
+  env: {
+    remoteName: undefined,
+  },
+}));
+
+describe('extensionHostContext', () => {
+  it('describes local extension host command resolution', () => {
+    const context = getExtensionHostContext({ remoteName: undefined });
+
+    expect(context).toEqual({
+      isRemote: false,
+      remoteName: undefined,
+      label: 'local extension host',
+      commandResolution: 'LSP commands and paths resolve on this machine.',
+    });
+    expect(describeExtensionHostContext(context)).toContain('local extension host');
+  });
+
+  it('labels common remote extension host names', () => {
+    const context = getExtensionHostContext({ remoteName: 'ssh-remote' });
+
+    expect(context.isRemote).toBe(true);
+    expect(context.remoteName).toBe('ssh-remote');
+    expect(context.label).toBe('remote extension host (Remote SSH)');
+    expect(describeExtensionHostContext(context)).toContain('remoteName=ssh-remote');
+    expect(describeExtensionHostContext(context)).toContain('remote workspace environment');
+  });
+
+  it('falls back to the raw remoteName for unknown remote hosts', () => {
+    const context = getExtensionHostContext({ remoteName: 'custom-remote' });
+
+    expect(context.label).toBe('remote extension host (custom-remote)');
+  });
+});


### PR DESCRIPTION
## Summary
- Set extensionKind for workspace-side LSP behavior with UI fallback
- Add local/remote extension-host context helpers and include that context in LSP startup logs/errors
- Document local and remote LSP smoke-test steps and remote command resolution

Closes #100

## Validation
- npm ci
- npm run compile
- npm run typecheck
- npm run ci:pr
