### PR TITLE
feat(lsp): add status bar and lifecycle log commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
     "onCommand:openqc.startLSP",
     "onCommand:openqc.stopLSP",
     "onCommand:openqc.restartLSP",
+    "onCommand:openqc.lsp.showStatus",
+    "onCommand:openqc.lsp.showLogs",
+    "onCommand:openqc.lsp.restartCurrent",
+    "onCommand:openqc.lsp.selectExecutable",
+    "onCommand:openqc.lsp.generateCompatibilityReport",
     "onCommand:openqc.visualizeStructure",
     "onCommand:openqc.plotData",
     "onCommand:openqc.validate",
@@ -223,6 +228,31 @@
         "command": "openqc.restartLSP",
         "title": "OpenQC: Restart Language Server",
         "icon": "$(debug-restart)"
+      },
+      {
+        "command": "openqc.lsp.showStatus",
+        "title": "OpenQC LSP: Show Status",
+        "icon": "$(pulse)"
+      },
+      {
+        "command": "openqc.lsp.showLogs",
+        "title": "OpenQC LSP: Show Logs",
+        "icon": "$(output)"
+      },
+      {
+        "command": "openqc.lsp.restartCurrent",
+        "title": "OpenQC LSP: Restart Current",
+        "icon": "$(debug-restart)"
+      },
+      {
+        "command": "openqc.lsp.selectExecutable",
+        "title": "OpenQC LSP: Select Executable",
+        "icon": "$(terminal)"
+      },
+      {
+        "command": "openqc.lsp.generateCompatibilityReport",
+        "title": "OpenQC LSP: Generate Compatibility Report",
+        "icon": "$(report)"
       },
       {
         "command": "openqc.validate",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,26 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
+    vscode.commands.registerCommand('openqc.lsp.showStatus', () => {
+      lspManager.showStatus();
+    }),
+
+    vscode.commands.registerCommand('openqc.lsp.showLogs', () => {
+      lspManager.showLogs();
+    }),
+
+    vscode.commands.registerCommand('openqc.lsp.restartCurrent', async () => {
+      await lspManager.restartCurrent();
+    }),
+
+    vscode.commands.registerCommand('openqc.lsp.selectExecutable', async () => {
+      await lspManager.selectExecutable();
+    }),
+
+    vscode.commands.registerCommand('openqc.lsp.generateCompatibilityReport', async () => {
+      await lspManager.generateCompatibilityReport();
+    }),
+
     // Validate current document
     vscode.commands.registerCommand('openqc.validate', async () => {
       const editor = vscode.window.activeTextEditor;

--- a/src/lsp/LspStatusService.ts
+++ b/src/lsp/LspStatusService.ts
@@ -1,0 +1,181 @@
+import * as vscode from 'vscode';
+
+export type LspLifecycleState = 'idle' | 'starting' | 'running' | 'stopped' | 'failed';
+
+export interface LspStatusSnapshot {
+  key: string;
+  state: LspLifecycleState;
+  software: string;
+  languageId: string;
+  workspaceLabel: string;
+  workspaceIdentity: string;
+  commandSummary: string;
+  hostContext: string;
+  message?: string;
+  updatedAt: Date;
+}
+
+export interface LspLifecycleDetails {
+  key: string;
+  software: string;
+  languageId: string;
+  workspaceLabel?: string;
+  workspaceIdentity: string;
+  commandSummary: string;
+  hostContext: string;
+  message?: string;
+}
+
+export class LspStatusService implements vscode.Disposable {
+  private readonly output: vscode.OutputChannel;
+  private readonly statusBarItem: vscode.StatusBarItem;
+  private readonly statuses = new Map<string, LspStatusSnapshot>();
+
+  constructor() {
+    this.output = vscode.window.createOutputChannel('OpenQC LSP');
+    this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 95);
+    this.statusBarItem.command = 'openqc.lsp.showStatus';
+    this.statusBarItem.name = 'OpenQC LSP Status';
+    this.setIdleStatus();
+  }
+
+  starting(details: LspLifecycleDetails): void {
+    this.record('starting', details, 'Starting');
+  }
+
+  running(details: LspLifecycleDetails): void {
+    this.record('running', details, 'Started');
+  }
+
+  stopped(details: LspLifecycleDetails): void {
+    this.record('stopped', details, 'Stopped');
+  }
+
+  failed(details: LspLifecycleDetails): void {
+    this.record('failed', details, 'Failed');
+  }
+
+  showLogs(): void {
+    this.output.show(true);
+  }
+
+  showStatus(): void {
+    this.output.appendLine(this.formatStatusReport());
+    this.output.show(true);
+  }
+
+  appendCompatibilityReport(report: string): void {
+    this.output.appendLine(report);
+    this.output.show(true);
+  }
+
+  getStatusReport(): string {
+    return this.formatStatusReport();
+  }
+
+  dispose(): void {
+    this.statusBarItem.dispose();
+    this.output.dispose();
+  }
+
+  private record(state: LspLifecycleState, details: LspLifecycleDetails, eventLabel: string): void {
+    const snapshot: LspStatusSnapshot = {
+      key: details.key,
+      state,
+      software: details.software,
+      languageId: details.languageId,
+      workspaceLabel: details.workspaceLabel || 'single file',
+      workspaceIdentity: details.workspaceIdentity,
+      commandSummary: details.commandSummary,
+      hostContext: details.hostContext,
+      message: details.message,
+      updatedAt: new Date(),
+    };
+
+    this.statuses.set(details.key, snapshot);
+    this.output.appendLine(this.formatLogLine(eventLabel, snapshot));
+    this.updateStatusBar();
+  }
+
+  private formatLogLine(eventLabel: string, snapshot: LspStatusSnapshot): string {
+    const message = snapshot.message ? ` message="${snapshot.message}"` : '';
+    return (
+      `[${snapshot.updatedAt.toISOString()}] ${eventLabel} ${snapshot.software} LSP` +
+      ` state=${snapshot.state}` +
+      ` languageId=${snapshot.languageId}` +
+      ` workspace="${snapshot.workspaceLabel}"` +
+      ` identity="${snapshot.workspaceIdentity}"` +
+      ` command="${snapshot.commandSummary}"` +
+      ` context="${snapshot.hostContext}"` +
+      message
+    );
+  }
+
+  private formatStatusReport(): string {
+    const snapshots = Array.from(this.statuses.values()).sort((a, b) => a.key.localeCompare(b.key));
+
+    if (snapshots.length === 0) {
+      return 'OpenQC LSP status: no language servers have been started in this session.';
+    }
+
+    const lines = ['OpenQC LSP status:'];
+    for (const snapshot of snapshots) {
+      lines.push(
+        [
+          `- ${snapshot.software} (${snapshot.languageId})`,
+          `state=${snapshot.state}`,
+          `workspace=${snapshot.workspaceLabel}`,
+          `identity=${snapshot.workspaceIdentity}`,
+          `command=${snapshot.commandSummary}`,
+          `context=${snapshot.hostContext}`,
+          `updated=${snapshot.updatedAt.toISOString()}`,
+          snapshot.message ? `message=${snapshot.message}` : undefined,
+        ]
+          .filter(Boolean)
+          .join('; ')
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  private updateStatusBar(): void {
+    const snapshots = Array.from(this.statuses.values());
+    const active =
+      snapshots.find(snapshot => snapshot.state === 'starting') ||
+      snapshots.find(snapshot => snapshot.state === 'failed') ||
+      snapshots.find(snapshot => snapshot.state === 'running') ||
+      snapshots[0];
+
+    if (!active) {
+      this.setIdleStatus();
+      return;
+    }
+
+    const icon = this.getIcon(active.state);
+    this.statusBarItem.text = `${icon} OpenQC LSP: ${active.software} ${active.state}`;
+    this.statusBarItem.tooltip = this.formatStatusReport();
+    this.statusBarItem.show();
+  }
+
+  private setIdleStatus(): void {
+    this.statusBarItem.text = '$(circle-outline) OpenQC LSP: Idle';
+    this.statusBarItem.tooltip = 'OpenQC LSP status: no active language servers.';
+    this.statusBarItem.show();
+  }
+
+  private getIcon(state: LspLifecycleState): string {
+    switch (state) {
+      case 'starting':
+        return '$(sync~spin)';
+      case 'running':
+        return '$(check)';
+      case 'failed':
+        return '$(error)';
+      case 'stopped':
+        return '$(debug-stop)';
+      default:
+        return '$(circle-outline)';
+    }
+  }
+}

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -20,6 +20,7 @@ import {
   describeExtensionHostContext,
   getExtensionHostContext,
 } from '../utils/extensionHostContext';
+import { LspLifecycleDetails, LspStatusService } from '../lsp/LspStatusService';
 
 interface LSPServerConfig {
   name: string;
@@ -38,6 +39,7 @@ interface LSPClientRecord {
   client: LanguageClient;
   documents: Set<string>;
   languageId: string;
+  lifecycleDetails: LspLifecycleDetails;
 }
 
 export class LSPManager {
@@ -48,11 +50,17 @@ export class LSPManager {
   private discovery: LSPDiscovery;
   private serverDefinitions: LSPServerDefinition[] = LSPManager.bundledDefinitions();
   private logger = createComponentLogger('LSPManager');
+  private statusService: LspStatusService;
 
-  constructor(context?: vscode.ExtensionContext, discovery?: LSPDiscovery) {
+  constructor(
+    context?: vscode.ExtensionContext,
+    discovery?: LSPDiscovery,
+    statusService?: LspStatusService
+  ) {
     this.fileTypeDetector = new FileTypeDetector();
     this.config = vscode.workspace.getConfiguration('openqc.lsp');
     this.discovery = discovery || new LSPDiscovery(context);
+    this.statusService = statusService || new LspStatusService();
   }
 
   /**
@@ -134,6 +142,14 @@ export class LSPManager {
     documentKey: string
   ): Promise<void> {
     const hostContextDescription = describeExtensionHostContext();
+    const lifecycleDetails = this.createLifecycleDetails(
+      software,
+      serverConfig,
+      identity,
+      hostContextDescription
+    );
+    this.statusService.starting(lifecycleDetails);
+
     try {
       const client = await this.createLanguageClient(software, serverConfig, document, identity);
       if (client) {
@@ -142,13 +158,15 @@ export class LSPManager {
           client,
           documents: new Set([documentKey]),
           languageId: serverConfig.definition.languageId,
+          lifecycleDetails,
         });
         this.logger.info(`${software} Language Server started in ${hostContextDescription}`);
-        vscode.window.showInformationMessage(`${software} Language Server started`);
+        this.statusService.running(lifecycleDetails);
       }
     } catch (error) {
       const message = `Failed to start ${software} Language Server in ${hostContextDescription}: ${error}`;
       this.logger.error(message, error as Error);
+      this.statusService.failed({ ...lifecycleDetails, message: String(error) });
       vscode.window.showErrorMessage(message);
       // Clean up the client if it was added
       this.clients.delete(identity.key);
@@ -222,10 +240,7 @@ export class LSPManager {
       const resolved = config.resolvedCommand;
       const hostContext = getExtensionHostContext();
       const hostContextDescription = describeExtensionHostContext(hostContext);
-      const commandSummary =
-        resolved.kind === 'pythonModule'
-          ? `${resolved.python} -m ${resolved.module}`
-          : resolved.command;
+      const commandSummary = this.summarizeResolvedCommand(resolved);
 
       // Verify the executable is available using a cross-platform check.
       // For pythonModule kind, check the python binary.
@@ -412,6 +427,7 @@ export class LSPManager {
       }
     } finally {
       this.clients.delete(clientKey);
+      this.statusService.stopped(record.lifecycleDetails);
     }
   }
 
@@ -440,6 +456,105 @@ export class LSPManager {
     }
   }
 
+  showStatus(): void {
+    this.statusService.showStatus();
+  }
+
+  showLogs(): void {
+    this.statusService.showLogs();
+  }
+
+  async restartCurrent(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showWarningMessage('No active text editor for OpenQC LSP restart');
+      return;
+    }
+
+    await this.restartLSPForDocument(editor.document);
+  }
+
+  async selectExecutable(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showWarningMessage('No active text editor for OpenQC LSP executable selection');
+      return;
+    }
+
+    const software = this.fileTypeDetector.detectSoftware(editor.document);
+    if (!software) {
+      vscode.window.showWarningMessage('Could not detect quantum chemistry software for this file');
+      return;
+    }
+
+    const serverConfig = await this.getServerConfig(software);
+    if (!serverConfig) {
+      vscode.window.showWarningMessage(`No bundled OpenQC LSP definition found for ${software}`);
+      return;
+    }
+
+    const languageId = serverConfig.definition.languageId;
+    const currentCommand =
+      serverConfig.resolvedCommand.kind === 'pythonModule'
+        ? serverConfig.resolvedCommand.python
+        : serverConfig.resolvedCommand.command;
+    const selectedCommand = await vscode.window.showInputBox({
+      prompt: `Executable command or absolute path for ${software} Language Server`,
+      value: currentCommand,
+      ignoreFocusOut: true,
+    });
+
+    if (!selectedCommand || selectedCommand.trim() === currentCommand) {
+      return;
+    }
+
+    await vscode.workspace
+      .getConfiguration()
+      .update(
+        `openqc.lsp.${languageId}.command`,
+        selectedCommand.trim(),
+        vscode.ConfigurationTarget.Workspace
+      );
+    const message = `Updated openqc.lsp.${languageId}.command to ${selectedCommand.trim()}`;
+    this.logger.info(message);
+    vscode.window.showInformationMessage(message);
+  }
+
+  async generateCompatibilityReport(): Promise<string> {
+    await this.refreshDiscoveredDefinitions();
+    const hostContextDescription = describeExtensionHostContext();
+    const lines = [
+      '# OpenQC LSP Compatibility Report',
+      '',
+      `Generated: ${new Date().toISOString()}`,
+      `Extension host: ${hostContextDescription}`,
+      '',
+      '## Bundled Language Servers',
+      '',
+    ];
+
+    for (const definition of this.serverDefinitions) {
+      const serverConfig = await this.getServerConfig(definition.name as QuantumChemistrySoftware);
+      if (!serverConfig) {
+        continue;
+      }
+
+      lines.push(
+        `- ${definition.name} (${definition.languageId})`,
+        `  - Enabled: ${serverConfig.enabled}`,
+        `  - Command: ${this.summarizeResolvedCommand(serverConfig.resolvedCommand)}`,
+        `  - Extensions: ${definition.fileExtensions.join(', ') || 'none'}`,
+        `  - Filenames: ${(definition.fileNames || []).join(', ') || 'none'}`
+      );
+    }
+
+    lines.push('', '## Current Session', '', this.statusService.getStatusReport());
+
+    const report = lines.join('\n');
+    this.statusService.appendCompatibilityReport(report);
+    return report;
+  }
+
   /**
    * Stop all managed LSP clients and clear their records.
    */
@@ -456,5 +571,31 @@ export class LSPManager {
     });
 
     await Promise.all(stopPromises);
+    this.statusService.dispose();
+  }
+
+  private createLifecycleDetails(
+    software: QuantumChemistrySoftware,
+    config: LSPServerConfig,
+    identity: LSPClientIdentity,
+    hostContextDescription: string
+  ): LspLifecycleDetails {
+    return {
+      key: identity.key,
+      software,
+      languageId: config.definition.languageId,
+      workspaceLabel: identity.label || 'single file',
+      workspaceIdentity: identity.key,
+      commandSummary: this.summarizeResolvedCommand(config.resolvedCommand),
+      hostContext: hostContextDescription,
+    };
+  }
+
+  private summarizeResolvedCommand(resolved: ResolvedLspCommand): string {
+    if (resolved.kind === 'pythonModule') {
+      return [resolved.python, '-m', resolved.module, ...resolved.args].join(' ');
+    }
+
+    return [resolved.command, ...resolved.args].join(' ');
   }
 }

--- a/tests/unit/LSPManager.test.ts
+++ b/tests/unit/LSPManager.test.ts
@@ -8,11 +8,25 @@ const mockFunctions: {
   showWarning: jest.Mock;
   showError: jest.Mock;
   languageClient: jest.Mock;
+  statusBarItem: {
+    show: jest.Mock;
+    hide: jest.Mock;
+    dispose: jest.Mock;
+    text?: string;
+    tooltip?: string;
+    command?: string;
+    name?: string;
+  };
 } = {
   showInfo: jest.fn(),
   showWarning: jest.fn(),
   showError: jest.fn(),
   languageClient: jest.fn(),
+  statusBarItem: {
+    show: jest.fn(),
+    hide: jest.fn(),
+    dispose: jest.fn(),
+  },
 };
 
 // Mock vscode module
@@ -29,7 +43,10 @@ jest.mock('vscode', () => ({
       hide: jest.fn(),
       dispose: jest.fn(),
     })),
+    createStatusBarItem: jest.fn(() => mockFunctions.statusBarItem),
   },
+  StatusBarAlignment: { Left: 1, Right: 2 },
+  ConfigurationTarget: { Workspace: 1 },
   workspace: {
     getConfiguration: jest.fn(() => ({
       get: jest.fn((key: string, defaultValue?: any) => {
@@ -92,6 +109,10 @@ describe('LSPManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFunctions.statusBarItem.text = undefined;
+    mockFunctions.statusBarItem.tooltip = undefined;
+    mockFunctions.statusBarItem.command = undefined;
+    mockFunctions.statusBarItem.name = undefined;
     Logger.resetInstance();
     // Reset the isExecutableAvailable mock to default (true)
     const { isExecutableAvailable } = require('../../src/lsp/commandResolver');
@@ -127,9 +148,17 @@ describe('LSPManager', () => {
       await lspManager.startLSPForDocument(mockDocument);
       // Bundled registry is used instead of GitHub discovery during normal flows
       expect(mockDiscovery.fetchLSPRepositories).not.toHaveBeenCalled();
-      expect(mockFunctions.showInfo).toHaveBeenCalledWith(
+      expect(mockFunctions.showInfo).not.toHaveBeenCalled();
+      expect(mockFunctions.statusBarItem.text).toBe('$(check) OpenQC LSP: Gaussian running');
+    });
+
+    it('should not show automatic success popups after LSP startup', async () => {
+      await lspManager.startLSPForDocument(mockDocument);
+
+      expect(mockFunctions.showInfo).not.toHaveBeenCalledWith(
         expect.stringContaining('Language Server started')
       );
+      expect(mockFunctions.showError).not.toHaveBeenCalled();
     });
 
     it('should use cross-platform command resolution for executable checks', async () => {
@@ -527,7 +556,7 @@ describe('LSPManager', () => {
       await lspManager.restartLSPForDocument(mockDocument);
       expect(mockStop).toHaveBeenCalled();
       expect(mockStart).toHaveBeenCalledTimes(2); // Once for initial start, once for restart
-      expect(mockFunctions.showInfo).toHaveBeenCalledWith(
+      expect(mockFunctions.showInfo).not.toHaveBeenCalledWith(
         expect.stringContaining('Language Server started')
       );
     });


### PR DESCRIPTION
## Summary
- Add OpenQC LSP output channel and status bar lifecycle service
- Register LSP status/log/restart/executable/report commands
- Replace automatic LSP startup success popups with status/log updates while keeping actionable failures

Closes #101

## Validation
- npm ci
- npm run compile
- npm run typecheck
- npm run test:unit -- LSPManager
- npm run ci:pr
