### PR TITLE
feat(lsp): add OpenQC↔Bohrium registry alignment check

### DIFF
--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -60,6 +60,7 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 | Startup | OpenQC starts the configured command over stdio and can prefer sibling local repositories when no user override is set. |
 | Latest tracking | Every registry entry records the upstream default branch used for latest-version checks. |
 | Agent CLI probe | `npm run lsp:check-latest -- --fail-on-drift` verifies remote HEAD, local worktree cleanliness, and source-backed `*-lsp-tool --help`. |
+| Bohrium registry alignment | `npm run lsp:check-bohrium-registry` compares OpenQC bundled ids/agent CLIs with `bohrium_skills/.../lsp_backends.yaml` and fails on drift. OpenQC editor integration and Bohrium skill routing are reported separately. |
 
 ## Release Verification
 
@@ -68,9 +69,10 @@ Before publishing a VSIX or Marketplace release:
 1. Run `npm run typecheck`.
 2. Run `npm run test:unit -- --runTestsByPath tests/unit/lsp/registry.test.ts`.
 3. Run `npm run lsp:check-latest -- --fail-on-drift` to compare sibling LSP checkouts with each configured remote default-branch HEAD and verify source-backed `*-lsp-tool --help`.
-4. Run `OpenQC LSP: Generate Compatibility Report` from VS Code and save the report with the release notes.
-5. For each LSP, smoke test one valid file and one intentionally invalid file on the latest configured executable or sibling repository checkout.
-6. Record the exact LSP version, release tag, or commit SHA used for the release smoke test.
+4. Run `npm run lsp:check-bohrium-registry` to compare OpenQC bundled registry ids with the Bohrium skill backend registry.
+5. Run `OpenQC LSP: Generate Compatibility Report` from VS Code and save the report with the release notes.
+6. For each LSP, smoke test one valid file and one intentionally invalid file on the latest configured executable or sibling repository checkout.
+7. Record the exact LSP version, release tag, or commit SHA used for the release smoke test.
 
 ## Known Limits
 

--- a/package.json
+++ b/package.json
@@ -1564,6 +1564,7 @@
     "watch": "tsc -watch -p ./",
     "lsp:check-latest": "node scripts/check-lsp-latest.mjs",
     "lsp:check-family": "node scripts/check-lsp-family.mjs",
