### PR TITLE
Fix CP2K syntax highlighting and LSP startup

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,7 +14,13 @@ node_modules/**
 !node_modules/plotly.js-dist-min/**
 !node_modules/vscode-languageclient/**
 !node_modules/vscode-languageserver-protocol/**
+!node_modules/vscode-jsonrpc/**
 !node_modules/vscode-languageserver-types/**
+!node_modules/vscode-languageserver-textdocument/**
+!node_modules/minimatch/**
+!node_modules/brace-expansion/**
+!node_modules/balanced-match/**
+!node_modules/semver/**
 .git/**
 .github/**
 **/.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openqc",
-  "version": "3.0.7",
+  "version": "3.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openqc",
-      "version": "3.0.7",
+      "version": "3.0.13",
       "license": "MIT",
       "dependencies": {
         "3dmol": "^2.5.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openqc",
   "displayName": "OpenQC - Quantum Chemistry & Molecular Dynamics Suite",
   "description": "Parse, visualize, and analyze computational chemistry, materials, and molecular-simulation files with 16 bundled LSP integrations.",
-  "version": "3.0.7",
+  "version": "3.0.13",
   "publisher": "newtontech",
   "engines": {
     "vscode": "^1.120.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -437,6 +437,17 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  for (const document of vscode.workspace.textDocuments) {
+    if (fileTypeDetector.detectSoftware(document)) {
+      if (languageFeaturePolicy.autoStartLsp) {
+        void lspManager.startLSPForDocument(document);
+      }
+      if (languageFeaturePolicy.validateWithLocalDiagnostics) {
+        void diagnosticsProvider.validateDocument(document);
+      }
+    }
+  }
+
   // Register ASE commands
   registerPythonBackendCommands(context);
   registerScientificBridgeCommands(context);

--- a/src/managers/LSPManager.ts
+++ b/src/managers/LSPManager.ts
@@ -1,10 +1,5 @@
 import * as vscode from 'vscode';
-import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  TransportKind,
-} from 'vscode-languageclient/node';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { FileTypeDetector, QuantumChemistrySoftware } from './FileTypeDetector';
 import { LSPDiscovery, LSPServerDefinition } from '../utils/LSPDiscovery';
 import { createComponentLogger } from '../utils/Logger';
