### PR TITLE
test(lsp): add fake stdio language client integration

### DIFF
--- a/tests/fixtures/fake-lsp-server.js
+++ b/tests/fixtures/fake-lsp-server.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+let buffer = Buffer.alloc(0);
+let nextVersion = 0;
+const documents = new Map();
+const eventsPath = process.env.FAKE_LSP_EVENTS_PATH;
+
+function logEvent(event) {
+  if (!eventsPath) {
+    return;
+  }
+
+  fs.appendFileSync(
+    eventsPath,
+    `${JSON.stringify({ ...event, sequence: ++nextVersion })}\n`,
+    'utf8'
+  );
+}
+
+function writeMessage(message) {
+  const body = JSON.stringify(message);
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`);
+}
+
+function sendResponse(id, result) {
+  writeMessage({ jsonrpc: '2.0', id, result });
+}
+
+function sendNotification(method, params) {
+  writeMessage({ jsonrpc: '2.0', method, params });
+}
+
+function textHasProblem(text) {
+  return text.toLowerCase().includes('problem');
+}
+
+function publishDiagnostics(uri) {
+  const text = documents.get(uri) || '';
+  const diagnostics = textHasProblem(text)
+    ? [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 7 },
+          },
+          severity: 2,
+          source: 'fake-lsp',
+          message: 'Fake diagnostic for problem marker',
+        },
+      ]
+    : [];
+
+  sendNotification('textDocument/publishDiagnostics', { uri, diagnostics });
+  logEvent({ method: 'textDocument/publishDiagnostics', uri, diagnosticCount: diagnostics.length });
+}
+
+function handleMessage(message) {
+  const { id, method, params } = message;
+  logEvent({ method, id });
+
+  if (method === 'initialize') {
+    sendResponse(id, {
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: 1,
+        },
+        completionProvider: {
+          triggerCharacters: ['#'],
+        },
+      },
+    });
+    return;
+  }
+
+  if (method === 'initialized') {
+    return;
+  }
+
+  if (method === 'textDocument/didOpen') {
+    const document = params.textDocument;
+    documents.set(document.uri, document.text);
+    logEvent({
+      method: 'fake/documentState',
+      uri: document.uri,
+      text: document.text,
+      version: document.version,
+    });
+    publishDiagnostics(document.uri);
+    return;
+  }
+
+  if (method === 'textDocument/didChange') {
+    const uri = params.textDocument.uri;
+    const text = params.contentChanges[params.contentChanges.length - 1].text;
+    documents.set(uri, text);
+    logEvent({
+      method: 'fake/documentState',
+      uri,
+      text,
+      version: params.textDocument.version,
+    });
+    publishDiagnostics(uri);
+    return;
+  }
+
+  if (method === 'textDocument/completion') {
+    sendResponse(id, {
+      isIncomplete: false,
+      items: [
+        {
+          label: 'fake-lsp-completion',
+          kind: 14,
+          detail: 'Fake LSP completion item',
+        },
+      ],
+    });
+    return;
+  }
+
+  if (method === 'shutdown') {
+    sendResponse(id, null);
+    return;
+  }
+
+  if (method === 'exit') {
+    process.exit(0);
+  }
+
+  if (id !== undefined) {
+    writeMessage({
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32601,
+        message: `Method not found: ${method}`,
+      },
+    });
+  }
+}
+
+function readMessages() {
+  while (true) {
+    const headerEnd = buffer.indexOf('\r\n\r\n');
+    if (headerEnd === -1) {
+      return;
+    }
+
+    const header = buffer.subarray(0, headerEnd).toString('utf8');
+    const lengthMatch = /Content-Length: (\d+)/i.exec(header);
+    if (!lengthMatch) {
+      throw new Error(`Missing Content-Length header: ${header}`);
+    }
+
+    const length = Number(lengthMatch[1]);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    if (buffer.length < bodyEnd) {
+      return;
+    }
+
+    const body = buffer.subarray(bodyStart, bodyEnd).toString('utf8');
+    buffer = buffer.subarray(bodyEnd);
+    handleMessage(JSON.parse(body));
+  }
+}
+
+process.stdin.on('data', chunk => {
+  buffer = Buffer.concat([buffer, chunk]);
+  readMessages();
+});
+
+process.stdin.on('end', () => process.exit(0));

--- a/tests/integration/fakeLspClient.test.ts
+++ b/tests/integration/fakeLspClient.test.ts
@@ -1,0 +1,175 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { LanguageClient, TransportKind } from 'vscode-languageclient/node';
+import {
+  CompletionRequest,
+  DidChangeTextDocumentNotification,
+  DidOpenTextDocumentNotification,
+  PublishDiagnosticsNotification,
+} from 'vscode-languageserver-protocol';
+
+interface FakeLspEvent {
+  method: string;
+  id?: number | string;
+  uri?: string;
+  text?: string;
+  version?: number;
+  diagnosticCount?: number;
+  sequence: number;
+}
+
+const fixturePath = path.join(__dirname, '../fixtures/fake-lsp-server.js');
+
+function readEvents(eventsPath: string): FakeLspEvent[] {
+  if (!fs.existsSync(eventsPath)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(eventsPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as FakeLspEvent);
+}
+
+async function waitForEvent(
+  eventsPath: string,
+  predicate: (event: FakeLspEvent) => boolean
+): Promise<FakeLspEvent> {
+  const timeoutAt = Date.now() + 5000;
+
+  while (Date.now() < timeoutAt) {
+    const match = readEvents(eventsPath).find(predicate);
+    if (match) {
+      return match;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+
+  throw new Error(`Timed out waiting for fake LSP event in ${eventsPath}`);
+}
+
+describe('fake stdio LSP client integration', () => {
+  let client: LanguageClient | undefined;
+  let tempDir: string;
+  let eventsPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openqc-fake-lsp-'));
+    eventsPath = path.join(tempDir, 'events.ndjson');
+  });
+
+  afterEach(async () => {
+    if (client?.needsStop()) {
+      await client.stop();
+    }
+    client = undefined;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('starts, exchanges document lifecycle messages, completes, and shuts down', async () => {
+    const diagnostics: unknown[] = [];
+    client = new LanguageClient(
+      'openqc-fake-lsp-integration',
+      'OpenQC Fake LSP Integration',
+      {
+        command: process.execPath,
+        args: [fixturePath],
+        transport: TransportKind.stdio,
+        options: {
+          env: {
+            ...process.env,
+            FAKE_LSP_EVENTS_PATH: eventsPath,
+          },
+        },
+      },
+      {
+        documentSelector: [{ scheme: 'file', language: 'gaussian' }],
+        initializationOptions: {
+          testName: 'fakeLspClient',
+        },
+      }
+    );
+
+    client.onNotification(PublishDiagnosticsNotification.type, params => {
+      diagnostics.push(params);
+    });
+
+    await client.start();
+    await waitForEvent(eventsPath, event => event.method === 'initialize');
+    await waitForEvent(eventsPath, event => event.method === 'initialized');
+
+    const uri = 'file:///tmp/openqc-fake-lsp-test.gjf';
+    client.sendNotification(DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri,
+        languageId: 'gaussian',
+        version: 1,
+        text: '# hf/sto-3g\n\n0 1\nH 0 0 0\n',
+      },
+    });
+
+    await waitForEvent(
+      eventsPath,
+      event =>
+        event.method === 'fake/documentState' &&
+        event.uri === uri &&
+        event.version === 1 &&
+        event.text?.includes('hf/sto-3g') === true
+    );
+
+    client.sendNotification(DidChangeTextDocumentNotification.type, {
+      textDocument: { uri, version: 2 },
+      contentChanges: [{ text: '# problem\n\n0 1\nH 0 0 0\n' }],
+    });
+
+    await waitForEvent(
+      eventsPath,
+      event =>
+        event.method === 'fake/documentState' &&
+        event.uri === uri &&
+        event.version === 2 &&
+        event.text?.includes('problem') === true
+    );
+    await waitForEvent(
+      eventsPath,
+      event =>
+        event.method === 'textDocument/publishDiagnostics' &&
+        event.uri === uri &&
+        event.diagnosticCount === 1
+    );
+
+    const completion = await client.sendRequest(CompletionRequest.type, {
+      textDocument: { uri },
+      position: { line: 0, character: 1 },
+      context: { triggerKind: 1 },
+    });
+
+    expect(completion).toEqual(
+      expect.objectContaining({
+        isIncomplete: false,
+        items: [
+          expect.objectContaining({
+            label: 'fake-lsp-completion',
+            detail: 'Fake LSP completion item',
+          }),
+        ],
+      })
+    );
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        uri,
+        diagnostics: [],
+      }),
+      expect.objectContaining({
+        uri,
+        diagnostics: [expect.objectContaining({ source: 'fake-lsp' })],
+      }),
+    ]);
+
+    await client.stop();
+    await waitForEvent(eventsPath, event => event.method === 'shutdown');
+    await waitForEvent(eventsPath, event => event.method === 'exit');
+  });
+});

--- a/tests/mocks/vscode.ts
+++ b/tests/mocks/vscode.ts
@@ -1,9 +1,15 @@
 // Mock vscode module for tests
+export const version = '1.120.0';
+
 export const window = {
-  showInformationMessage: jest.fn(),
-  showWarningMessage: jest.fn(),
-  showErrorMessage: jest.fn(),
+  showInformationMessage: jest.fn(() => Promise.resolve(undefined)),
+  showWarningMessage: jest.fn(() => Promise.resolve(undefined)),
+  showErrorMessage: jest.fn(() => Promise.resolve(undefined)),
   activeTextEditor: undefined,
+  onDidChangeActiveTextEditor: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeVisibleTextEditors: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeTextEditorSelection: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeTextEditorVisibleRanges: jest.fn(() => ({ dispose: jest.fn() })),
   createWebviewPanel: jest.fn(() => ({
     webview: {
       html: '',
@@ -53,7 +59,13 @@ export const workspace = {
     dispose: jest.fn(),
   })),
   onDidOpenTextDocument: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeTextDocument: jest.fn(() => ({ dispose: jest.fn() })),
   onDidCloseTextDocument: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidSaveTextDocument: jest.fn(() => ({ dispose: jest.fn() })),
+  onWillSaveTextDocument: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeConfiguration: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidChangeWorkspaceFolders: jest.fn(() => ({ dispose: jest.fn() })),
+  textDocuments: [],
   workspaceFolders: [],
   getWorkspaceFolder: jest.fn(),
   asRelativePath: jest.fn((path: string) => path),
@@ -62,6 +74,258 @@ export const workspace = {
     writeFile: jest.fn(),
     stat: jest.fn(),
   },
+};
+
+export const languages = {
+  registerCompletionItemProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerHoverProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDefinitionProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerReferenceProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDocumentHighlightProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDocumentSymbolProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerCodeActionsProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerCodeLensProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDocumentFormattingEditProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDocumentRangeFormattingEditProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerOnTypeFormattingEditProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerRenameProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerDocumentLinkProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerColorProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerFoldingRangeProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerImplementationProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerSelectionRangeProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  registerTypeDefinitionProvider: jest.fn(() => ({ dispose: jest.fn() })),
+  createDiagnosticCollection: jest.fn(() => ({
+    set: jest.fn(),
+    delete: jest.fn(),
+    clear: jest.fn(),
+    dispose: jest.fn(),
+  })),
+  match: jest.fn(() => 10),
+};
+
+export class Position {
+  constructor(
+    public line: number,
+    public character: number
+  ) {}
+}
+
+export class Range {
+  constructor(
+    public start: Position,
+    public end: Position
+  ) {}
+}
+
+export class CompletionItem {
+  constructor(public label: string) {}
+}
+
+export class CodeLens {
+  constructor(public range: Range) {}
+}
+
+export class CodeAction {
+  constructor(
+    public title: string,
+    public kind?: unknown
+  ) {}
+}
+
+export class Diagnostic {
+  constructor(
+    public range: Range,
+    public message: string,
+    public severity?: unknown
+  ) {}
+}
+
+export class DocumentLink {
+  constructor(
+    public range: Range,
+    public target?: unknown
+  ) {}
+}
+
+export class InlayHint {
+  constructor(
+    public position: Position,
+    public label: unknown,
+    public kind?: unknown
+  ) {}
+}
+
+export class SymbolInformation {
+  constructor(
+    public name: string,
+    public kind: unknown,
+    public rangeOrContainer: unknown,
+    public locationOrUri?: unknown,
+    public containerName?: string
+  ) {}
+}
+
+export class CallHierarchyItem {
+  constructor(
+    public kind: unknown,
+    public name: string,
+    public detail: string,
+    public uri: unknown,
+    public range: Range,
+    public selectionRange: Range
+  ) {}
+}
+
+export class TypeHierarchyItem {
+  constructor(
+    public kind: unknown,
+    public name: string,
+    public detail: string,
+    public uri: unknown,
+    public range: Range,
+    public selectionRange: Range
+  ) {}
+}
+
+export class Location {
+  constructor(
+    public uri: unknown,
+    public range: Range
+  ) {}
+}
+
+export class DocumentSymbol {
+  children: DocumentSymbol[] = [];
+  tags?: unknown[];
+
+  constructor(
+    public name: string,
+    public detail: string,
+    public kind: unknown,
+    public range: Range,
+    public selectionRange: Range
+  ) {}
+}
+
+export class CompletionList {
+  constructor(
+    public items: unknown[],
+    public isIncomplete?: boolean
+  ) {}
+}
+
+export class MarkdownString {
+  value = '';
+  supportHtml = false;
+
+  constructor(value = '') {
+    this.value = value;
+  }
+
+  appendMarkdown(value: string): MarkdownString {
+    this.value += value;
+    return this;
+  }
+
+  appendCodeblock(value: string): MarkdownString {
+    this.value += value;
+    return this;
+  }
+}
+
+export class SnippetString {
+  constructor(public value = '') {}
+}
+
+export class TextEdit {
+  constructor(
+    public range: Range,
+    public newText: string
+  ) {}
+}
+
+export class CancellationError extends Error {
+  constructor() {
+    super('Canceled');
+    this.name = 'CancellationError';
+  }
+}
+
+export const DiagnosticSeverity = {
+  Error: 0,
+  Warning: 1,
+  Information: 2,
+  Hint: 3,
+};
+
+export const CodeActionKind = {
+  Empty: { value: '' },
+  QuickFix: { value: 'quickfix' },
+  Refactor: { value: 'refactor' },
+  RefactorExtract: { value: 'refactor.extract' },
+  RefactorInline: { value: 'refactor.inline' },
+  RefactorRewrite: { value: 'refactor.rewrite' },
+  Source: { value: 'source' },
+  SourceOrganizeImports: { value: 'source.organizeImports' },
+};
+
+export const CompletionItemKind = {
+  Text: 1,
+};
+
+export const CompletionItemTag = {
+  Deprecated: 1,
+};
+
+export const DiagnosticTag = {
+  Unnecessary: 1,
+  Deprecated: 2,
+};
+
+export const DocumentHighlightKind = {
+  Text: 1,
+  Read: 2,
+  Write: 3,
+};
+
+export const SymbolKind = {
+  File: 1,
+  Module: 2,
+  Namespace: 3,
+  Package: 4,
+  Class: 5,
+  Method: 6,
+  Property: 7,
+  Field: 8,
+  Constructor: 9,
+  Enum: 10,
+  Interface: 11,
+  Function: 12,
+  Variable: 13,
+  Constant: 14,
+  String: 15,
+  Number: 16,
+  Boolean: 17,
+  Array: 18,
+  Object: 19,
+  Key: 20,
+  Null: 21,
+  EnumMember: 22,
+  Struct: 23,
+  Event: 24,
+  Operator: 25,
+  TypeParameter: 26,
+};
+
+export const SymbolTag = {
+  Deprecated: 1,
+};
+
+export const FoldingRangeKind = {
+  Comment: 1,
+  Imports: 2,
+  Region: 3,
 };
 
 export const commands = {
@@ -114,10 +378,39 @@ export const TextDocument = jest.fn();
 export const TextEditor = jest.fn();
 
 export default {
+  version,
   window,
   workspace,
   commands,
   env,
+  languages,
+  Position,
+  Range,
+  CompletionItem,
+  CodeLens,
+  CodeAction,
+  Diagnostic,
+  DocumentLink,
+  InlayHint,
+  SymbolInformation,
+  CallHierarchyItem,
+  TypeHierarchyItem,
+  Location,
+  DocumentSymbol,
+  CompletionList,
+  MarkdownString,
+  SnippetString,
+  TextEdit,
+  CancellationError,
+  DiagnosticSeverity,
+  CodeActionKind,
+  CompletionItemKind,
+  CompletionItemTag,
+  DiagnosticTag,
+  DocumentHighlightKind,
+  SymbolKind,
+  SymbolTag,
+  FoldingRangeKind,
   ViewColumn,
   Uri,
   EventEmitter,


### PR DESCRIPTION
## Summary
- Add a fake stdio LSP server fixture for deterministic client lifecycle tests
- Add a real LanguageClient integration test covering initialize, didOpen/didChange, diagnostics, completion, shutdown, and exit
- Extend the VS Code test mock enough for vscode-languageclient feature registration

Closes #102

## Validation
- npm ci
- npx jest tests/integration/fakeLspClient.test.ts --runInBand --detectOpenHandles
- npm run compile
- npm run typecheck
- npm run test:integration
- npm run ci:pr