+    "lsp:check-bohrium-registry": "node scripts/check-bohrium-registry-alignment.mjs --strict",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-bohrium-registry-alignment.mjs
+++ b/scripts/check-bohrium-registry-alignment.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * OpenQC ↔ Bohrium LSP registry alignment check.
+ *
+ * Compares bundled OpenQC registry ids/agent CLIs with the Bohrium skill
+ * backend registry. Surfaces missing or excess entries without conflating
+ * OpenQC editor integration readiness with Bohrium skill-router availability.
+ *
+ * Usage:
+ *   node scripts/check-bohrium-registry-alignment.mjs
+ *   node scripts/check-bohrium-registry-alignment.mjs --json
+ *   node scripts/check-bohrium-registry-alignment.mjs --strict
+ *   node scripts/check-bohrium-registry-alignment.mjs --bohrium-registry /path/to/lsp_backends.yaml
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/194
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const codeRoot = resolve(repoRoot, '..');
+
+const jsonMode = process.argv.includes('--json');
+const strictMode = process.argv.includes('--strict');
+const registryArgIndex = process.argv.indexOf('--bohrium-registry');
+const defaultBohriumRegistry = join(
+  codeRoot,
+  'bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml'
+);
+const bohriumRegistryPath =
+  registryArgIndex >= 0 ? resolve(process.argv[registryArgIndex + 1]) : defaultBohriumRegistry;
+
+const openqcRegistryPath = join(repoRoot, 'src/lsp/registry.ts');
+const openqcRegistry = readFileSync(openqcRegistryPath, 'utf8');
+
+const openqcEntries = [...openqcRegistry.matchAll(
+  /id: '([^']+)'[\s\S]*?languageId: '([^']+)'/g
+)].map(match => ({
+  id: match[1],
+  languageId: match[2],
+}));
+
+const openqcReadiness = new Map([...openqcRegistry.matchAll(
+  /'([^']+)': diagnosticReadiness\('([^']+)', '([^']+)'/g
+)].map(match => [
+  match[1],
+  {
+    agentCli: match[2],
+    closedLoop: match[3],
+  },
+]));
+
+if (!existsSync(bohriumRegistryPath)) {
+  const message = `Bohrium registry not found: ${bohriumRegistryPath}`;
+  if (jsonMode) {
+    console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+  } else {
+    console.error(message);
+  }
+  process.exit(strictMode ? 1 : 0);
+}
+
+const bohriumRegistry = JSON.parse(readFileSync(bohriumRegistryPath, 'utf8'));
+const bohriumBackends = (bohriumRegistry.backends ?? []).map(backend => ({
+  id: backend.id,
+  software: backend.software,
+  agentCli: backend.agent_cli ?? backend.executable,
+  maturity: backend.maturity,
+  blocking: Boolean(backend.blocking),
+}));
+
+const openqcIds = new Set(openqcEntries.map(entry => entry.id));
+const bohriumIds = new Set(bohriumBackends.map(backend => backend.id));
+
+const missingInBohrium = [...openqcIds].filter(id => !bohriumIds.has(id)).sort();
+const excessInBohrium = [...bohriumIds].filter(id => !openqcIds.has(id)).sort();
+
+const agentCliMismatches = [];
+for (const entry of openqcEntries) {
+  const backend = bohriumBackends.find(item => item.id === entry.id);
+  if (!backend) {
+    continue;
+  }
+  const expectedAgentCli = openqcReadiness.get(entry.id)?.agentCli;
+  if (expectedAgentCli && backend.agentCli !== expectedAgentCli) {
+    agentCliMismatches.push({
+      id: entry.id,
+      openqcAgentCli: expectedAgentCli,
+      bohriumAgentCli: backend.agentCli,
+    });
+  }
+}
+
+const aligned = missingInBohrium.length === 0 && excessInBohrium.length === 0 && agentCliMismatches.length === 0;
+
+const report = {
+  ok: aligned,
+  generatedAt: new Date().toISOString(),
+  surfaces: {
+    openqc: {
+      role: 'editor-integration',
+      source: openqcRegistryPath,
+      backendCount: openqcEntries.length,
+      description: 'Bundled VS Code language contributions and local LSP startup registry.',
+    },
+    bohrium: {
+      role: 'skill-router',
+      source: bohriumRegistryPath,
+      backendCount: bohriumBackends.length,
+      description: 'Bohrium LSP skill backend registry used by lsp_agent_router.py and lsp_skill_probe.py.',
+    },
+  },
+  summary: {
+    openqcCount: openqcEntries.length,
+    bohriumCount: bohriumBackends.length,
+    missingInBohrium,
+    excessInBohrium,
+    agentCliMismatches,
+  },
+  note:
+    'OpenQC editor integration and Bohrium skill routing share backend ids and agent CLI names, but maturity/blocking in Bohrium may differ from OpenQC stability until fleet closeout.',
+  backends: openqcEntries.map(entry => {
+    const readiness = openqcReadiness.get(entry.id);
+    const backend = bohriumBackends.find(item => item.id === entry.id);
+    return {
+      id: entry.id,
+      languageId: entry.languageId,
+      openqcAgentCli: readiness?.agentCli ?? null,
+      openqcClosedLoop: readiness?.closedLoop ?? null,
+      bohriumPresent: Boolean(backend),
+      bohriumAgentCli: backend?.agentCli ?? null,
+      bohriumMaturity: backend?.maturity ?? null,
+      bohriumBlocking: backend?.blocking ?? null,
+    };
+  }),
+};
+
+if (jsonMode) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  console.log('# OpenQC ↔ Bohrium LSP Registry Alignment');
+  console.log('');
+  console.log(`OpenQC editor registry: ${report.surfaces.openqc.backendCount} backends (${openqcRegistryPath})`);
+  console.log(`Bohrium skill registry: ${report.surfaces.bohrium.backendCount} backends (${bohriumRegistryPath})`);
+  console.log('');
+  if (aligned) {
+    console.log('Status: aligned');
+  } else {
+    console.log('Status: drift detected');
+    if (missingInBohrium.length > 0) {
+      console.log(`- Missing in Bohrium: ${missingInBohrium.join(', ')}`);
+    }
+    if (excessInBohrium.length > 0) {
+      console.log(`- Excess in Bohrium: ${excessInBohrium.join(', ')}`);
+    }
+    if (agentCliMismatches.length > 0) {
+      console.log(`- Agent CLI mismatches: ${agentCliMismatches.map(item => item.id).join(', ')}`);
+    }
+  }
+  console.log('');
+  console.log(report.note);
+}
+
+if (strictMode && !aligned) {
+  process.exit(1);
+}

--- a/scripts/check-bohrium-registry-alignment.mjs
+++ b/scripts/check-bohrium-registry-alignment.mjs
@@ -37,22 +37,24 @@ const bohriumRegistryPath =
 const openqcRegistryPath = join(repoRoot, 'src/lsp/registry.ts');
 const openqcRegistry = readFileSync(openqcRegistryPath, 'utf8');
 