@@ -279,7 +274,6 @@ export class LSPManager {
       const serverOptions: ServerOptions = {
         command: serverCommand,
         args: serverArgs,
-        transport: TransportKind.stdio,
         ...(serverEnv || serverCwd
           ? { options: { env: { ...process.env, ...serverEnv }, cwd: serverCwd } }
           : {}),

--- a/syntaxes/cp2k.tmLanguage.json
+++ b/syntaxes/cp2k.tmLanguage.json
@@ -1,44 +1,99 @@
 {
   "scopeName": "source.cp2k",
+  "name": "CP2K Input",
   "patterns": [
-    {
-      "match": "^\\s*(#|!).*",
-      "name": "comment.line.number-sign.cp2k"
+    { "include": "#comments" },
+    { "include": "#preprocessor" },
+    { "include": "#sections" },
+    { "include": "#keywords" },
+    { "include": "#values" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "match": "^\\s*(#|!).*",
+          "name": "comment.line.cp2k"
+        },
+        {
+          "match": "(?<!\\S)(#|!).*$",
+          "name": "comment.line.inline.cp2k"
+        }
+      ]
     },
-    {
-      "match": "\\b(&[A-Z_]+)\\b",
-      "name": "keyword.control.cp2k"
+    "preprocessor": {
+      "patterns": [
+        {
+          "match": "^\\s*(@(?:SET|IF|ELIF|ELSE|ENDIF|INCLUDE))\\b",
+          "name": "keyword.control.preprocessor.cp2k"
+        },
+        {
+          "match": "\\$\\{[A-Za-z_][A-Za-z0-9_]*\\}",
+          "name": "variable.other.cp2k"
+        },
+        {
+          "match": "(?<=@INCLUDE\\s)(?:\"[^\"]+\"|'[^']+'|\\S+)",
+          "name": "string.unquoted.include.cp2k"
+        }
+      ]
     },
-    {
-      "match": "\\b(&END)\\s*([A-Z_]+)",
-      "name": "keyword.control.cp2k"
+    "sections": {
+      "patterns": [
+        {
+          "match": "^\\s*&END(?:\\s+([A-Za-z_][A-Za-z0-9_]*))?\\b",
+          "name": "keyword.control.section.end.cp2k"
+        },
+        {
+          "match": "^\\s*&([A-Za-z_][A-Za-z0-9_]*)\\b",
+          "name": "keyword.control.section.begin.cp2k"
+        }
+      ]
     },
-    {
-      "match": "\\b([A-Z_]+)\\s*=\\s*([^\\s]+)",
-      "captures": {
-        "1": { "name": "variable.parameter.cp2k" },
-        "2": { "name": "string.unquoted.cp2k" }
-      }
+    "keywords": {
+      "patterns": [
+        {
+          "match": "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\b(?=\\s*(?:=|\\S))",
+          "captures": {
+            "1": { "name": "variable.parameter.cp2k" }
+          }
+        }
+      ]
     },
-    {
-      "match": "\\b(\\.TRUE\\.|\\.FALSE\\.|\\.YES\\.|\\.NO\\.)\\b",
-      "name": "constant.language.boolean.cp2k"
-    },
-    {
-      "match": "\\b\\d+\\.\\d+([eE][+-]?\\d+)?\\b",
-      "name": "constant.numeric.float.cp2k"
-    },
-    {
-      "match": "\\b\\d+\\b",
-      "name": "constant.numeric.integer.cp2k"
-    },
-    {
-      "match": "\"([^\"]*)\"",
-      "name": "string.quoted.double.cp2k"
-    },
-    {
-      "match": "'([^']*)'",
-      "name": "string.quoted.single.cp2k"
+    "values": {
+      "patterns": [
+        {
+          "match": "\\b(?:\\.TRUE\\.|\\.FALSE\\.|\\.YES\\.|\\.NO\\.|TRUE|FALSE|YES|NO|ON|OFF|T|F)\\b",
+          "name": "constant.language.boolean.cp2k"
+        },
+        {
+          "match": "(?<![A-Za-z_])[-+]?\\d+\\.\\d*(?:[eE][-+]?\\d+)?\\b",
+          "name": "constant.numeric.float.cp2k"
+        },
+        {
+          "match": "(?<![A-Za-z_])[-+]?\\d+(?:[eE][-+]?\\d+)?\\b",
+          "name": "constant.numeric.integer.cp2k"
+        },
+        {
+          "match": "\\[[A-Za-z_][A-Za-z0-9_./-]*\\]",
+          "name": "constant.other.unit.cp2k"
+        },
+        {
+          "match": "\"(?:[^\"\\\\]|\\\\.)*\"",
+          "name": "string.quoted.double.cp2k"
+        },
+        {
+          "match": "'(?:[^'\\\\]|\\\\.)*'",
+          "name": "string.quoted.single.cp2k"
+        },
+        {
+          "match": "(?<=\\s)(?:\\.\\.?/|/)?[A-Za-z0-9_./+-]+\\.(?:inp|inc|basis|pot|dat|xyz|pdb|restart)\\b",
+          "name": "string.unquoted.path.cp2k"
+        },
+        {
+          "match": "\\b(?:BASIS_[A-Za-z0-9_+-]+|GTH-[A-Za-z0-9_+-]+|POTENTIALS?|BASIS_MOLOPT)\\b",
+          "name": "string.unquoted.datafile.cp2k"
+        }
+      ]
     }
-  ]
+  }
 }

--- a/tests/unit/syntaxes/cp2kGrammar.test.ts
+++ b/tests/unit/syntaxes/cp2kGrammar.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const grammarPath = path.join(__dirname, '../../../syntaxes/cp2k.tmLanguage.json');
+
+interface GrammarPattern {
+  name?: string;
+  match?: string;
+  patterns?: GrammarPattern[];
+  captures?: Record<string, { name?: string }>;
+}
+
+function collectPatterns(node: unknown, patterns: Array<{ name: string; regex: RegExp }> = []) {
+  if (!node || typeof node !== 'object') return patterns;
+
+  const value = node as GrammarPattern & Record<string, unknown>;
+  if (typeof value.name === 'string' && typeof value.match === 'string') {
+    patterns.push({ name: value.name, regex: new RegExp(value.match) });
+  }
+
+  if (value.captures && typeof value.match === 'string') {
+    for (const capture of Object.values(value.captures)) {
+      if (typeof capture.name === 'string') {
+        patterns.push({ name: capture.name, regex: new RegExp(value.match) });
+      }
+    }
+  }
+
+  for (const child of Object.values(value)) {
+    if (Array.isArray(child)) {
+      child.forEach(item => collectPatterns(item, patterns));
+    } else if (child && typeof child === 'object') {
+      collectPatterns(child, patterns);
+    }
+  }
+
+  return patterns;
+}
+
+function scopesFor(line: string): string[] {
+  const grammar = JSON.parse(fs.readFileSync(grammarPath, 'utf8'));
+  return collectPatterns(grammar)
+    .filter(pattern => pattern.regex.test(line))
+    .map(pattern => pattern.name);
+}
+
+describe('CP2K TextMate grammar', () => {
+  it('declares the CP2K source scope', () => {
+    const grammar = JSON.parse(fs.readFileSync(grammarPath, 'utf8'));
+    expect(grammar.scopeName).toBe('source.cp2k');
+    expect(grammar.repository).toHaveProperty('preprocessor');
+    expect(grammar.repository).toHaveProperty('sections');
+    expect(grammar.repository).toHaveProperty('values');
+  });
+
+  it('covers full CP2K input syntax used before LSP startup', () => {
+    const examples: Record<string, string[]> = {
+      '! comment': ['comment.line.cp2k'],
+      '&GLOBAL': ['keyword.control.section.begin.cp2k'],
+      '&END GLOBAL': ['keyword.control.section.end.cp2k'],
+      '  RUN_TYPE ENERGY': ['variable.parameter.cp2k'],
+      '  UKS TRUE': ['variable.parameter.cp2k', 'constant.language.boolean.cp2k'],
+      '  CUTOFF 400': ['variable.parameter.cp2k', 'constant.numeric.integer.cp2k'],
+      '  EPS_SCF 1.0E-7': ['variable.parameter.cp2k', 'constant.numeric.float.cp2k'],
+      '  A [angstrom] 10.0 0.0 0.0': ['variable.parameter.cp2k', 'constant.other.unit.cp2k'],
+      "@INCLUDE './common.inc'": [
+        'keyword.control.preprocessor.cp2k',
+        'string.unquoted.include.cp2k',
+        'string.quoted.single.cp2k',
+      ],
+      '@SET PROJECT_NAME water': ['keyword.control.preprocessor.cp2k'],
+      '  PROJECT ${PROJECT_NAME}': ['variable.parameter.cp2k', 'variable.other.cp2k'],
+      '  COORD_FILE_NAME ./coords.xyz': ['variable.parameter.cp2k', 'string.unquoted.path.cp2k'],
+      '  BASIS_SET DZVP-MOLOPT-SR-GTH': ['variable.parameter.cp2k'],
+      '  POTENTIAL GTH-PBE': ['variable.parameter.cp2k', 'string.unquoted.datafile.cp2k'],
+    };
+
+    for (const [line, expectedScopes] of Object.entries(examples)) {
+      const scopes = scopesFor(line);
+      for (const expectedScope of expectedScopes) {
+        expect(scopes).toContain(expectedScope);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- expand CP2K TextMate grammar for sections, preprocessor directives, variables, comments, numeric values, units, paths, and CP2K data-file tokens
- package the runtime dependencies required by vscode-languageclient so the VSIX activates correctly
- start CP2K LSP/diagnostics for already-open CP2K documents and stop appending an unsupported --stdio option
- bump local VSIX version to 3.0.13 for verified install

Fixes #183.
Refs newtontech/cp2k-lsp-enhanced#51.

## Tests
- npm run compile
- npm run typecheck
- npm run lint (0 errors, 3 existing curly warnings)
- npx jest --coverage=false --runTestsByPath tests/unit/syntaxes/cp2kGrammar.test.ts --runInBand
- pre-commit: 66 unit suites passed, 1418 tests passed, coverage 91.25% statements
- npm run package:vsix
- code --install-extension openqc-3.0.13.vsix --force
- VS Code log: CP2K LSP started and reached running state for examples/cp2k/h2o_sp.inp