-const openqcEntries = [...openqcRegistry.matchAll(
-  /id: '([^']+)'[\s\S]*?languageId: '([^']+)'/g
-)].map(match => ({
+const openqcEntries = [
+  ...openqcRegistry.matchAll(/id: '([^']+)'[\s\S]*?languageId: '([^']+)'/g),
+].map(match => ({
   id: match[1],
   languageId: match[2],
 }));
 
-const openqcReadiness = new Map([...openqcRegistry.matchAll(
-  /'([^']+)': diagnosticReadiness\('([^']+)', '([^']+)'/g
-)].map(match => [
-  match[1],
-  {
-    agentCli: match[2],
-    closedLoop: match[3],
-  },
-]));
+const openqcReadiness = new Map(
+  [...openqcRegistry.matchAll(/'([^']+)': diagnosticReadiness\('([^']+)', '([^']+)'/g)].map(
+    match => [
+      match[1],
+      {
+        agentCli: match[2],
+        closedLoop: match[3],
+      },
+    ]
+  )
+);
 
 if (!existsSync(bohriumRegistryPath)) {
   const message = `Bohrium registry not found: ${bohriumRegistryPath}`;
@@ -95,7 +97,8 @@ for (const entry of openqcEntries) {
   }
 }
 
-const aligned = missingInBohrium.length === 0 && excessInBohrium.length === 0 && agentCliMismatches.length === 0;
+const aligned =
+  missingInBohrium.length === 0 && excessInBohrium.length === 0 && agentCliMismatches.length === 0;
 
 const report = {
   ok: aligned,
@@ -111,7 +114,8 @@ const report = {
       role: 'skill-router',
       source: bohriumRegistryPath,
       backendCount: bohriumBackends.length,
-      description: 'Bohrium LSP skill backend registry used by lsp_agent_router.py and lsp_skill_probe.py.',
+      description:
+        'Bohrium LSP skill backend registry used by lsp_agent_router.py and lsp_skill_probe.py.',
     },
   },
   summary: {
@@ -121,8 +125,7 @@ const report = {
     excessInBohrium,
     agentCliMismatches,
   },
-  note:
-    'OpenQC editor integration and Bohrium skill routing share backend ids and agent CLI names, but maturity/blocking in Bohrium may differ from OpenQC stability until fleet closeout.',
+  note: 'OpenQC editor integration and Bohrium skill routing share backend ids and agent CLI names, but maturity/blocking in Bohrium may differ from OpenQC stability until fleet closeout.',
   backends: openqcEntries.map(entry => {
     const readiness = openqcReadiness.get(entry.id);
     const backend = bohriumBackends.find(item => item.id === entry.id);
@@ -144,8 +147,12 @@ if (jsonMode) {
 } else {
   console.log('# OpenQC ↔ Bohrium LSP Registry Alignment');
   console.log('');
-  console.log(`OpenQC editor registry: ${report.surfaces.openqc.backendCount} backends (${openqcRegistryPath})`);
-  console.log(`Bohrium skill registry: ${report.surfaces.bohrium.backendCount} backends (${bohriumRegistryPath})`);
+  console.log(
+    `OpenQC editor registry: ${report.surfaces.openqc.backendCount} backends (${openqcRegistryPath})`
+  );
+  console.log(
+    `Bohrium skill registry: ${report.surfaces.bohrium.backendCount} backends (${bohriumRegistryPath})`
+  );
   console.log('');
   if (aligned) {
     console.log('Status: aligned');

--- a/tests/unit/lsp/bohriumRegistryAlignment.test.ts
+++ b/tests/unit/lsp/bohriumRegistryAlignment.test.ts
@@ -1,0 +1,87 @@
+/**
+ * OpenQC ↔ Bohrium registry alignment unit tests.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/194
+ */
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getLspDiagnosticReadiness, listBundledLspServers } from '../../../src/lsp/registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const CODE_ROOT = path.resolve(REPO_ROOT, '..');
+const DEFAULT_BOHRIUM_REGISTRY = path.join(
+  CODE_ROOT,
+  'bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml'
+);
+const ALIGNMENT_SCRIPT = path.join(REPO_ROOT, 'scripts/check-bohrium-registry-alignment.mjs');
+
+function loadBohriumBackends(registryPath: string): Array<{
+  id: string;
+  agent_cli?: string;
+}> {
+  const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')) as {
+    backends: Array<{ id: string; agent_cli?: string }>;
+  };
+  return registry.backends;
+}
+
+describe('OpenQC ↔ Bohrium registry alignment', () => {
+  const openqcServers = listBundledLspServers();
+  const registryPath = process.env.BOHRIUM_LSP_REGISTRY ?? DEFAULT_BOHRIUM_REGISTRY;
+  const registryExists = fs.existsSync(registryPath);
+
+  (registryExists ? it : it.skip)(
+    'keeps OpenQC registry ids aligned with Bohrium backend ids',
+    () => {
+      const bohriumBackends = loadBohriumBackends(registryPath);
+      const openqcIds = openqcServers.map(server => server.id).sort();
+      const bohriumIds = bohriumBackends.map(backend => backend.id).sort();
+
+      expect(openqcIds).toEqual(bohriumIds);
+    }
+  );
+
+  (registryExists ? it : it.skip)(
+    'keeps agent CLI names aligned between OpenQC readiness and Bohrium registry',
+    () => {
+      const bohriumById = new Map(
+        loadBohriumBackends(registryPath).map(backend => [backend.id, backend])
+      );
+
+      for (const server of openqcServers) {
+        const readiness = getLspDiagnosticReadiness(server.id);
+        const backend = bohriumById.get(server.id);
+        expect(backend).toBeDefined();
+        expect(readiness?.agentCli).toBe(backend?.agent_cli);
+      }
+    }
+  );
+
+  it('exposes a local alignment script with JSON output', () => {
+    const output = execFileSync(
+      process.execPath,
+      [ALIGNMENT_SCRIPT, '--json', '--bohrium-registry', registryPath],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+
+    const report = JSON.parse(output) as {
+      ok: boolean;
+      surfaces: { openqc: { backendCount: number }; bohrium: { backendCount: number } };
+      summary: { missingInBohrium: string[]; excessInBohrium: string[] };
+    };
+
+    expect(report.surfaces.openqc.backendCount).toBe(17);
+    if (registryExists) {
+      expect(report.surfaces.bohrium.backendCount).toBe(17);
+      expect(report.summary.missingInBohrium).toEqual([]);
+      expect(report.summary.excessInBohrium).toEqual([]);
+      expect(report.ok).toBe(true);
+    }
+  });
+});

--- a/tests/unit/lsp/bohriumRegistryAlignment.test.ts
+++ b/tests/unit/lsp/bohriumRegistryAlignment.test.ts
@@ -60,9 +60,26 @@ describe('OpenQC ↔ Bohrium registry alignment', () => {
   );
 
   it('exposes a local alignment script with JSON output', () => {
+    const tempDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-bohrium-registry-'));
+    const tempRegistry = path.join(tempDir, 'lsp_backends.yaml');
+    const readinessById = new Map(
+      openqcServers.map(server => [server.id, getLspDiagnosticReadiness(server.id)])
+    );
+    fs.writeFileSync(
+      tempRegistry,
+      JSON.stringify({
+        backends: openqcServers.map(server => ({
+          id: server.id,
+          software: server.languageId,
+          agent_cli: readinessById.get(server.id)?.agentCli,
+        })),
+      }),
+      'utf8'
+    );
+
     const output = execFileSync(
       process.execPath,
-      [ALIGNMENT_SCRIPT, '--json', '--bohrium-registry', registryPath],
+      [ALIGNMENT_SCRIPT, '--json', '--bohrium-registry', tempRegistry],
       {
         cwd: REPO_ROOT,
         encoding: 'utf8',
@@ -77,11 +94,11 @@ describe('OpenQC ↔ Bohrium registry alignment', () => {
     };
 
     expect(report.surfaces.openqc.backendCount).toBe(17);
-    if (registryExists) {
-      expect(report.surfaces.bohrium.backendCount).toBe(17);
-      expect(report.summary.missingInBohrium).toEqual([]);
-      expect(report.summary.excessInBohrium).toEqual([]);
-      expect(report.ok).toBe(true);
-    }
+    expect(report.surfaces.bohrium.backendCount).toBe(17);
+    expect(report.summary.missingInBohrium).toEqual([]);
+    expect(report.summary.excessInBohrium).toEqual([]);
+    expect(report.ok).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Add `scripts/check-bohrium-registry-alignment.mjs` and `npm run lsp:check-bohrium-registry` to compare OpenQC bundled registry ids/agent CLIs with the Bohrium skill backend registry.
- Document the editor-integration vs skill-router distinction in `docs/LSP_COMPATIBILITY.md` release verification steps.
- Add unit tests that fail on missing/excess backend ids or agent CLI drift.

Fixes #194

## Test Plan
- [x] `npm run lsp:check-bohrium-registry`
- [x] `npx jest --runTestsByPath tests/unit/lsp/registry.test.ts tests/unit/lsp/bohriumRegistryAlignment.test.ts`
- [x] `python3 ../bohrium_skills/bohrium_skills/lsp-skills/scripts/lsp_skill_probe.py --root /Users/yhm/Desktop/code/.worktrees-lsp-latest --json` reports 17 backends once bohrium_skills PR is merged

Made with [Cursor](https://cursor.com)
