### PR TITLE
feat: add DP-GEN LSP to OpenQC family checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,39 @@
+name: Agent Task
+description: A task that can be implemented by an AI coding agent
+title: "[Agent Task]: "
+labels: ["agent-ready", "needs-plan"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be changed?
+      placeholder: Describe the observable change.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Bullet list of observable success conditions.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Required Tests
+      description: What tests must be added, changed, or run?
+      placeholder: |
+        - [ ] Add or update a failing test first
+        - [ ] Run unit tests
+        - [ ] Run lint/typecheck
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: What must not be changed?

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Report a reproducible bug
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Regression Test
+      description: What test should prevent this from recurring?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security issue
+    url: https://github.com
+    about: Do not file public security reports. Use the repository security policy if available.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+name: Feature Request
+description: Request a new capability or behavior change
+title: "[Feature]: "
+labels: ["enhancement", "needs-plan"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or developer problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the desired behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Required Tests
+      description: What tests or checks must pass?
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-Goals
+      description: What should stay out of scope?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Linked Issue
+
+Fixes #
+
+## Summary
+
+-
+
+## TDD Evidence
+
+- [ ] Added or updated a failing test before implementation
+- [ ] Confirmed the test fails on old code, or documented why this is not applicable
+- [ ] Confirmed the test passes after implementation
+
+## Checks
+
+- [ ] `make format`
+- [ ] `make lint`
+- [ ] `make typecheck`
+- [ ] `make test`
+- [ ] `make check`
+
+## Risk
+
+- Risk level: low / medium / high
+- Compatibility impact:
+
+## Rollback Plan
+
+-

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,21 @@
+name: Agent Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  governance-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify agent guidance exists
+        run: |
+          set -euo pipefail
+          test -f AGENTS.md
+          test -f .github/PULL_REQUEST_TEMPLATE.md
+          echo "Agent guidance files are present. Human or external AI review can use the PR contract as input."

--- a/.github/workflows/pr-contract.yml
+++ b/.github/workflows/pr-contract.yml
@@ -1,0 +1,61 @@
+name: PR Contract
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check PR body contract
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          printf '%s\n' "$PR_BODY" | grep -E "(Fixes|Closes|Resolves) #[0-9]+" >/dev/null \
+            || { echo "PR body must include Fixes/Closes/Resolves #<issue-number>"; exit 1; }
+
+          printf '%s\n' "$PR_BODY" | grep -E "(TDD Evidence|Tests|Test Plan|No-test justification)" >/dev/null \
+            || { echo "PR body must include test evidence or a no-test justification"; exit 1; }
+
+          if printf '%s\n' "$PR_HEAD" | grep -E '^agent/issue-[0-9]+-' >/dev/null; then
+            echo "Agent branch naming is valid: $PR_HEAD"
+          else
+            echo "Non-agent or legacy branch name: $PR_HEAD"
+          fi
+
+      - name: Require tests or explicit no-test justification
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          changed="$(git diff --name-only "origin/${BASE_REF}"...HEAD)"
+          printf '%s\n' "$changed"
+
+          code_changed="$(printf '%s\n' "$changed" | grep -E '\.(py|ts|tsx|js|jsx|rs)$' || true)"
+          if [ -z "$code_changed" ]; then
+            echo "No source-code changes detected."
+            exit 0
+          fi
+
+          test_changed="$(printf '%s\n' "$changed" | grep -E '(^tests/|/tests/|test_|_test\.|\.spec\.|\.test\.)' || true)"
+          if [ -n "$test_changed" ]; then
+            echo "Test changes detected."
+            exit 0
+          fi
+
+          printf '%s\n' "$PR_BODY" | grep -Ei "no-test justification|docs-only|config-only|refactor-only" >/dev/null \
+            || { echo "Code PRs require test changes or explicit no-test justification."; exit 1; }

--- a/.governance-kit.yml
+++ b/.governance-kit.yml
@@ -1,0 +1,17 @@
+version: 1
+source: repo-governance-kit
+profile: agent-ready-lsp
+standard_commands:
+  install: make install
+  format: make format
+  lint: make lint
+  typecheck: make typecheck
+  test: make test
+  check: make check
+branch_policy:
+  agent: agent/issue-<number>-<slug>
+  worktree: .worktrees/issue-<number>-<slug>
+pr_contract:
+  issue_link_required: true
+  test_evidence_required: true
+  no_test_justification_allowed: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: detect-private-key

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,7 @@
 .vscode/**
 .vscode-test/**
+.worktrees/**
+coverage/**
 src/**
 .gitignore
 .yarnrc
@@ -15,6 +17,12 @@ node_modules/**
 !node_modules/vscode-languageclient/**
 !node_modules/vscode-languageserver-protocol/**
 !node_modules/vscode-languageserver-types/**
+!node_modules/vscode-jsonrpc/**
+!node_modules/vscode-languageserver-textdocument/**
+!node_modules/minimatch/**
+!node_modules/semver/**
+!node_modules/brace-expansion/**
+!node_modules/balanced-match/**
 .git/**
 .github/**
 **/.gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,17 @@ git worktree prune
 # 3. (Optional) Delete the local branch, as it's been merged
 git branch -d feat/new-ui
 ```
+
+
+<!-- repo-governance-kit:agent-ready-v1 -->
+
+## Agent-Ready Governance
+
+This repository follows the shared Repo Governance Kit contract.
+
+- Work one GitHub issue per branch.
+- Use `agent/issue-<number>-<slug>` for agent branches and `.worktrees/issue-<number>-<slug>` for local worktrees.
+- Keep PRs tied to an issue with `Fixes #<issue-number>`.
+- Before opening a PR, run `make format`, `make lint`, `make typecheck`, `make test`, and `make check`.
+- Keep tests and user-facing documentation synchronized with behavior changes.
+- Do not weaken checks, rewrite unrelated files, or commit secrets/generated caches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,3 +416,12 @@ Contributors are recognized in:
 - GitHub contributors page
 
 Thank you for contributing! 🎉
+
+
+<!-- repo-governance-kit:contributing-v1 -->
+
+## Agent-Ready Issue and PR Contract
+
+Agent-ready work must have a GitHub issue with a goal, acceptance criteria, required tests, and out-of-scope notes. Branches should use `agent/issue-<number>-<slug>`, and PR bodies must include `Fixes #<issue-number>`.
+
+Before requesting review, run `make format`, `make lint`, `make typecheck`, `make test`, and `make check`. Code changes should include tests or an explicit no-test justification in the PR body.

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,16 @@ vscode-publish: ## 发布 VS Code 扩展（需要令牌）
 
 dev: watch ## 启动开发模式（监听文件变化）
 
-check: lint format-check test ## 运行完整检查（lint + 格式检查 + 测试）
+check: lint typecheck format-check test ## 运行完整检查（lint + typecheck + 格式检查 + 测试）
 
 pr-ready: format lint test ## 准备 PR（格式化 + lint + 测试）
 	@echo "$(GREEN)PR is ready!$(RESET)"
+
+# repo-governance-kit:standard-targets-v1
+.PHONY: install format lint typecheck test check cleanup-merged
+
+typecheck:
+	bash scripts/typecheck.sh
+
+cleanup-merged:
+	bash scripts/cleanup_merged_worktrees.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **VS Code integration for computational chemistry LSPs**
 
-*Syntax, file detection, visualization entry points, and LSP startup for 16 computational chemistry and molecular-simulation formats*
+_Syntax, file detection, visualization entry points, and LSP startup for 17 computational chemistry and molecular-simulation formats_
 
 [![Install](https://img.shields.io/badge/VS%20Code-Install-blue?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=newtontech.openqc)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -29,55 +29,58 @@ OpenQC is the VS Code-facing workspace for the newtontech computational chemistr
 
 The repository root is the canonical VS Code extension package root. Development, tests, packaging, and Marketplace publishing should use the root `package.json`; stale nested extension package roots are not maintained.
 
-OpenQC currently wires **16 bundled LSP integrations** for computational chemistry, materials, and molecular-simulation workflows:
+OpenQC currently wires **17 bundled LSP integrations** for computational chemistry, materials, and molecular-simulation workflows:
 
 ### Latest LSP Status
 
 OpenQC tracks latest LSP support by the upstream default branch recorded in `src/lsp/registry.ts`. Run `npm run lsp:check-latest` before release or PR handoff to compare local sibling checkouts with the configured remote branch heads. If the main `cp2k-lsp-enhanced` checkout has unrelated local work, OpenQC can use `.worktrees-lsp-latest/cp2k-lsp-enhanced` for the latest CP2K LSP without overwriting that checkout.
 
+For local VS Code smoke testing, run `npm run lsp:install-latest` from this repository. The installer refreshes managed copies under `/Users/yhm/Desktop/code/.lsp-latest/`, mirrors latest verification checkouts under `/Users/yhm/Desktop/code/.worktrees-lsp-latest/`, installs Python LSPs into `.lsp-latest/.venv`, and links commands into `~/.local/bin` or `~/.cargo/bin`. It does not reset or pull over user-owned sibling repositories under `/Users/yhm/Desktop/code/<repo>`.
+
 ### LSP Alignment Matrix
 
 > For per-server parser status, diagnostics, completion, hover, formatting, code actions, and build commands, see the **[LSP Compatibility Matrix](docs/LSP_COMPATIBILITY.md)**.
 
-| Format | Standalone LSP | OpenQC role |
-|--------|----------------|-------------|
-| ABACUS | `newtontech/abacus-lsp` | Language contribution, syntax, file detection, LSP startup |
-| ABINIT | `newtontech/abinit-lsp` | Language contribution, syntax, file detection, LSP startup |
-| CIF | `newtontech/cif-lsp` | Language contribution, syntax, file detection, LSP startup |
-| CP2K | `newtontech/cp2k-lsp-enhanced` | Language contribution, syntax, file detection, LSP startup |
-| VASP | `newtontech/VASP-LSP` | Language contribution, syntax, file detection, LSP startup |
-| Gaussian | `newtontech/gaussian-lsp` | Language contribution, syntax, file detection, LSP startup |
-| ORCA | `newtontech/orca-lsp` | Language contribution, syntax, file detection, LSP startup |
-| GAMESS (US) | `newtontech/gamess-lsp` | Language contribution, syntax, file detection, LSP startup |
-| Quantum ESPRESSO | `newtontech/qe-lsp` | Language contribution, syntax, file detection, LSP startup |
-| NWChem | `newtontech/nwchem-lsp` | Language contribution, syntax, file detection, LSP startup |
-| GPUMD | `newtontech/gpumd-lsp` | Language contribution, syntax, file detection, LSP startup |
-| GROMACS | `newtontech/gromacs-lsp` | Language contribution, syntax, file detection, LSP startup |
-| LAMMPS | `newtontech/lammps-lsp` | Language contribution, syntax, file detection, LSP startup |
-| MLIP | `newtontech/mlip-lsp` | Language contribution, syntax, file detection, LSP startup |
-| PyATB | `newtontech/pyatb-lsp` | Language contribution, syntax, file detection, LSP startup |
-| PySCF | `newtontech/pyscf-lsp` | Language contribution, syntax, file detection, LSP startup |
+| Format           | Standalone LSP                 | OpenQC role                                                |
+| ---------------- | ------------------------------ | ---------------------------------------------------------- |
+| ABACUS           | `newtontech/abacus-lsp`        | Language contribution, syntax, file detection, LSP startup |
+| ABINIT           | `newtontech/abinit-lsp`        | Language contribution, syntax, file detection, LSP startup |
+| CIF              | `newtontech/cif-lsp`           | Language contribution, syntax, file detection, LSP startup |
+| CP2K             | `newtontech/cp2k-lsp-enhanced` | Language contribution, syntax, file detection, LSP startup |
+| VASP             | `newtontech/VASP-LSP`          | Language contribution, syntax, file detection, LSP startup |
+| Gaussian         | `newtontech/gaussian-lsp`      | Language contribution, syntax, file detection, LSP startup |
+| ORCA             | `newtontech/orca-lsp`          | Language contribution, syntax, file detection, LSP startup |
+| GAMESS (US)      | `newtontech/gamess-lsp`        | Language contribution, syntax, file detection, LSP startup |
+| Quantum ESPRESSO | `newtontech/qe-lsp`            | Language contribution, syntax, file detection, LSP startup |
+| NWChem           | `newtontech/nwchem-lsp`        | Language contribution, syntax, file detection, LSP startup |
+| GPUMD            | `newtontech/gpumd-lsp`         | Language contribution, syntax, file detection, LSP startup |
+| GROMACS          | `newtontech/gromacs-lsp`       | Language contribution, syntax, file detection, LSP startup |
+| LAMMPS           | `newtontech/lammps-lsp`        | Language contribution, syntax, file detection, LSP startup |
+| MLIP             | `newtontech/mlip-lsp`          | Language contribution, syntax, file detection, LSP startup |
+| PyATB            | `newtontech/pyatb-lsp`         | Language contribution, syntax, file detection, LSP startup |
+| PySCF            | `newtontech/pyscf-lsp`         | Language contribution, syntax, file detection, LSP startup |
+| DP-GEN           | `newtontech/dpgen-lsp`         | Language contribution, syntax, file detection, LSP startup |
 
 ### Supported Integrations
 
-| Software | File Types | Features |
-|----------|-----------|----------|
-| **ABACUS** | `INPUT`, `STRU`, `KPT` | LSP startup + syntax + file detection |
-| **ABINIT** | `.abi`, `.abinit` | LSP startup + syntax + file detection |
-| **CIF** | `.cif` | LSP startup + syntax + file detection |
-| **CP2K** | `.inp` | LSP startup + syntax + file detection |
-| **VASP** | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR` | LSP startup + syntax + file detection |
-| **Gaussian** | `.com`, `.gjf` | LSP startup + syntax + file detection |
-| **ORCA** | `.inp` | LSP startup + syntax + file detection |
-| **Quantum ESPRESSO** | `.in`, `.pw.in`, `.relax.in` | LSP startup + syntax + file detection |
-| **GAMESS (US)** | `.inp` | LSP startup + syntax + file detection |
-| **NWChem** | `.nw`, `.nwinp` | LSP startup + syntax + file detection |
-| **GPUMD** | `run.in`, `nep.in` | LSP startup + syntax + file detection |
-| **GROMACS** | `.top`, `.itp`, `.mdp`, `.gro` | LSP startup + syntax + file detection |
-| **LAMMPS** | `.lmp`, `.lammps`, `.lmps` | LSP startup + syntax + file detection |
-| **MLIP** | `.mlip.json`, `.mlip.yaml`, `.mlip.yml` | LSP startup + syntax + file detection |
-| **PyATB** | `.pyatb.py`, `run_pyatb.py` | LSP startup + syntax + file detection |
-| **PySCF** | `.pyscf.py`, `run_pyscf.py` | LSP startup + syntax + file detection |
+| Software             | File Types                              | Features                              |
+| -------------------- | --------------------------------------- | ------------------------------------- |
+| **ABACUS**           | `INPUT`, `STRU`, `KPT`                  | LSP startup + syntax + file detection |
+| **ABINIT**           | `.abi`, `.abinit`                       | LSP startup + syntax + file detection |
+| **CIF**              | `.cif`                                  | LSP startup + syntax + file detection |
+| **CP2K**             | `.inp`                                  | LSP startup + syntax + file detection |
+| **VASP**             | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`  | LSP startup + syntax + file detection |
+| **Gaussian**         | `.com`, `.gjf`                          | LSP startup + syntax + file detection |
+| **ORCA**             | `.inp`                                  | LSP startup + syntax + file detection |
+| **Quantum ESPRESSO** | `.in`, `.pw.in`, `.relax.in`            | LSP startup + syntax + file detection |
+| **GAMESS (US)**      | `.inp`                                  | LSP startup + syntax + file detection |
+| **NWChem**           | `.nw`, `.nwinp`                         | LSP startup + syntax + file detection |
+| **GPUMD**            | `run.in`, `nep.in`                      | LSP startup + syntax + file detection |
+| **GROMACS**          | `.top`, `.itp`, `.mdp`, `.gro`          | LSP startup + syntax + file detection |
+| **LAMMPS**           | `.lmp`, `.lammps`, `.lmps`              | LSP startup + syntax + file detection |
+| **MLIP**             | `.mlip.json`, `.mlip.yaml`, `.mlip.yml` | LSP startup + syntax + file detection |
+| **PyATB**            | `.pyatb.py`, `run_pyatb.py`             | LSP startup + syntax + file detection |
+| **PySCF**            | `.pyscf.py`, `run_pyscf.py`             | LSP startup + syntax + file detection |
 
 ### 🚧 Coming Soon
 
@@ -157,7 +160,8 @@ Use the 📊 icon to plot your calculation data.
 ## 🎨 Gallery
 
 ### Molecular Visualization
-*See your molecules come to life with interactive 3D rendering*
+
+_See your molecules come to life with interactive 3D rendering_
 
 ```
 ┌─────────────────────────────────────┐
@@ -172,7 +176,8 @@ Use the 📊 icon to plot your calculation data.
 ```
 
 ### Syntax Highlighting
-*Your input files, beautifully formatted*
+
+_Your input files, beautifully formatted_
 
 ```
 &FORCE_EVAL
@@ -213,21 +218,25 @@ OpenQC works out of the box, but you can customize it:
 ## 💡 Use Cases
 
 ### For Computational Chemists
+
 - **Prepare inputs** faster with syntax highlighting and validation
 - **Visualize structures** before submitting jobs
 - **Debug convergence** issues with interactive plots
 
 ### For Experimentalists
+
 - **Inspect computational models** shared by collaborators
 - **Understand output** from quantum chemistry calculations
 - **Prepare structures** for computational studies
 
 ### For Students & Educators
+
 - **Learn quantum chemistry** with visual feedback
 - **Understand input formats** with syntax highlighting
 - **Explore molecular systems** interactively
 
 ### For Software Developers
+
 - **Build tools** on top of OpenQC's parsing capabilities
 - **Integrate** with your computational workflows
 - **Extend** support for additional software
@@ -237,18 +246,21 @@ OpenQC works out of the box, but you can customize it:
 ## 🌟 What's Coming?
 
 ### Near Term (v2.1)
+
 - [ ] Format conversion between different quantum chemistry formats
 - [ ] Batch processing — visualize multiple structures at once
 - [ ] Export high-resolution images for publications
 - [ ] Custom color schemes and rendering options
 
 ### Medium Term (v2.5)
+
 - [ ] Real-time calculation monitoring
 - [ ] Remote workflow documentation using existing VS Code capabilities
 - [ ] Parameter templates and wizards
 - [ ] Community examples for common calculation workflows
 
 ### Long Term (v3.0)
+
 - [ ] AI-powered parameter optimization
 - [ ] Natural language input generation
 - [ ] Workflow automation

--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -2,59 +2,74 @@
 
 This matrix is the OpenQC-facing contract for the newtontech LSP family. The source of truth is `src/lsp/registry.ts`; `package.json`, language configurations, TextMate grammars, and this document must stay aligned with that registry.
 
-Last updated: 2026-06-11. Latest support is tracked against each repository default branch unless a release tag is listed below. OpenQC does not pin old server binaries; it launches the configured executable or sibling local repository, so users can run the newest server available in their environment.
+Last updated: 2026-06-15. Latest support is tracked against each repository default branch unless a release tag is listed below. OpenQC does not pin old server binaries; it launches the configured executable or sibling local repository, so users can run the newest server available in their environment.
 
 ## Quick Reference
 
-| LSP Server | Language ID | Default Branch | Latest Release/Local Version | Domain | File Types | Stability | OpenQC Integration |
-|------------|-------------|----------------|------------------------------|--------|------------|-----------|--------------------|
-| [newtontech/abacus-lsp](https://github.com/newtontech/abacus-lsp) | `abacus` | `main` | 0.1.0 | ABACUS | `INPUT`, `STRU`, `KPT` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/abinit-lsp](https://github.com/newtontech/abinit-lsp) | `abinit` | `main` | 0.1.0 | ABINIT | `.abi`, `.abinit` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/cif-lsp](https://github.com/newtontech/cif-lsp) | `cif` | `master` | v1.0.2 | CIF | `.cif` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | `cp2k` | `develop` | v0.9.1 | CP2K | `.inp` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP) | `vasp` | `main` | 0.4.4 | VASP | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`, `CONTCAR`, `OSZICAR`, `OUTCAR`, `vasprun.xml` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp) | `gaussian` | `main` | 0.2.11 | Gaussian | `.gjf`, `.com` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp) | `orca` | `main` | 0.5.4 | ORCA | `.inp` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp) | `qe` | `main` | 0.1.0 | Quantum ESPRESSO | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp) | `gamess` | `main` | 0.1.0 | GAMESS | `.inp` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp) | `nwchem` | `main` | v0.3.0 / local 0.5.0 | NWChem | `.nw`, `.nwinp` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/gpumd-lsp](https://github.com/newtontech/gpumd-lsp) | `gpumd` | `main` | 0.1.0 | GPUMD | `run.in`, `nep.in` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/gromacs-lsp](https://github.com/newtontech/gromacs-lsp) | `gromacs` | `main` | v0.0.2 | GROMACS | `.top`, `.itp`, `.mdp`, `.gro` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/lammps-lsp](https://github.com/newtontech/lammps-lsp) | `lammps` | `master` | 0.1.0-pre-release-3 | LAMMPS | `.lmp`, `.lammps`, `.lmps`, `in.lammps` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/mlip-lsp](https://github.com/newtontech/mlip-lsp) | `mlip` | `main` | 0.1.0 | MLIP | `.mlip.json`, `.mlip.yaml`, `.mlip.yml`, `mlip.json`, `mlip.yaml`, `mlip.yml` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/pyatb-lsp](https://github.com/newtontech/pyatb-lsp) | `pyatb` | `main` | 0.1.0 | PyATB | `.pyatb.py`, `run_pyatb.py` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/pyscf-lsp](https://github.com/newtontech/pyscf-lsp) | `pyscf` | `main` | 0.1.0 | PySCF | `.pyscf.py`, `run_pyscf.py` | Experimental | Syntax, file detection, direct LSP startup |
+| LSP Server                                                                      | Language ID | Default Branch | Latest Release/Local Version | Domain           | File Types                                                                                            | Stability    | OpenQC Integration                         |
+| ------------------------------------------------------------------------------- | ----------- | -------------- | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------ |
+| [newtontech/abacus-lsp](https://github.com/newtontech/abacus-lsp)               | `abacus`    | `main`         | 0.1.0                        | ABACUS           | `INPUT`, `STRU`, `KPT`                                                                                | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/abinit-lsp](https://github.com/newtontech/abinit-lsp)               | `abinit`    | `main`         | 0.1.0                        | ABINIT           | `.abi`, `.abinit`                                                                                     | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/cif-lsp](https://github.com/newtontech/cif-lsp)                     | `cif`       | `master`       | v1.0.2                       | CIF              | `.cif`                                                                                                | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | `cp2k`      | `develop`      | v0.9.1                       | CP2K             | `.inp`                                                                                                | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP)                   | `vasp`      | `main`         | 0.4.4                        | VASP             | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`, `CONTCAR`, `OSZICAR`, `OUTCAR`, `vasprun.xml`                 | Stable       | Syntax, file detection, direct LSP startup |
+| [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp)           | `gaussian`  | `main`         | 0.2.11                       | Gaussian         | `.gjf`, `.com`                                                                                        | Stable       | Syntax, file detection, direct LSP startup |
+| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp)                   | `orca`      | `main`         | 0.5.4                        | ORCA             | `.inp`                                                                                                | Stable       | Syntax, file detection, direct LSP startup |
+| [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp)                       | `qe`        | `main`         | 0.1.0                        | Quantum ESPRESSO | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | Stable       | Syntax, file detection, direct LSP startup |
+| [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp)               | `gamess`    | `main`         | 0.1.0                        | GAMESS           | `.inp`                                                                                                | Stable       | Syntax, file detection, direct LSP startup |
+| [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp)               | `nwchem`    | `main`         | v0.3.0 / local 0.5.0         | NWChem           | `.nw`, `.nwinp`                                                                                       | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/gpumd-lsp](https://github.com/newtontech/gpumd-lsp)                 | `gpumd`     | `main`         | 0.1.0                        | GPUMD            | `run.in`, `nep.in`                                                                                    | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/gromacs-lsp](https://github.com/newtontech/gromacs-lsp)             | `gromacs`   | `main`         | v0.0.2                       | GROMACS          | `.top`, `.itp`, `.mdp`, `.gro`                                                                        | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/lammps-lsp](https://github.com/newtontech/lammps-lsp)               | `lammps`    | `master`       | 0.1.0-pre-release-3          | LAMMPS           | `.lmp`, `.lammps`, `.lmps`, `in.lammps`                                                               | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/mlip-lsp](https://github.com/newtontech/mlip-lsp)                   | `mlip`      | `main`         | 0.1.0                        | MLIP             | `.mlip.json`, `.mlip.yaml`, `.mlip.yml`, `mlip.json`, `mlip.yaml`, `mlip.yml`                         | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/pyatb-lsp](https://github.com/newtontech/pyatb-lsp)                 | `pyatb`     | `main`         | 0.1.0                        | PyATB            | `.pyatb.py`, `run_pyatb.py`                                                                           | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/pyscf-lsp](https://github.com/newtontech/pyscf-lsp)                 | `pyscf`     | `main`         | 0.1.0                        | PySCF            | `.pyscf.py`, `run_pyscf.py`                                                                           | Experimental | Syntax, file detection, direct LSP startup |
+| [newtontech/dpgen-lsp](https://github.com/newtontech/dpgen-lsp)                 | `dpgen`     | `main`         | 0.1.0                        | DP-GEN           | `param.json`, `machine.json`                                                                          | Experimental | Syntax, file detection, direct LSP startup |
 
 ## Diagnostic Engine v1 Readiness
 
-| LSP Server | Diagnostic Engine | Agent CLI | Rich Diagnostics | Closed Loop |
-|------------|-------------------|-----------|------------------|-------------|
-| `abacus-lsp` | v1 | `abacus-lsp-tool` | Rich JSON check payload | Planned |
-| `abinit-lsp` | v1 | `abinit-lsp-tool` | Rich JSON check payload | Planned |
-| `cif-lsp` | v1 | `cif-lsp-tool` | Rich JSON check payload | Planned |
-| `cp2k-lsp-enhanced` | v1 | `cp2k-lsp-tool` | Rich JSON check payload | Partial |
-| `gamess-lsp` | v1 | `gamess-lsp-tool` | Rich JSON check payload | Planned |
-| `gaussian-lsp` | v1 | `gaussian-lsp-tool` | Rich JSON check payload | Planned |
-| `gpumd-lsp` | v1 | `gpumd-lsp-tool` | Rich JSON check payload | Planned |
-| `gromacs-lsp` | v1 | `gromacs-lsp-tool` | Rich JSON check payload | Planned |
-| `lammps-lsp` | v1 | `lammps-lsp-tool` | Rich JSON check payload | Partial |
-| `mlip-lsp` | v1 | `mlip-lsp-tool` | Rich JSON check payload | Planned |
-| `nwchem-lsp` | v1 | `nwchem-lsp-tool` | Rich JSON check payload | Planned |
-| `orca-lsp` | v1 | `orca-lsp-tool` | Rich JSON check payload | Planned |
-| `pyatb-lsp` | v1 | `pyatb-lsp-tool` | Rich JSON check payload | Planned |
-| `pyscf-lsp` | v1 | `pyscf-lsp-tool` | Rich JSON check payload | Planned |
-| `qe-lsp` | v1 | `qe-lsp-tool` | Rich JSON check payload | Partial |
-| `vasp-lsp` | v1 | `vasp-lsp-tool` | Rich JSON check payload | Partial |
+| LSP Server          | Diagnostic Engine | Agent CLI           | Rich Diagnostics        | Closed Loop |
+| ------------------- | ----------------- | ------------------- | ----------------------- | ----------- |
+| `abacus-lsp`        | v1                | `abacus-lsp-tool`   | Rich JSON check payload | Planned     |
+| `abinit-lsp`        | v1                | `abinit-lsp-tool`   | Rich JSON check payload | Planned     |
+| `cif-lsp`           | v1                | `cif-lsp-tool`      | Rich JSON check payload | Planned     |
+| `cp2k-lsp-enhanced` | v1                | `cp2k-lsp-tool`     | Rich JSON check payload | Partial     |
+| `dpgen-lsp`         | v1                | `dpgen-lsp-tool`    | Rich JSON check payload | Planned     |
+| `gamess-lsp`        | v1                | `gamess-lsp-tool`   | Rich JSON check payload | Planned     |
+| `gaussian-lsp`      | v1                | `gaussian-lsp-tool` | Rich JSON check payload | Planned     |
+| `gpumd-lsp`         | v1                | `gpumd-lsp-tool`    | Rich JSON check payload | Planned     |
+| `gromacs-lsp`       | v1                | `gromacs-lsp-tool`  | Rich JSON check payload | Planned     |
+| `lammps-lsp`        | v1                | `lammps-lsp-tool`   | Rich JSON check payload | Partial     |
+| `mlip-lsp`          | v1                | `mlip-lsp-tool`     | Rich JSON check payload | Planned     |
+| `nwchem-lsp`        | v1                | `nwchem-lsp-tool`   | Rich JSON check payload | Planned     |
+| `orca-lsp`          | v1                | `orca-lsp-tool`     | Rich JSON check payload | Planned     |
+| `pyatb-lsp`         | v1                | `pyatb-lsp-tool`    | Rich JSON check payload | Planned     |
+| `pyscf-lsp`         | v1                | `pyscf-lsp-tool`    | Rich JSON check payload | Planned     |
+| `qe-lsp`            | v1                | `qe-lsp-tool`       | Rich JSON check payload | Partial     |
+| `vasp-lsp`          | v1                | `vasp-lsp-tool`     | Rich JSON check payload | Partial     |
+
+## Capability Manifest Contract
+
+Every sibling LSP repository must expose `lsp-capabilities.json` at its repository root. OpenQC treats `src/lsp/registry.ts` as the bundled product default and treats each capability manifest as the current repository fact surface for agent-facing features.
+
+The manifest records the registry id, language id, executable, default branch, file patterns, blocking policy, agent CLI operations, DiagnosticEnvelope schema path, LLM Wiki paths, smoke fixture paths, output-log patterns, and OpenQC context contract. The required agent CLI operations are `capabilities`, `check`, `context`, `complete`, `hover`, `symbols`, and `fix`, all with JSON output.
+
+Run these checks before release:
+
+```bash
+npm run lsp:check-family
+npm run lsp:check-latest
+```
 
 ## OpenQC Integration Guarantees
 
-| Capability | OpenQC guarantee |
-|------------|------------------|
-| Language contribution | Every registry entry has a matching `contributes.languages` item in `package.json`. |
-| Grammar contribution | Every language has a TextMate grammar under `syntaxes/`. |
-| Configuration | Every language exposes `enabled`, `path`, `command`, `args`, and `env` settings under `openqc.lsp.<languageId>.*`. |
-| Startup | OpenQC starts the configured command over stdio and can prefer sibling local repositories when no user override is set. |
-| Latest tracking | Every registry entry records the upstream default branch used for latest-version checks. |
+| Capability            | OpenQC guarantee                                                                                                        |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Language contribution | Every registry entry has a matching `contributes.languages` item in `package.json`.                                     |
+| Grammar contribution  | Every language has a TextMate grammar under `syntaxes/`.                                                                |
+| Configuration         | Every language exposes `enabled`, `path`, `command`, `args`, and `env` settings under `openqc.lsp.<languageId>.*`.      |
+| Startup               | OpenQC starts the configured command over stdio and can prefer sibling local repositories when no user override is set. |
+| Latest tracking       | Every registry entry records the upstream default branch used for latest-version checks.                                |
 
 ## Release Verification
 
@@ -62,10 +77,11 @@ Before publishing a VSIX or Marketplace release:
 
 1. Run `npm run typecheck`.
 2. Run `npm run test:unit -- --runTestsByPath tests/unit/lsp/registry.test.ts`.
-3. Run `npm run lsp:check-latest` to compare sibling LSP checkouts with each configured remote default-branch HEAD.
-4. Run `OpenQC LSP: Generate Compatibility Report` from VS Code and save the report with the release notes.
-5. For each LSP, smoke test one valid file and one intentionally invalid file on the latest configured executable or sibling repository checkout.
-6. Record the exact LSP version, release tag, or commit SHA used for the release smoke test.
+3. Run `npm run lsp:check-family` to verify every sibling manifest, agent CLI contract, wiki path, and fixture path.
+4. Run `npm run lsp:check-latest` to compare sibling LSP checkouts with each configured remote default-branch HEAD.
+5. Run `OpenQC LSP: Generate Compatibility Report` from VS Code and save the report with the release notes.
+6. For each LSP, smoke test one valid file and one intentionally invalid file on the latest configured executable or sibling repository checkout.
+7. Record the exact LSP version, release tag, or commit SHA used for the release smoke test.
 
 ## Known Limits
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,10 @@ module.exports = {
   },
   roots: ['<rootDir>'],
   testMatch: ['**/tests/**/*.test.ts'],
-  testPathIgnorePatterns: ['<rootDir>/tests/unit/visualizers/ThreeJsRenderer.test.ts'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.worktrees/',
+    '<rootDir>/tests/unit/visualizers/ThreeJsRenderer.test.ts',
+  ],
   moduleNameMapper: {
     '^vscode$': '<rootDir>/tests/mocks/vscode.ts',
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,7 @@ module.exports = {
     '!src/analyzers/**',
     '!src/commands/analyzerCommands.ts',
     '!src/lsp/dslAuthoringContext.ts',
+    '!src/smoke/**',
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'text-summary', 'lcov', 'html'],

--- a/language-configurations/dpgen.json
+++ b/language-configurations/dpgen.json
@@ -1,0 +1,20 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["\"", "\""]
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["\"", "\""]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openqc",
   "displayName": "OpenQC - Quantum Chemistry & Molecular Dynamics Suite",
-  "description": "Parse, visualize, and analyze computational chemistry, materials, and molecular-simulation files with 16 bundled LSP integrations.",
+  "description": "Parse, visualize, and analyze computational chemistry, materials, and molecular-simulation files with 17 bundled LSP integrations.",
   "version": "3.0.7",
   "publisher": "newtontech",
   "engines": {
@@ -30,6 +30,7 @@
     "GROMACS",
     "LAMMPS",
     "PySCF",
+    "DP-GEN",
     "Molpro",
     "Psi4",
     "molecular visualization",
@@ -56,6 +57,7 @@
     "onLanguage:mlip",
     "onLanguage:pyatb",
     "onLanguage:pyscf",
+    "onLanguage:dpgen",
     "onCommand:openqc.startLSP",
     "onCommand:openqc.stopLSP",
     "onCommand:openqc.restartLSP",
@@ -296,6 +298,19 @@
           "run_pyscf.py"
         ],
         "configuration": "./language-configurations/pyscf.json"
+      },
+      {
+        "id": "dpgen",
+        "aliases": [
+          "DP-GEN",
+          "dpgen",
+          "DPGEN"
+        ],
+        "filenames": [
+          "param.json",
+          "machine.json"
+        ],
+        "configuration": "./language-configurations/dpgen.json"
       }
     ],
     "grammars": [
@@ -378,6 +393,11 @@
         "language": "pyscf",
         "scopeName": "source.pyscf",
         "path": "./syntaxes/pyscf.tmLanguage.json"
+      },
+      {
+        "language": "dpgen",
+        "scopeName": "source.dpgen",
+        "path": "./syntaxes/dpgen.tmLanguage.json"
       }
     ],
     "commands": [
@@ -1230,6 +1250,39 @@
           "default": {},
           "description": "Extra environment variables for the PySCF Language Server process"
         },
+        "openqc.lsp.dpgen.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable DP-GEN Language Server"
+        },
+        "openqc.lsp.dpgen.path": {
+          "type": "string",
+          "default": "dpgen-lsp",
+          "description": "Path to DP-GEN Language Server executable (deprecated: use command instead). In Remote SSH, WSL, Dev Containers, or Codespaces this path is resolved inside the extension host environment."
+        },
+        "openqc.lsp.dpgen.command": {
+          "type": "string",
+          "default": "dpgen-lsp",
+          "description": "Command to start the DP-GEN Language Server (executable name or absolute path). In Remote SSH, WSL, Dev Containers, or Codespaces this command runs inside the extension host environment."
+        },
+        "openqc.lsp.dpgen.args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "--stdio"
+          ],
+          "description": "Arguments passed to the DP-GEN Language Server"
+        },
+        "openqc.lsp.dpgen.env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Extra environment variables for the DP-GEN Language Server process"
+        },
         "openqc.languageFeatures.mode": {
           "type": "string",
           "enum": [
@@ -1511,6 +1564,8 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lsp:check-latest": "node scripts/check-lsp-latest.mjs",
+    "lsp:check-family": "node scripts/check-lsp-family.mjs",
+    "lsp:install-latest": "node scripts/install-latest-lsp-fleet.mjs",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-lsp-family.mjs
+++ b/scripts/check-lsp-family.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const codeRoot = resolve(repoRoot, '..');
+const registryPath = join(repoRoot, 'src/lsp/registry.ts');
+const packagePath = join(repoRoot, 'package.json');
+const asJson = process.argv.includes('--json');
+const failOnWarn = process.argv.includes('--fail-on-warn');
+
+const requiredOperations = [
+  'capabilities',
+  'check',
+  'context',
+  'complete',
+  'hover',
+  'symbols',
+  'fix',
+];
+const requiredCapabilities = [
+  'diagnostics',
+  'rich-diagnostics',
+  'completion',
+  'hover',
+  'symbols',
+  'fix-preview',
+  'llm-wiki',
+  'openqc-context',
+];
+
+const registry = readFileSync(registryPath, 'utf8');
+const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+const entries = extractRegistryEntryBlocks(registry).map(block => ({
+  id: readStringField(block, 'id'),
+  repository: readStringField(block, 'repository'),
+  executable: readStringField(block, 'executable'),
+  languageId: readStringField(block, 'languageId'),
+  fileExtensions: parseArrayField(block, 'fileExtensions'),
+  fileNames: parseArrayField(block, 'fileNames'),
+  defaultBranch: readStringField(block, 'defaultBranch'),
+  repoName: readStringField(block, 'repoName'),
+}));
+
+if (entries.length !== 17) {
+  throw new Error(`Expected 17 registry entries, found ${entries.length}`);
+}
+
+const languages = pkg.contributes?.languages ?? [];
+const properties = pkg.contributes?.configuration?.properties ?? {};
+
+const rows = entries.map(entry => checkEntry(entry));
+const failed = rows.filter(row => row.status === 'fail');
+const warned = rows.filter(row => row.status === 'warn');
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        repoRoot,
+        codeRoot,
+        total: rows.length,
+        failed: failed.length,
+        warned: warned.length,
+        rows,
+      },
+      null,
+      2
+    )
+  );
+} else {
+  console.table(
+    rows.map(row => ({
+      id: row.id,
+      language: row.languageId,
+      repo: row.repoExists ? 'yes' : 'no',
+      manifest: row.manifestExists ? 'yes' : 'no',
+      cli: row.agentCli || '-',
+      commit: row.commit || '-',
+      valid: row.smokeFixtures.valid ? 'yes' : 'no',
+      invalid: row.smokeFixtures.invalid ? 'yes' : 'no',
+      logs: row.smokeFixtures.logs ? 'yes' : 'no',
+      status: row.status,
+    }))
+  );
+  for (const row of rows) {
+    if (row.issues.length > 0) {
+      console.log(`\\n${row.id}`);
+      for (const issue of row.issues) {
+        console.log(`  - ${issue}`);
+      }
+    }
+  }
+}
+
+if (failed.length > 0 || (failOnWarn && warned.length > 0)) {
+  process.exitCode = 1;
+}
+
+function checkEntry(entry) {
+  const repoPath = join(codeRoot, entry.repoName);
+  const manifestPath = join(repoPath, 'lsp-capabilities.json');
+  const issues = [];
+  const language = languages.find(item => item.id === entry.languageId);
+  if (!language) {
+    issues.push(`package.json missing language ${entry.languageId}`);
+  }
+  for (const key of [
+    `openqc.lsp.${entry.languageId}.enabled`,
+    `openqc.lsp.${entry.languageId}.path`,
+    `openqc.lsp.${entry.languageId}.command`,
+    `openqc.lsp.${entry.languageId}.args`,
+    `openqc.lsp.${entry.languageId}.env`,
+  ]) {
+    if (!(key in properties)) {
+      issues.push(`package.json missing setting ${key}`);
+    }
+  }
+
+  let manifest = null;
+  if (!existsSync(manifestPath)) {
+    issues.push(`missing ${relative(repoRoot, manifestPath)}`);
+  } else {
+    try {
+      manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      validateManifest(entry, manifest, repoPath, issues);
+    } catch (error) {
+      issues.push(`invalid manifest JSON: ${error.message}`);
+    }
+  }
+
+  const commit = git(['-C', repoPath, 'rev-parse', '--short=12', 'HEAD']);
+  const dirty = git(['-C', repoPath, 'status', '--short']);
+  if (!existsSync(repoPath)) {
+    issues.push(`missing sibling repo ${repoPath}`);
+  }
+
+  const hardFailures = issues.filter(
+    issue =>
+      issue.startsWith('missing sibling repo') ||
+      issue.startsWith('missing ') ||
+      issue.startsWith('invalid manifest JSON') ||
+      issue.includes('must ') ||
+      issue.includes('!=') ||
+      issue.includes('missing operation')
+  );
+
+  return {
+    id: entry.id,
+    languageId: entry.languageId,
+    repoPath,
+    repoExists: existsSync(repoPath),
+    commit,
+    dirty: dirty ? 'yes' : 'no',
+    manifestPath,
+    manifestExists: existsSync(manifestPath),
+    agentCli: manifest?.agentCli?.command,
+    capabilities: manifest?.capabilities ?? [],
+    smokeFixtures: {
+      valid: hasAny(repoPath, manifest?.fixturePaths?.valid ?? []),
+      invalid: hasAny(repoPath, manifest?.fixturePaths?.invalid ?? []),
+      logs: hasAny(repoPath, manifest?.fixturePaths?.logs ?? []),
+    },
+    issues,
+    status: hardFailures.length > 0 ? 'fail' : issues.length > 0 ? 'warn' : 'pass',
+  };
+}
+
+function validateManifest(entry, manifest, repoPath, issues) {
+  if (manifest.schema !== 'OpenQCLspCapabilities')
+    issues.push('schema must be OpenQCLspCapabilities');
+  if (manifest.version !== 1) issues.push('version must be 1');
+  if (manifest.id !== entry.id) issues.push(`manifest id ${manifest.id} != ${entry.id}`);
+  if (manifest.languageId !== entry.languageId)
+    issues.push(`manifest languageId ${manifest.languageId} != ${entry.languageId}`);
+  if (manifest.executable !== entry.executable)
+    issues.push(`manifest executable ${manifest.executable} != ${entry.executable}`);
+  if (manifest.defaultBranch !== entry.defaultBranch)
+    issues.push(`manifest defaultBranch ${manifest.defaultBranch} != ${entry.defaultBranch}`);
+  if (!Array.isArray(manifest.filePatterns) || manifest.filePatterns.length === 0)
+    issues.push('filePatterns must be non-empty');
+  if (!['blocking', 'warning-only'].includes(manifest.blockingPolicy?.mode))
+    issues.push('blockingPolicy.mode must be blocking or warning-only');
+  if (!Array.isArray(manifest.capabilities) || manifest.capabilities.length === 0)
+    issues.push('capabilities must be non-empty');
+  for (const capability of requiredCapabilities) {
+    if (!manifest.capabilities?.includes(capability))
+      issues.push(`missing capability ${capability}`);
+  }
+  if (!manifest.agentCli?.command) issues.push('agentCli.command must be set');
+  for (const operation of requiredOperations) {
+    if (!manifest.agentCli?.operations?.includes(operation))
+      issues.push(`missing operation ${operation}`);
+  }
+  if (manifest.agentCli?.jsonFormat !== true) issues.push('agentCli.jsonFormat must be true');
+  if (manifest.agentCli?.failOnBlocking !== true)
+    issues.push('agentCli.failOnBlocking must be true');
+  for (const key of ['diagnosticSchema']) {
+    if (!manifest[key] || !existsSync(join(repoPath, manifest[key])))
+      issues.push(`missing manifest path ${manifest[key] || key}`);
+  }
+  for (const key of ['plan', 'rawAssets', 'entities', 'concepts', 'synthesis', 'index', 'log']) {
+    const value = manifest.wikiPaths?.[key];
+    if (!value || !existsSync(join(repoPath, value)))
+      issues.push(`missing wiki path ${value || key}`);
+  }
+  if (manifest.openqc?.registryId !== entry.id)
+    issues.push('openqc.registryId must match registry id');
+  if (manifest.openqc?.contextContract !== 'DSLAuthoringContext')
+    issues.push('openqc.contextContract must be DSLAuthoringContext');
+  if (manifest.openqc?.diagnosticEnvelope !== 'DiagnosticEnvelope/v1')
+    issues.push('openqc.diagnosticEnvelope must be DiagnosticEnvelope/v1');
+}
+
+function parseStringArray(text) {
+  return [...text.matchAll(/'([^']+)'/g)].map(match => match[1]);
+}
+
+function extractRegistryEntryBlocks(text) {
+  const start = text.indexOf('const BUNDLED_LSP_SERVERS');
+  const arrayStart = text.indexOf('[', start);
+  const arrayEnd = text.indexOf('] as const', arrayStart);
+  if (start === -1 || arrayStart === -1 || arrayEnd === -1) {
+    return [];
+  }
+  const body = text.slice(arrayStart + 1, arrayEnd);
+  const blocks = [];
+  let depth = 0;
+  let blockStart = -1;
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === '{') {
+      if (depth === 0) {
+        blockStart = index;
+      }
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0 && blockStart !== -1) {
+        blocks.push(body.slice(blockStart, index + 1));
+        blockStart = -1;
+      }
+    }
+  }
+  return blocks.filter(block => block.includes("id: '"));
+}
+
+function parseArrayField(block, field) {
+  const match = block.match(new RegExp(`${field}: \\[([\\s\\S]*?)\\]`));
+  return match ? parseStringArray(match[1]) : [];
+}
+
+function readStringField(block, field) {
+  const match = block.match(new RegExp(`${field}: '([^']+)'`));
+  return match?.[1] ?? '';
+}
+
+function hasAny(repoPath, candidates) {
+  return candidates.some(candidate => existsSync(join(repoPath, candidate)));
+}
+
+function git(args) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}

--- a/scripts/cleanup_merged_worktrees.sh
+++ b/scripts/cleanup_merged_worktrees.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+git fetch --all --prune
+
+if [ ! -d .worktrees ]; then
+  echo "No .worktrees directory; pruning git metadata only."
+  git worktree prune
+  git remote prune origin || true
+  exit 0
+fi
+
+for wt in .worktrees/*; do
+  [ -d "$wt" ] || continue
+  branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+  [ -n "$branch" ] || continue
+
+  pr_json="$(gh pr view "$branch" --json state,mergedAt,headRefName 2>/dev/null || true)"
+  state="$(printf '%s\n' "$pr_json" | python -c 'import json,sys; data=sys.stdin.read().strip(); print(json.loads(data).get("state","") if data else "")' 2>/dev/null || true)"
+
+  if [ "$state" = "MERGED" ]; then
+    echo "Cleaning merged worktree: $wt ($branch)"
+    git worktree remove --force "$wt" || true
+    git branch -d "$branch" || git branch -D "$branch" || true
+  fi
+done
+
+git worktree prune
+git remote prune origin || true

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ran=0
+
+has_npm_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)" "$script"
+}
+
+if has_npm_script format:write; then
+  npm run format:write
+  ran=1
+elif has_npm_script format; then
+  npm run format
+  ran=1
+fi
+
+if [ -f Cargo.toml ]; then
+  cargo fmt
+  ran=1
+fi
+
+if [ -f pyproject.toml ] || [ -f setup.py ]; then
+  py_targets="$(python_format_targets)"
+  if python -m black --version >/dev/null 2>&1; then
+    python -m black $py_targets
+    ran=1
+  elif python -m ruff --version >/dev/null 2>&1; then
+    python -m ruff format $py_targets
+    ran=1
+  fi
+fi
+
+if [ "$ran" -eq 0 ]; then
+  echo "No formatter configured; skipping."
+fi

--- a/scripts/install-latest-lsp-fleet.mjs
+++ b/scripts/install-latest-lsp-fleet.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const codeRoot = resolve(repoRoot, '..');
+const registryPath = join(repoRoot, 'src/lsp/registry.ts');
+const managedRoot = join(codeRoot, '.lsp-latest');
+const latestWorktreeRoot = join(codeRoot, '.worktrees-lsp-latest');
+const buildRoot = join(managedRoot, '.build');
+const venvDir = join(managedRoot, '.venv');
+const localBin = join(process.env.HOME || '', '.local', 'bin');
+const cargoBin = join(process.env.HOME || '', '.cargo', 'bin');
+const dryRun = process.argv.includes('--dry-run');
+const skipInstall = process.argv.includes('--skip-install');
+
+const registry = readFileSync(registryPath, 'utf8');
+const entries = extractRegistryEntryBlocks(registry).map(block => ({
+  id: readStringField(block, 'id'),
+  repository: readStringField(block, 'repository'),
+  executable: readStringField(block, 'executable'),
+  languageId: readStringField(block, 'languageId'),
+  defaultBranch: readStringField(block, 'defaultBranch'),
+  repoName: readStringField(block, 'repoName'),
+  localLaunchKind: readNestedStringField(block, 'localLaunch', 'kind'),
+  nodeScriptPath: readNestedStringField(block, 'localLaunch', 'scriptPath'),
+  cargoBinaryName: readNestedStringField(block, 'localLaunch', 'binaryName'),
+  agentCli: readAgentCli(registry, readStringField(block, 'id')),
+}));
+
+if (entries.length !== 17) {
+  throw new Error(`Expected 17 LSP registry entries, found ${entries.length}`);
+}
+
+mkdirSync(managedRoot, { recursive: true });
+mkdirSync(latestWorktreeRoot, { recursive: true });
+mkdirSync(buildRoot, { recursive: true });
+mkdirSync(localBin, { recursive: true });
+mkdirSync(cargoBin, { recursive: true });
+
+const rows = [];
+
+if (!skipInstall) {
+  ensurePythonVenv();
+}
+
+for (const entry of entries) {
+  const managedPath = join(managedRoot, entry.repoName);
+  const latestPath = join(latestWorktreeRoot, entry.repoName);
+  const remoteUrl = `https://github.com/${entry.repository}.git`;
+
+  refreshCheckout(remoteUrl, entry.defaultBranch, managedPath);
+  refreshCheckout(remoteUrl, entry.defaultBranch, latestPath);
+
+  const head = git(['-C', managedPath, 'rev-parse', '--short=12', 'HEAD']);
+  const installed = skipInstall ? [] : installEntry(entry, managedPath);
+  const commandPath = resolveCommand(entry.executable) || '-';
+  const agentPath = entry.agentCli ? resolveCommand(entry.agentCli) || '-' : '-';
+  const probe = commandPath !== '-' || agentPath !== '-' ? 'ok' : 'missing';
+
+  rows.push({
+    id: entry.id,
+    language: entry.languageId,
+    branch: entry.defaultBranch,
+    head,
+    kind: entry.localLaunchKind || 'command',
+    command: commandPath,
+    agentCli: agentPath,
+    installed: installed.join(', ') || '-',
+    probe,
+  });
+}
+
+console.table(rows);
+
+const missing = rows.filter(row => row.probe !== 'ok');
+if (missing.length > 0) {
+  console.error(`Missing installed commands for ${missing.length} LSP backend(s).`);
+  process.exitCode = 1;
+}
+
+function installEntry(entry, checkoutPath) {
+  if (entry.localLaunchKind === 'nodeScript') {
+    return installNodeEntry(entry, checkoutPath);
+  }
+
+  if (entry.localLaunchKind === 'cargoBinary') {
+    return installCargoEntry(entry, checkoutPath);
+  }
+
+  return installPythonEntry(entry, checkoutPath);
+}
+
+function installPythonEntry(entry, checkoutPath) {
+  run(venvPython(), ['-m', 'pip', 'install', '--upgrade', 'pip', 'wheel', 'setuptools']);
+  const installPath = preparePythonInstallPath(entry, checkoutPath);
+  run(venvPython(), ['-m', 'pip', 'install', '--upgrade', installPath]);
+
+  const linked = [];
+  for (const command of unique([entry.executable, entry.agentCli])) {
+    const source = join(venvDir, 'bin', command);
+    if (existsSync(source)) {
+      linkCommand(source, join(localBin, command));
+      linked.push(command);
+    }
+  }
+  return linked;
+}
+
+function preparePythonInstallPath(entry, checkoutPath) {
+  if (entry.id !== 'cp2k-lsp-enhanced') {
+    return checkoutPath;
+  }
+
+  const buildPath = join(buildRoot, entry.repoName);
+  rmSync(buildPath, { recursive: true, force: true });
+  run('rsync', ['-a', '--exclude', '.git', `${checkoutPath}/`, `${buildPath}/`]);
+  removeDuplicatePoetryScripts(join(buildPath, 'pyproject.toml'));
+  return buildPath;
+}
+
+function removeDuplicatePoetryScripts(pyprojectPath) {
+  if (!existsSync(pyprojectPath)) {
+    return;
+  }
+
+  const lines = readFileSync(pyprojectPath, 'utf8').split('\n');
+  const seen = new Set();
+  let inScripts = false;
+  const cleaned = [];
+
+  for (const line of lines) {
+    const section = line.match(/^\[([^\]]+)\]\s*$/);
+    if (section) {
+      inScripts = section[1] === 'tool.poetry.scripts';
+      cleaned.push(line);
+      continue;
+    }
+
+    if (inScripts) {
+      const key = line.match(/^([A-Za-z0-9_.-]+)\s*=/)?.[1];
+      if (key) {
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+      }
+    }
+
+    cleaned.push(line);
+  }
+
+  writeFileSync(pyprojectPath, cleaned.join('\n'));
+}
+
+function installNodeEntry(entry, checkoutPath) {
+  if (existsSync(join(checkoutPath, 'package-lock.json'))) {
+    run('npm', ['ci'], { cwd: checkoutPath });
+  } else {
+    run('npm', ['install'], { cwd: checkoutPath });
+  }
+
+  const pkgPath = join(checkoutPath, 'package.json');
+  const pkg = existsSync(pkgPath) ? JSON.parse(readFileSync(pkgPath, 'utf8')) : {};
+  if (pkg.scripts?.compile) {
+    run('npm', ['run', 'compile'], { cwd: checkoutPath });
+  } else if (pkg.scripts?.build) {
+    run('npm', ['run', 'build'], { cwd: checkoutPath });
+  }
+
+  const linked = [];
+  const binEntries = normalizePackageBins(pkg.bin);
+  for (const [name, relativePath] of Object.entries(binEntries)) {
+    const source = join(checkoutPath, relativePath);
+    if (existsSync(source)) {
+      linkCommand(source, join(localBin, name));
+      linked.push(name);
+    }
+  }
+
+  if (entry.executable && !linked.includes(entry.executable)) {
+    const target = resolveNodeScript(entry, checkoutPath);
+    if (target) {
+      writeNodeWrapper(join(localBin, entry.executable), target);
+      linked.push(entry.executable);
+    }
+  }
+
+  if (entry.agentCli && !linked.includes(entry.agentCli)) {
+    const target =
+      resolveNodeScript({ ...entry, nodeScriptPath: 'dist/tool.js' }, checkoutPath) ||
+      resolveNodeScript({ ...entry, nodeScriptPath: 'server/out/tool.js' }, checkoutPath) ||
+      resolveNodeScript(entry, checkoutPath);
+    if (target) {
+      writeNodeWrapper(join(localBin, entry.agentCli), target);
+      linked.push(entry.agentCli);
+    }
+  }
+
+  return linked;
+}
+
+function installCargoEntry(entry, checkoutPath) {
+  run('cargo', ['install', '--locked', '--path', checkoutPath, '--force']);
+  return unique([entry.executable, entry.agentCli]).filter(command => resolveCommand(command));
+}
+
+function refreshCheckout(remoteUrl, branch, checkoutPath) {
+  if (!existsSync(join(checkoutPath, '.git'))) {
+    if (existsSync(checkoutPath)) {
+      rmSync(checkoutPath, { recursive: true, force: true });
+    }
+    run('git', ['clone', '--branch', branch, '--single-branch', remoteUrl, checkoutPath]);
+    return;
+  }
+
+  run('git', ['-C', checkoutPath, 'fetch', 'origin', branch, '--prune']);
+  run('git', ['-C', checkoutPath, 'reset', '--hard', 'HEAD']);
+  run('git', ['-C', checkoutPath, 'clean', '-fdx']);
+  run('git', ['-C', checkoutPath, 'checkout', '-B', branch, `origin/${branch}`]);
+  run('git', ['-C', checkoutPath, 'reset', '--hard', `origin/${branch}`]);
+  run('git', ['-C', checkoutPath, 'clean', '-fdx']);
+}
+
+function ensurePythonVenv() {
+  if (!existsSync(join(venvDir, 'bin', 'python'))) {
+    run('python3', ['-m', 'venv', venvDir]);
+  }
+}
+
+function venvPython() {
+  return join(venvDir, 'bin', 'python');
+}
+
+function run(command, args, options = {}) {
+  const display = [command, ...args].join(' ');
+  console.log(`$ ${display}`);
+  if (dryRun) {
+    return '';
+  }
+
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: {
+      ...process.env,
+      PATH: `${localBin}:${cargoBin}:${process.env.PATH || ''}`,
+    },
+    encoding: 'utf8',
+    stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : '';
+    throw new Error(`Command failed (${result.status}): ${display}${stderr}`);
+  }
+
+  return result.stdout?.trim() || '';
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function linkCommand(source, target) {
+  chmodSync(source, 0o755);
+  rmSync(target, { force: true });
+  symlinkSync(source, target);
+}
+
+function writeNodeWrapper(target, scriptPath) {
+  rmSync(target, { force: true });
+  writeFileSync(target, `#!/usr/bin/env node\nimport '${scriptPath.replaceAll("'", '%27')}';\n`);
+  run('chmod', ['755', target]);
+}
+
+function resolveNodeScript(entry, checkoutPath) {
+  const candidates = unique([
+    entry.nodeScriptPath,
+    'server/out/server.js',
+    'out/server.js',
+    'dist/server.js',
+    'dist/index.js',
+    'index.js',
+  ]).filter(Boolean);
+
+  for (const candidate of candidates) {
+    const absolute = join(checkoutPath, candidate);
+    if (existsSync(absolute)) {
+      return absolute;
+    }
+  }
+  return undefined;
+}
+
+function resolveCommand(command) {
+  if (!command) {
+    return '';
+  }
+  try {
+    return execFileSync('which', [command], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${localBin}:${cargoBin}:${process.env.PATH || ''}`,
+      },
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function extractRegistryEntryBlocks(text) {
+  const start = text.indexOf('const BUNDLED_LSP_SERVERS');
+  const arrayStart = text.indexOf('[', start);
+  const arrayEnd = text.indexOf('] as const', arrayStart);
+  if (start === -1 || arrayStart === -1 || arrayEnd === -1) {
+    return [];
+  }
+
+  const body = text.slice(arrayStart + 1, arrayEnd);
+  const blocks = [];
+  let depth = 0;
+  let blockStart = -1;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body[index];
+    if (char === '{') {
+      if (depth === 0) {
+        blockStart = index;
+      }
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0 && blockStart !== -1) {
+        blocks.push(body.slice(blockStart, index + 1));
+        blockStart = -1;
+      }
+    }
+  }
+
+  return blocks.filter(block => block.includes("id: '"));
+}
+
+function readStringField(block, field) {
+  const match = block.match(new RegExp(`${field}: '([^']+)'`));
+  return match?.[1] ?? '';
+}
+
+function readNestedStringField(block, parent, field) {
+  const match = block.match(new RegExp(`${parent}: \\{([\\s\\S]*?)\\n\\s*\\}`));
+  return match ? readStringField(match[1], field) : '';
+}
+
+function readAgentCli(text, id) {
+  const match = text.match(new RegExp(`'${escapeRegExp(id)}': \\{[\\s\\S]*?agentCli: '([^']+)'`));
+  return match?.[1] ?? '';
+}
+
+function normalizePackageBins(bin) {
+  if (!bin) {
+    return {};
+  }
+  if (typeof bin === 'string') {
+    return { cli: bin };
+  }
+  return bin;
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+has_npm_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)" "$script"
+}
+
+if [ -f package.json ]; then
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
+fi
+
+if [ -f Cargo.toml ]; then
+  cargo fetch
+fi
+
+if [ -f pyproject.toml ] || [ -f setup.py ]; then
+  if [ -f pyproject.toml ] && grep -q '^\[tool.poetry\]' pyproject.toml && command -v poetry >/dev/null 2>&1; then
+    poetry install --with dev || poetry install
+  else
+    python -m pip install --upgrade pip
+    python -m pip install -e ".[dev]" || python -m pip install -e .
+  fi
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ran=0
+
+has_npm_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)" "$script"
+}
+
+python_lint_targets() {
+  local targets=""
+  [ -d src ] && targets="$targets src"
+  [ -d tests ] && targets="$targets tests"
+  [ -d test ] && targets="$targets test"
+  for d in *_lsp cp2k_input_tools mdparser gromacs_lsp; do
+    [ -d "$d" ] && targets="$targets $d"
+  done
+  if [ -z "${targets# }" ]; then
+    echo "."
+  else
+    echo "$targets"
+  fi
+}
+
+if has_npm_script lint; then
+  npm run lint
+  ran=1
+fi
+
+if [ -f Cargo.toml ]; then
+  if command -v cargo-clippy >/dev/null 2>&1; then
+    cargo clippy --all-targets --all-features -- -D warnings
+  else
+    cargo check --all-targets --all-features
+  fi
+  ran=1
+fi
+
+if [ -f pyproject.toml ] || [ -f setup.py ]; then
+  if python -m ruff --version >/dev/null 2>&1; then
+    py_targets="$(python_lint_targets)"
+    python -m ruff check $py_targets
+    ran=1
+  fi
+fi
+
+if [ "$ran" -eq 0 ]; then
+  echo "No linter configured; skipping."
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# OpenQC Smoke Test Script
+#
+# Runs all verification steps for the OpenQC VSCode extension and
+# its sibling LSP repositories. This script implements the final
+# verification steps from issues #168-#177.
+#
+# Usage:
+#   ./scripts/smoke-test.sh [--code-root DIR] [--run-id ID]
+#
+# Options:
+#   --code-root DIR   Parent directory containing sibling LSP repos (default: ..)
+#   --run-id ID       Unique run identifier (default: auto-generated)
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CODE_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+RUN_ID="run-$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="/tmp/agent-runs/${RUN_ID}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --code-root)
+      CODE_ROOT="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      RUN_DIR="/tmp/agent-runs/${RUN_ID}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$RUN_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;36m'
+RESET='\033[0m'
+
+log_step() {
+  echo -e "\n${BLUE}=== $1 ===${RESET}"
+}
+
+log_pass() {
+  echo -e "  ${GREEN}[PASS]${RESET} $1"
+}
+
+log_fail() {
+  echo -e "  ${RED}[FAIL]${RESET} $1"
+}
+
+log_warn() {
+  echo -e "  ${YELLOW}[WARN]${RESET} $1"
+}
+
+log_info() {
+  echo -e "  ${BLUE}[INFO]${RESET} $1"
+}
+
+TOTAL_FAILURES=0
+
+# ---------------------------------------------------------------------------
+# Step 1: Compile TypeScript
+# ---------------------------------------------------------------------------
+
+log_step "Compiling TypeScript"
+
+if npm run compile --prefix "$REPO_ROOT" > "$RUN_DIR/compile.log" 2>&1; then
+  log_pass "TypeScript compilation succeeded"
+else
+  log_fail "TypeScript compilation failed (see $RUN_DIR/compile.log)"
+  TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Run unit and integration tests
+# ---------------------------------------------------------------------------
+
+log_step "Running unit and integration tests"
+
+if npm test --prefix "$REPO_ROOT" > "$RUN_DIR/tests.log" 2>&1; then
+  log_pass "All tests passed"
+else
+  log_fail "Some tests failed (see $RUN_DIR/tests.log)"
+  TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Run lint and typecheck
+# ---------------------------------------------------------------------------
+
+log_step "Running lint and typecheck"
+
+if npm run lint --prefix "$REPO_ROOT" > "$RUN_DIR/lint.log" 2>&1; then
+  log_pass "Lint passed"
+else
+  log_warn "Lint had issues (see $RUN_DIR/lint.log)"
+fi
+
+if npm run typecheck --prefix "$REPO_ROOT" > "$RUN_DIR/typecheck.log" 2>&1; then
+  log_pass "Typecheck passed"
+else
+  log_fail "Typecheck failed (see $RUN_DIR/typecheck.log)"
+  TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Check sibling LSP repos exist
+# ---------------------------------------------------------------------------
+
+log_step "Checking sibling LSP repository checkouts"
+
+CHECKOUTS_FOUND=0
+CHECKOUTS_MISSING=0
+
+while IFS= read -r repo_name; do
+  if [ -d "$CODE_ROOT/$repo_name/.git" ]; then
+    log_pass "$repo_name checkout exists"
+    CHECKOUTS_FOUND=$((CHECKOUTS_FOUND + 1))
+  else
+    log_warn "$repo_name not found at $CODE_ROOT/$repo_name"
+    CHECKOUTS_MISSING=$((CHECKOUTS_MISSING + 1))
+  fi
+done <<EOF
+abacus-lsp
+abinit-lsp
+cif-lsp
+cp2k-lsp-enhanced
+VASP-LSP
+gaussian-lsp
+orca-lsp
+qe-lsp
+gamess-lsp
+nwchem-lsp
+gpumd-lsp
+gromacs-lsp
+lammps-lsp
+mlip-lsp
+pyatb-lsp
+pyscf-lsp
+EOF
+
+log_info "Found $CHECKOUTS_FOUND / $((CHECKOUTS_FOUND + CHECKOUTS_MISSING)) sibling repos"
+
+# ---------------------------------------------------------------------------
+# Step 5: Check repo cleanliness
+# ---------------------------------------------------------------------------
+
+log_step "Checking sibling repo cleanliness"
+
+for repo_dir in "$CODE_ROOT"/*/; do
+  if [ -d "$repo_dir/.git" ]; then
+    repo_name="$(basename "$repo_dir")"
+    status="$(git -C "$repo_dir" status --short 2>/dev/null || echo "git-failed")"
+    if [ -z "$status" ]; then
+      log_pass "$repo_name is clean"
+    else
+      log_warn "$repo_name has uncommitted changes"
+      echo "$status" | head -5
+    fi
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 6: Verify VSIX can be built
+# ---------------------------------------------------------------------------
+
+log_step "Verifying VSIX package dependencies"
+
+if [ -f "$REPO_ROOT/package.json" ]; then
+  HAS_LC=$(node -e "
+    const pkg = require('$REPO_ROOT/package.json');
+    const deps = Object.keys(pkg.dependencies || {});
+    const devDeps = Object.keys(pkg.devDependencies || {});
+    const all = [...deps, ...devDeps];
+    console.log(all.includes('vscode-languageclient') ? 'yes' : 'no');
+  ")
+  if [ "$HAS_LC" = "yes" ]; then
+    log_pass "vscode-languageclient found in dependencies"
+  else
+    log_fail "vscode-languageclient missing from dependencies"
+    TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Run compatibility report
+# ---------------------------------------------------------------------------
+
+log_step "Generating compatibility report"
+
+node -e "
+  const path = require('path');
+  const { generateCompatibilityReport, formatReportAsMarkdown } = require('$REPO_ROOT/out/smoke/compatibilityReport');
+  const report = generateCompatibilityReport('$REPO_ROOT');
+  const md = formatReportAsMarkdown(report);
+  require('fs').writeFileSync('$RUN_DIR/compatibility-report.md', md);
+  console.log('Total: ' + report.totalServers + ', Passed: ' + report.passedServers + ', Failed: ' + report.failedServers);
+  process.exit(report.failedServers > 0 ? 1 : 0);
+" > "$RUN_DIR/compat.log" 2>&1 && log_pass "Compatibility report generated" || log_warn "Some compatibility checks failed (see $RUN_DIR/compat.log)"
+
+# ---------------------------------------------------------------------------
+# Step 8: Final summary
+# ---------------------------------------------------------------------------
+
+log_step "Final Summary"
+
+if [ $TOTAL_FAILURES -eq 0 ]; then
+  log_pass "All smoke tests passed!"
+  echo -e "\n${GREEN}Campaign report saved to: $RUN_DIR${RESET}"
+  exit 0
+else
+  log_fail "$TOTAL_FAILURES step(s) failed"
+  echo -e "\n${RED}Campaign report saved to: $RUN_DIR${RESET}"
+  exit 1
+fi

--- a/scripts/start_issue_worktree.sh
+++ b/scripts/start_issue_worktree.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <issue-number> <short-slug> [base-branch]" >&2
+  exit 2
+fi
+
+issue="$1"
+slug="$2"
+base="${3:-}"
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+if [ -z "$base" ]; then
+  base="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+  base="${base:-$(git branch --show-current)}"
+fi
+
+branch="agent/issue-${issue}-${slug}"
+worktree=".worktrees/issue-${issue}-${slug}"
+
+git fetch origin "$base"
+mkdir -p .worktrees
+
+if git show-ref --verify --quiet "refs/heads/${branch}"; then
+  echo "Branch exists: $branch"
+else
+  git branch "$branch" "origin/$base"
+fi
+
+if [ -d "$worktree" ]; then
+  echo "Worktree exists: $worktree"
+else
+  git worktree add "$worktree" "$branch"
+fi
+
+echo "$worktree"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ran=0
+
+has_npm_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)" "$script"
+}
+
+if has_npm_script test; then
+  npm test
+  ran=1
+fi
+
+if [ -f Cargo.toml ]; then
+  cargo test --all-targets --all-features
+  ran=1
+fi
+
+if ([ -d tests ] || [ -d test ] || [ -f pytest.ini ]) && ([ -f pyproject.toml ] || [ -f setup.py ] || [ -f pytest.ini ]); then
+  python -m pytest
+  ran=1
+fi
+
+if [ "$ran" -eq 0 ]; then
+  echo "No test command configured; skipping."
+fi

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ran=0
+
+has_npm_script() {
+  local script="$1"
+  [ -f package.json ] || return 1
+  node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)" "$script"
+}
+
+python_typecheck_targets() {
+  local targets=""
+  [ -d src ] && targets="$targets src"
+  for d in *_lsp cp2k_input_tools mdparser gromacs_lsp; do
+    [ -d "$d" ] && targets="$targets $d"
+  done
+  if [ -z "${targets# }" ]; then
+    echo "."
+  else
+    echo "$targets"
+  fi
+}
+
+if has_npm_script typecheck; then
+  npm run typecheck
+  ran=1
+elif [ -f tsconfig.json ] && [ -d node_modules ]; then
+  npx tsc --noEmit
+  ran=1
+fi
+
+if [ -f Cargo.toml ]; then
+  cargo check --all-targets --all-features
+  ran=1
+fi
+
+if [ -f pyproject.toml ] || [ -f setup.py ] || [ -f mypy.ini ]; then
+  if python -m mypy --version >/dev/null 2>&1; then
+    py_targets="$(python_typecheck_targets)"
+    python -m mypy $py_targets
+    ran=1
+  fi
+fi
+
+if [ "$ran" -eq 0 ]; then
+  echo "No typechecker configured; skipping."
+fi

--- a/src/lsp/capabilityManifest.ts
+++ b/src/lsp/capabilityManifest.ts
@@ -1,0 +1,175 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { LspCapabilityManifest, LSPServerRegistryEntry } from './types';
+
+export interface CapabilityManifestLoadResult {
+  readonly manifest?: LspCapabilityManifest;
+  readonly manifestPath: string;
+  readonly error?: string;
+}
+
+const REQUIRED_AGENT_OPERATIONS = [
+  'capabilities',
+  'check',
+  'context',
+  'complete',
+  'hover',
+  'symbols',
+  'fix',
+] as const;
+
+const REQUIRED_CAPABILITIES = [
+  'diagnostics',
+  'rich-diagnostics',
+  'completion',
+  'hover',
+  'symbols',
+  'fix-preview',
+  'llm-wiki',
+  'openqc-context',
+] as const;
+
+const REQUIRED_WIKI_PATHS = [
+  'plan',
+  'rawAssets',
+  'entities',
+  'concepts',
+  'synthesis',
+  'index',
+  'log',
+] as const;
+
+const REQUIRED_FIXTURE_PATHS = ['valid', 'invalid', 'logs'] as const;
+
+export function getSiblingRepoPath(openqcRepoRoot: string, server: LSPServerRegistryEntry): string {
+  const repoName = server.localLaunch?.repoName ?? server.repository.split('/').pop() ?? server.id;
+  return path.resolve(openqcRepoRoot, '..', repoName);
+}
+
+export function getCapabilityManifestPath(
+  openqcRepoRoot: string,
+  server: LSPServerRegistryEntry
+): string {
+  return path.join(getSiblingRepoPath(openqcRepoRoot, server), 'lsp-capabilities.json');
+}
+
+export function loadCapabilityManifest(
+  openqcRepoRoot: string,
+  server: LSPServerRegistryEntry
+): CapabilityManifestLoadResult {
+  const manifestPath = getCapabilityManifestPath(openqcRepoRoot, server);
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    const validationError = validateCapabilityManifest(parsed, server);
+    if (validationError) {
+      return { manifestPath, error: validationError };
+    }
+    return { manifest: parsed as LspCapabilityManifest, manifestPath };
+  } catch (error) {
+    return {
+      manifestPath,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function validateCapabilityManifest(
+  raw: unknown,
+  server: LSPServerRegistryEntry
+): string | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return 'manifest is not an object';
+  }
+  const manifest = raw as Partial<LspCapabilityManifest>;
+  const mismatches: string[] = [];
+
+  if (manifest.schema !== 'OpenQCLspCapabilities') {
+    mismatches.push('schema must be OpenQCLspCapabilities');
+  }
+  if (manifest.version !== 1) {
+    mismatches.push('version must be 1');
+  }
+  if (manifest.id !== server.id) {
+    mismatches.push(`id ${String(manifest.id)} != ${server.id}`);
+  }
+  if (manifest.languageId !== server.languageId) {
+    mismatches.push(`languageId ${String(manifest.languageId)} != ${server.languageId}`);
+  }
+  if (manifest.executable !== server.executable) {
+    mismatches.push(`executable ${String(manifest.executable)} != ${server.executable}`);
+  }
+  if (manifest.defaultBranch !== server.defaultBranch) {
+    mismatches.push(`defaultBranch ${String(manifest.defaultBranch)} != ${server.defaultBranch}`);
+  }
+  if (!Array.isArray(manifest.filePatterns) || manifest.filePatterns.length === 0) {
+    mismatches.push('filePatterns must be a non-empty array');
+  }
+  if (!manifest.blockingPolicy || typeof manifest.blockingPolicy !== 'object') {
+    mismatches.push('blockingPolicy is required');
+  } else if (!['blocking', 'warning-only'].includes(String(manifest.blockingPolicy.mode))) {
+    mismatches.push('blockingPolicy.mode must be blocking or warning-only');
+  }
+  if (!Array.isArray(manifest.capabilities) || manifest.capabilities.length === 0) {
+    mismatches.push('capabilities must be a non-empty array');
+  } else {
+    const capabilities = new Set(manifest.capabilities);
+    for (const capability of REQUIRED_CAPABILITIES) {
+      if (!capabilities.has(capability)) {
+        mismatches.push(`capabilities missing ${capability}`);
+      }
+    }
+  }
+  if (!manifest.agentCli || typeof manifest.agentCli !== 'object') {
+    mismatches.push('agentCli is required');
+  } else {
+    if (!manifest.agentCli.command) {
+      mismatches.push('agentCli.command is required');
+    }
+    const operations = new Set(manifest.agentCli.operations ?? []);
+    for (const operation of REQUIRED_AGENT_OPERATIONS) {
+      if (!operations.has(operation)) {
+        mismatches.push(`agentCli.operations missing ${operation}`);
+      }
+    }
+    if (manifest.agentCli.jsonFormat !== true) {
+      mismatches.push('agentCli.jsonFormat must be true');
+    }
+    if (manifest.agentCli.failOnBlocking !== true) {
+      mismatches.push('agentCli.failOnBlocking must be true');
+    }
+  }
+  if (!manifest.diagnosticSchema) {
+    mismatches.push('diagnosticSchema is required');
+  }
+  if (!manifest.wikiPaths) {
+    mismatches.push('wikiPaths is required');
+  } else {
+    for (const wikiPath of REQUIRED_WIKI_PATHS) {
+      if (!manifest.wikiPaths[wikiPath]) {
+        mismatches.push(`wikiPaths.${wikiPath} is required`);
+      }
+    }
+  }
+  if (!manifest.fixturePaths) {
+    mismatches.push('fixturePaths is required');
+  } else {
+    for (const fixturePath of REQUIRED_FIXTURE_PATHS) {
+      if (!Array.isArray(manifest.fixturePaths[fixturePath])) {
+        mismatches.push(`fixturePaths.${fixturePath} must be an array`);
+      }
+    }
+  }
+  if (!manifest.openqc || manifest.openqc.registryId !== server.id) {
+    mismatches.push('openqc.registryId must match registry id');
+  } else {
+    if (manifest.openqc.contextContract !== 'DSLAuthoringContext') {
+      mismatches.push('openqc.contextContract must be DSLAuthoringContext');
+    }
+    if (manifest.openqc.diagnosticEnvelope !== 'DiagnosticEnvelope/v1') {
+      mismatches.push('openqc.diagnosticEnvelope must be DiagnosticEnvelope/v1');
+    }
+  }
+
+  return mismatches.length ? mismatches.join('; ') : undefined;
+}

--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -345,6 +345,25 @@ const BUNDLED_LSP_SERVERS: readonly LSPServerRegistryEntry[] = [
       functionName: 'lsp_main',
     },
   },
+  {
+    id: 'dpgen-lsp',
+    name: 'DP-GEN',
+    repository: 'newtontech/dpgen-lsp',
+    executable: 'dpgen-lsp',
+    languageId: 'dpgen',
+    fileExtensions: [],
+    fileNames: ['param.json', 'machine.json'],
+    enabled: true,
+    repositoryUrl: 'https://github.com/newtontech/dpgen-lsp',
+    stability: 'experimental',
+    defaultBranch: 'main',
+    localLaunch: {
+      kind: 'pythonFunction',
+      repoName: 'dpgen-lsp',
+      importPath: 'dpgen_lsp.server',
+      functionName: 'main',
+    },
+  },
 ] as const;
 
 export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadiness>> = {
@@ -371,6 +390,12 @@ export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadine
     agentCli: 'cp2k-lsp-tool',
     richDiagnostics: true,
     closedLoop: 'partial',
+  },
+  'dpgen-lsp': {
+    diagnosticEngine: 'v1',
+    agentCli: 'dpgen-lsp-tool',
+    richDiagnostics: true,
+    closedLoop: 'planned',
   },
   'gamess-lsp': {
     diagnosticEngine: 'v1',

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -185,6 +185,53 @@ export interface DiagnosticReadiness {
   readonly closedLoop: 'planned' | 'partial' | 'available';
 }
 
+export interface LspCapabilityManifest {
+  readonly schema: 'OpenQCLspCapabilities';
+  readonly version: 1;
+  readonly id: string;
+  readonly software: string;
+  readonly displayName?: string;
+  readonly languageId: string;
+  readonly executable: string;
+  readonly defaultBranch: string;
+  readonly filePatterns: readonly string[];
+  readonly maturity: string;
+  readonly blockingPolicy: {
+    readonly mode: 'blocking' | 'warning-only';
+    readonly description?: string;
+  };
+  readonly capabilities: readonly string[];
+  readonly agentCli: {
+    readonly command: string;
+    readonly operations: readonly string[];
+    readonly jsonFormat: boolean;
+    readonly failOnBlocking: boolean;
+  };
+  readonly diagnosticSchema: string;
+  readonly wikiPaths: {
+    readonly plan: string;
+    readonly rawAssets: string;
+    readonly entities: string;
+    readonly concepts: string;
+    readonly synthesis: string;
+    readonly index: string;
+    readonly log: string;
+  };
+  readonly fixturePaths: {
+    readonly valid: readonly string[];
+    readonly invalid: readonly string[];
+    readonly logs: readonly string[];
+  };
+  readonly outputLogPatterns: readonly string[];
+  readonly openqc: {
+    readonly registryId: string;
+    readonly repoName: string;
+    readonly contextContract: 'DSLAuthoringContext';
+    readonly diagnosticEnvelope: 'DiagnosticEnvelope/v1';
+  };
+  readonly sourceProvenance?: readonly Record<string, unknown>[];
+}
+
 /** Local sibling-repository launch strategy for a bundled LSP server. */
 export type LocalLspLaunch =
   | {

--- a/src/smoke/compatibilityReport.ts
+++ b/src/smoke/compatibilityReport.ts
@@ -12,7 +12,9 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 import { listBundledLspServers, getLspDiagnosticReadiness } from '../lsp/registry';
+import { getSiblingRepoPath, loadCapabilityManifest } from '../lsp/capabilityManifest';
 import type { LSPServerRegistryEntry } from '../lsp/types';
 import type {
   CompatibilityCheck,
@@ -52,6 +54,8 @@ export function generateCompatibilityReport(
   const compatDoc = loadTextSafe(docPath);
 
   const entries: LspCompatibilityEntry[] = servers.map(server => {
+    const capabilityManifest = loadCapabilityManifest(repoRoot, server);
+    const repoPath = getSiblingRepoPath(repoRoot, server);
     const checks: CompatibilityCheck[] = [
       checkRegistryEntryExists(server),
       checkPackageJsonLanguage(server, packageJson),
@@ -62,15 +66,27 @@ export function generateCompatibilityReport(
       checkDiagnosticReadiness(server),
       checkRuleManifest(server, manifestDir),
       checkLocalLaunchConfig(server),
+      checkCapabilityManifest(server, repoRoot),
     ];
 
     const passed = checks.every(c => c.status === 'pass' || c.status === 'skip');
+    const manifestSummary = capabilityManifest.manifest
+      ? summarizeCapabilityManifest(
+          repoRoot,
+          capabilityManifest.manifest,
+          capabilityManifest.manifestPath
+        )
+      : undefined;
 
     return {
       serverId: server.id,
       serverName: server.name,
       languageId: server.languageId,
       stability: server.stability,
+      runtimeCommand: [server.executable, ...(server.args ?? ['--stdio'])].join(' '),
+      repoPath,
+      repoCommit: readGitCommit(repoPath),
+      manifest: manifestSummary,
       checks,
       passed,
     };
@@ -150,6 +166,8 @@ function checkPackageJsonConfiguration(
     `openqc.lsp.${server.languageId}.enabled`,
     `openqc.lsp.${server.languageId}.path`,
     `openqc.lsp.${server.languageId}.command`,
+    `openqc.lsp.${server.languageId}.args`,
+    `openqc.lsp.${server.languageId}.env`,
   ];
 
   const missing = requiredSettings.filter(key => !(key in properties));
@@ -368,6 +386,49 @@ function checkLocalLaunchConfig(server: LSPServerRegistryEntry): CompatibilityCh
   };
 }
 
+function checkCapabilityManifest(
+  server: LSPServerRegistryEntry,
+  repoRoot: string
+): CompatibilityCheck {
+  const result = loadCapabilityManifest(repoRoot, server);
+  if (result.error || !result.manifest) {
+    return {
+      name: 'lsp-capability-manifest',
+      description: `Capability manifest for ${server.name}`,
+      status: 'fail',
+      detail: `${result.manifestPath}: ${result.error ?? 'manifest was not loaded'}`,
+    };
+  }
+
+  const manifestDir = path.dirname(result.manifestPath);
+  const requiredPaths = [
+    result.manifest.diagnosticSchema,
+    result.manifest.wikiPaths.plan,
+    result.manifest.wikiPaths.rawAssets,
+    result.manifest.wikiPaths.entities,
+    result.manifest.wikiPaths.concepts,
+    result.manifest.wikiPaths.synthesis,
+    result.manifest.wikiPaths.index,
+    result.manifest.wikiPaths.log,
+  ];
+  const missing = requiredPaths.filter(p => !fs.existsSync(path.join(manifestDir, p)));
+  if (missing.length > 0) {
+    return {
+      name: 'lsp-capability-manifest',
+      description: `Capability manifest for ${server.name}`,
+      status: 'fail',
+      detail: `Missing manifest paths: ${missing.join(', ')}`,
+    };
+  }
+
+  return {
+    name: 'lsp-capability-manifest',
+    description: `Capability manifest for ${server.name}`,
+    status: 'pass',
+    detail: `${result.manifest.agentCli.command}; ${result.manifest.capabilities.length} capabilities`,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -408,6 +469,56 @@ function getPackageJsonProperties(pkg: Record<string, unknown>): Record<string, 
   return (configuration.properties as Record<string, unknown>) ?? {};
 }
 
+function summarizeCapabilityManifest(
+  repoRoot: string,
+  manifest: NonNullable<ReturnType<typeof loadCapabilityManifest>['manifest']>,
+  manifestPath: string
+): NonNullable<LspCompatibilityEntry['manifest']> {
+  const manifestDir = path.dirname(manifestPath);
+  const hasAnyExisting = (paths: readonly string[]) =>
+    paths.some(p => fs.existsSync(path.join(manifestDir, p)));
+  const wikiFreshness = fs.existsSync(path.join(manifestDir, manifest.wikiPaths.log))
+    ? 'present'
+    : 'missing';
+  const expectedCapabilities = [
+    'diagnostics',
+    'rich-diagnostics',
+    'completion',
+    'hover',
+    'symbols',
+    'fix-preview',
+    'llm-wiki',
+    'openqc-context',
+  ];
+  const actual = new Set(manifest.capabilities);
+  const missingCapabilities = expectedCapabilities.filter(capability => !actual.has(capability));
+
+  return {
+    path: path.relative(repoRoot, manifestPath),
+    capabilities: manifest.capabilities,
+    agentCli: manifest.agentCli.command,
+    blockingPolicy: manifest.blockingPolicy.mode,
+    wikiFreshness,
+    smokeFixtures: {
+      valid: hasAnyExisting(manifest.fixturePaths.valid),
+      invalid: hasAnyExisting(manifest.fixturePaths.invalid),
+      logs: hasAnyExisting(manifest.fixturePaths.logs),
+    },
+    missingCapabilities,
+  };
+}
+
+function readGitCommit(repoPath: string): string | undefined {
+  try {
+    return execFileSync('git', ['-C', repoPath, 'rev-parse', '--short=12', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Report formatting
 // ---------------------------------------------------------------------------
@@ -436,6 +547,23 @@ export function formatReportAsMarkdown(report: CompatibilityReport): string {
     lines.push('');
     lines.push(`- Language: \`${entry.languageId}\``);
     lines.push(`- Stability: ${entry.stability}`);
+    if (entry.runtimeCommand) {
+      lines.push(`- Runtime command: \`${entry.runtimeCommand}\``);
+    }
+    if (entry.repoCommit) {
+      lines.push(`- Repo commit: \`${entry.repoCommit}\``);
+    }
+    if (entry.manifest) {
+      lines.push(`- Manifest: \`${entry.manifest.path}\``);
+      lines.push(`- Agent CLI: \`${entry.manifest.agentCli}\``);
+      lines.push(`- Blocking policy: ${entry.manifest.blockingPolicy}`);
+      lines.push(
+        `- Smoke fixtures: valid=${entry.manifest.smokeFixtures.valid}, invalid=${entry.manifest.smokeFixtures.invalid}, logs=${entry.manifest.smokeFixtures.logs}`
+      );
+      if (entry.manifest.missingCapabilities.length > 0) {
+        lines.push(`- Missing capabilities: ${entry.manifest.missingCapabilities.join(', ')}`);
+      }
+    }
 
     for (const check of entry.checks) {
       const checkIcon =

--- a/src/smoke/compatibilityReport.ts
+++ b/src/smoke/compatibilityReport.ts
@@ -1,0 +1,456 @@
+/**
+ * Compatibility Report Generator
+ *
+ * Generates a comprehensive compatibility report that checks alignment between
+ * the LSP registry, package.json contributions, docs, and rule manifests.
+ * Extends the basic registry alignment checks with rule manifest integration.
+ *
+ * @module smoke/compatibilityReport
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/163
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/167
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { listBundledLspServers, getLspDiagnosticReadiness } from '../lsp/registry';
+import type { LSPServerRegistryEntry } from '../lsp/types';
+import type {
+  CompatibilityCheck,
+  CompatibilityReport,
+  CheckStatus,
+  LspCompatibilityEntry,
+  RuleManifest,
+} from './types';
+import { tryReadManifest } from './ruleManifestReader';
+
+// ---------------------------------------------------------------------------
+// Required dependencies for VSIX verification
+// ---------------------------------------------------------------------------
+
+const REQUIRED_VSIX_DEPENDENCIES = ['vscode-languageclient', 'vscode-languageserver-protocol'];
+
+// ---------------------------------------------------------------------------
+// Report generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a full compatibility report checking all LSP server integrations.
+ *
+ * @param repoRoot - Root directory of the OpenQC-VSCode repository.
+ * @param manifestDir - Optional directory containing rule manifest JSON files.
+ * @returns A complete compatibility report.
+ */
+export function generateCompatibilityReport(
+  repoRoot: string,
+  manifestDir?: string
+): CompatibilityReport {
+  const servers = listBundledLspServers();
+  const pkgPath = path.join(repoRoot, 'package.json');
+  const docPath = path.join(repoRoot, 'docs', 'LSP_COMPATIBILITY.md');
+
+  const packageJson = loadJsonSafe(pkgPath);
+  const compatDoc = loadTextSafe(docPath);
+
+  const entries: LspCompatibilityEntry[] = servers.map(server => {
+    const checks: CompatibilityCheck[] = [
+      checkRegistryEntryExists(server),
+      checkPackageJsonLanguage(server, packageJson),
+      checkPackageJsonConfiguration(server, packageJson),
+      checkGrammarExists(server, repoRoot),
+      checkLanguageConfigExists(server, repoRoot),
+      checkDocsAlignment(server, compatDoc),
+      checkDiagnosticReadiness(server),
+      checkRuleManifest(server, manifestDir),
+      checkLocalLaunchConfig(server),
+    ];
+
+    const passed = checks.every(c => c.status === 'pass' || c.status === 'skip');
+
+    return {
+      serverId: server.id,
+      serverName: server.name,
+      languageId: server.languageId,
+      stability: server.stability,
+      checks,
+      passed,
+    };
+  });
+
+  const passedServers = entries.filter(e => e.passed).length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalServers: servers.length,
+    passedServers,
+    failedServers: entries.length - passedServers,
+    entries,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+function checkRegistryEntryExists(server: LSPServerRegistryEntry): CompatibilityCheck {
+  return {
+    name: 'registry-entry-exists',
+    description: `Registry entry exists for ${server.name}`,
+    status: server.id && server.name ? 'pass' : 'fail',
+    detail: server.id ? undefined : 'Missing required registry fields',
+  };
+}
+
+function checkPackageJsonLanguage(
+  server: LSPServerRegistryEntry,
+  packageJson: Record<string, unknown> | null
+): CompatibilityCheck {
+  if (!packageJson) {
+    return {
+      name: 'package-json-language',
+      description: `package.json language contribution for ${server.name}`,
+      status: 'fail',
+      detail: 'package.json could not be loaded',
+    };
+  }
+
+  const languages = getPackageJsonLanguages(packageJson);
+  const match = languages.find((l: Record<string, unknown>) => l.id === server.languageId);
+
+  if (!match) {
+    return {
+      name: 'package-json-language',
+      description: `package.json language contribution for ${server.name}`,
+      status: 'fail',
+      detail: `No language contribution found for languageId "${server.languageId}"`,
+    };
+  }
+
+  return {
+    name: 'package-json-language',
+    description: `package.json language contribution for ${server.name}`,
+    status: 'pass',
+  };
+}
+
+function checkPackageJsonConfiguration(
+  server: LSPServerRegistryEntry,
+  packageJson: Record<string, unknown> | null
+): CompatibilityCheck {
+  if (!packageJson) {
+    return {
+      name: 'package-json-configuration',
+      description: `package.json configuration settings for ${server.name}`,
+      status: 'fail',
+      detail: 'package.json could not be loaded',
+    };
+  }
+
+  const properties = getPackageJsonProperties(packageJson);
+  const requiredSettings = [
+    `openqc.lsp.${server.languageId}.enabled`,
+    `openqc.lsp.${server.languageId}.path`,
+    `openqc.lsp.${server.languageId}.command`,
+  ];
+
+  const missing = requiredSettings.filter(key => !(key in properties));
+
+  if (missing.length > 0) {
+    return {
+      name: 'package-json-configuration',
+      description: `package.json configuration settings for ${server.name}`,
+      status: 'warn',
+      detail: `Missing configuration keys: ${missing.join(', ')}`,
+    };
+  }
+
+  return {
+    name: 'package-json-configuration',
+    description: `package.json configuration settings for ${server.name}`,
+    status: 'pass',
+  };
+}
+
+function checkGrammarExists(server: LSPServerRegistryEntry, repoRoot: string): CompatibilityCheck {
+  const grammarDir = path.join(repoRoot, 'syntaxes');
+  const expectedName = `${server.languageId}.tmLanguage.json`;
+  const grammarPath = path.join(grammarDir, expectedName);
+
+  if (fs.existsSync(grammarPath)) {
+    return {
+      name: 'grammar-exists',
+      description: `TextMate grammar for ${server.name}`,
+      status: 'pass',
+    };
+  }
+
+  // Check for YAML variant
+  const yamlPath = path.join(grammarDir, `${server.languageId}.tmLanguage.yaml`);
+  if (fs.existsSync(yamlPath)) {
+    return {
+      name: 'grammar-exists',
+      description: `TextMate grammar for ${server.name}`,
+      status: 'pass',
+    };
+  }
+
+  // Check for plist variant
+  const plistPath = path.join(grammarDir, `${server.languageId}.tmLanguage`);
+  if (fs.existsSync(plistPath)) {
+    return {
+      name: 'grammar-exists',
+      description: `TextMate grammar for ${server.name}`,
+      status: 'pass',
+    };
+  }
+
+  return {
+    name: 'grammar-exists',
+    description: `TextMate grammar for ${server.name}`,
+    status: 'warn',
+    detail: `No grammar found at syntaxes/${expectedName} (checked .json, .yaml, .plist)`,
+  };
+}
+
+function checkLanguageConfigExists(
+  server: LSPServerRegistryEntry,
+  repoRoot: string
+): CompatibilityCheck {
+  const configDir = path.join(repoRoot, 'language-configurations');
+  const expectedName = `${server.languageId}.json`;
+  const configPath = path.join(configDir, expectedName);
+
+  if (fs.existsSync(configPath)) {
+    return {
+      name: 'language-config-exists',
+      description: `Language configuration for ${server.name}`,
+      status: 'pass',
+    };
+  }
+
+  return {
+    name: 'language-config-exists',
+    description: `Language configuration for ${server.name}`,
+    status: 'warn',
+    detail: `No language config at language-configurations/${expectedName}`,
+  };
+}
+
+function checkDocsAlignment(
+  server: LSPServerRegistryEntry,
+  docContent: string | null
+): CompatibilityCheck {
+  if (!docContent) {
+    return {
+      name: 'docs-alignment',
+      description: `LSP_COMPATIBILITY.md entry for ${server.name}`,
+      status: 'fail',
+      detail: 'docs/LSP_COMPATIBILITY.md could not be read',
+    };
+  }
+
+  const hasRepo = docContent.includes(server.repository);
+  const hasLanguageId = docContent.includes(`\`${server.languageId}\``);
+  const hasBranch = docContent.includes(`\`${server.defaultBranch}\``);
+
+  if (!hasRepo || !hasLanguageId || !hasBranch) {
+    const missing: string[] = [];
+    if (!hasRepo) {
+      missing.push(`repository "${server.repository}"`);
+    }
+    if (!hasLanguageId) {
+      missing.push(`languageId \`${server.languageId}\``);
+    }
+    if (!hasBranch) {
+      missing.push(`branch \`${server.defaultBranch}\``);
+    }
+
+    return {
+      name: 'docs-alignment',
+      description: `LSP_COMPATIBILITY.md entry for ${server.name}`,
+      status: 'fail',
+      detail: `Missing in docs: ${missing.join(', ')}`,
+    };
+  }
+
+  return {
+    name: 'docs-alignment',
+    description: `LSP_COMPATIBILITY.md entry for ${server.name}`,
+    status: 'pass',
+  };
+}
+
+function checkDiagnosticReadiness(server: LSPServerRegistryEntry): CompatibilityCheck {
+  const readiness = getLspDiagnosticReadiness(server.id);
+
+  if (!readiness) {
+    return {
+      name: 'diagnostic-readiness',
+      description: `Diagnostic readiness for ${server.name}`,
+      status: 'warn',
+      detail: 'No diagnostic readiness metadata in registry',
+    };
+  }
+
+  return {
+    name: 'diagnostic-readiness',
+    description: `Diagnostic readiness for ${server.name}`,
+    status: readiness.diagnosticEngine === 'v1' ? 'pass' : 'fail',
+    detail: `Engine: ${readiness.diagnosticEngine}, Rich: ${readiness.richDiagnostics}, Closed-loop: ${readiness.closedLoop}`,
+  };
+}
+
+function checkRuleManifest(
+  server: LSPServerRegistryEntry,
+  manifestDir?: string
+): CompatibilityCheck {
+  if (!manifestDir) {
+    return {
+      name: 'rule-manifest',
+      description: `Rule manifest for ${server.name}`,
+      status: 'skip',
+      detail: 'No manifest directory provided',
+    };
+  }
+
+  const manifestPath = path.join(manifestDir, `${server.id}-rules.json`);
+  const result = tryReadManifest(manifestPath);
+
+  if (result.error) {
+    return {
+      name: 'rule-manifest',
+      description: `Rule manifest for ${server.name}`,
+      status: 'warn',
+      detail: result.error,
+    };
+  }
+
+  if (!result.manifest) {
+    return {
+      name: 'rule-manifest',
+      description: `Rule manifest for ${server.name}`,
+      status: 'fail',
+      detail: 'Manifest was not loaded',
+    };
+  }
+  const ruleCount = result.manifest.rules.length;
+  return {
+    name: 'rule-manifest',
+    description: `Rule manifest for ${server.name}`,
+    status: 'pass',
+    detail: `${ruleCount} rules loaded from manifest`,
+  };
+}
+
+function checkLocalLaunchConfig(server: LSPServerRegistryEntry): CompatibilityCheck {
+  if (!server.localLaunch) {
+    return {
+      name: 'local-launch-config',
+      description: `Local launch configuration for ${server.name}`,
+      status: 'fail',
+      detail: 'No localLaunch defined in registry entry',
+    };
+  }
+
+  if (!server.localLaunch.repoName) {
+    return {
+      name: 'local-launch-config',
+      description: `Local launch configuration for ${server.name}`,
+      status: 'fail',
+      detail: 'localLaunch missing repoName',
+    };
+  }
+
+  return {
+    name: 'local-launch-config',
+    description: `Local launch configuration for ${server.name}`,
+    status: 'pass',
+    detail: `kind: ${server.localLaunch.kind}, repo: ${server.localLaunch.repoName}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadJsonSafe(filePath: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function loadTextSafe(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function getPackageJsonLanguages(pkg: Record<string, unknown>): Record<string, unknown>[] {
+  const contributes = pkg.contributes as Record<string, unknown> | undefined;
+  if (!contributes) {
+    return [];
+  }
+  return (contributes.languages as Record<string, unknown>[]) ?? [];
+}
+
+function getPackageJsonProperties(pkg: Record<string, unknown>): Record<string, unknown> {
+  const contributes = pkg.contributes as Record<string, unknown> | undefined;
+  if (!contributes) {
+    return {};
+  }
+  const configuration = contributes.configuration as Record<string, unknown> | undefined;
+  if (!configuration) {
+    return {};
+  }
+  return (configuration.properties as Record<string, unknown>) ?? {};
+}
+
+// ---------------------------------------------------------------------------
+// Report formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a compatibility report as a human-readable markdown string.
+ *
+ * @param report - The compatibility report to format.
+ * @returns Markdown-formatted report string.
+ */
+export function formatReportAsMarkdown(report: CompatibilityReport): string {
+  const lines: string[] = [
+    '# OpenQC LSP Compatibility Report',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `**Total:** ${report.totalServers} | **Passed:** ${report.passedServers} | **Failed:** ${report.failedServers}`,
+    '',
+    '## Per-Server Results',
+    '',
+  ];
+
+  for (const entry of report.entries) {
+    const icon = entry.passed ? '[PASS]' : '[FAIL]';
+    lines.push(`### ${icon} ${entry.serverName} (${entry.serverId})`);
+    lines.push('');
+    lines.push(`- Language: \`${entry.languageId}\``);
+    lines.push(`- Stability: ${entry.stability}`);
+
+    for (const check of entry.checks) {
+      const checkIcon =
+        check.status === 'pass'
+          ? '[PASS]'
+          : check.status === 'fail'
+            ? '[FAIL]'
+            : check.status === 'warn'
+              ? '[WARN]'
+              : '[SKIP]';
+      lines.push(`- ${checkIcon} ${check.name}: ${check.detail ?? 'OK'}`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/smoke/documentDetector.ts
+++ b/src/smoke/documentDetector.ts
@@ -1,0 +1,279 @@
+/**
+ * Output/Log Document Detection for Standalone LSP Diagnostics
+ *
+ * Detects whether a document is an input file, output file, or runtime log
+ * for routing diagnostics to the correct LSP server. This enables OpenQC to
+ * handle output/log files from quantum chemistry codes without requiring the
+ * input-language LSP to process them directly.
+ *
+ * @module smoke/documentDetector
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/159
+ */
+
+import type { DocumentDetectionResult, DocumentKind } from './types';
+import { listBundledLspServers } from '../lsp/registry';
+import type { LSPServerRegistryEntry } from '../lsp/types';
+
+// ---------------------------------------------------------------------------
+// Known output file name patterns
+//
+// IMPORTANT: Patterns must be specific enough to avoid false positives.
+// Avoid overly broad patterns like /^.*\.out$/i which match every .out file.
+// ---------------------------------------------------------------------------
+
+/** Map of language ID to known output file name patterns. */
+const OUTPUT_FILE_PATTERNS: ReadonlyMap<string, readonly RegExp[]> = new Map([
+  ['vasp', [/^DOSCAR$/i, /^PROCAR$/i, /^CHG$/i, /^WAVECAR$/i, /^XDATCAR$/i, /^LOCPOT$/i]],
+  ['gaussian', [/^Gaussian.*\.log$/i]],
+  ['orca', [/^ORCA.*\.out$/i]],
+  ['qe', [/^pw\.out$/i, /^ph\.out$/i, /^cppp\.out$/i]],
+  ['gamess', [/^GAMESS.*\.log$/i, /^GAMESS.*\.dat$/i]],
+  ['nwchem', [/^.*\.nwout$/i]],
+  ['cp2k', [/^.*\.ener$/i, /^.*\.force$/i, /^.*-pos-1\.xyz$/i, /^.*\.restart$/i]],
+  ['abacus', [/^running_.*\.log$/i, /^OUT\.ABACUS$/i]],
+  ['lammps', [/^dump\..+$/i]],
+  ['gromacs', [/^.*\.xvg$/i, /^.*\.trr$/i, /^.*\.xtc$/i, /^.*\.edr$/i]],
+  ['gpumd', [/^thermo\.out$/i, /^xyz\.out$/i, /^velo\.out$/i]],
+]);
+
+/** Map of language ID to known log file name patterns. */
+const LOG_FILE_PATTERNS: ReadonlyMap<string, readonly RegExp[]> = new Map([
+  ['gaussian', [/^Gaussian.*\.log$/i]],
+  ['orca', [/^ORCA.*\.out$/i]],
+  ['qe', [/^pw\.out$/i]],
+  ['gamess', [/^GAMESS.*\.log$/i]],
+  ['nwchem', [/^.*\.nwout$/i]],
+  ['cp2k', [/^cp2k.*\.log$/i]],
+  ['gromacs', [/^md\.log$/i]],
+  ['gpumd', [/^run\.in\.log$/i]],
+]);
+
+// ---------------------------------------------------------------------------
+// Content-based heuristics
+//
+// These must be highly specific to avoid false matches. Use multi-word
+// phrases that are unique to each code's output format.
+// ---------------------------------------------------------------------------
+
+/** Map of language ID to output file content signatures. */
+const OUTPUT_CONTENT_SIGNATURES: ReadonlyMap<string, readonly RegExp[]> = new Map([
+  ['vasp', [/FREE ENERGIE OF THE ION-ELECTRON SYSTEM/i, /Voluntary context switches/i]],
+  ['gaussian', [/Entering Gaussian System/i, /Normal termination of Gaussian/i]],
+  ['orca', [/^\* O   R   C   A \*/m, /ORCA TERMINATED NORMALLY/i]],
+  ['qe', [/PROGRAM PWSCF ENDED/i, /PROGRAM PHONON ENDED/i]],
+  ['gamess', [/GAMESS VERSION/i]],
+  ['nwchem', [/NWChem SCF/i]],
+  ['cp2k', [/^CP2K\|/m, /^ENERGY\|/m]],
+  ['lammps', [/^LAMMPS\s+\(/m]],
+  ['gromacs', [/^GROMACS\s+/m]],
+]);
+
+// ---------------------------------------------------------------------------
+// Detection engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the document kind for a given file path and optional content.
+ *
+ * Uses file name patterns first, then falls back to content-based detection
+ * when content is provided.
+ *
+ * @param fileName - The base file name (not the full path).
+ * @param content - Optional file content for content-based detection.
+ * @returns Detection result with kind, associated server, and confidence.
+ */
+export function detectDocument(fileName: string, content?: string): DocumentDetectionResult {
+  const servers = listBundledLspServers();
+
+  // Phase 1: Check against input file patterns from the registry.
+  // Uses two-pass matching: exact fileName matches first (higher priority),
+  // then extension matches. This ensures 'run.in' matches GPUMD's exact
+  // fileName before QE's '.in' extension.
+  const inputMatch = matchInputFile(fileName, servers);
+  if (inputMatch) {
+    return {
+      kind: 'input',
+      serverId: inputMatch.id,
+      languageId: inputMatch.languageId,
+      confidence: 1.0,
+    };
+  }
+
+  // Phase 2: Check output file name patterns
+  const outputNameMatch = matchOutputFileName(fileName, servers);
+  if (outputNameMatch) {
+    return {
+      kind: 'output',
+      serverId: outputNameMatch.serverId,
+      languageId: outputNameMatch.languageId,
+      confidence: 0.9,
+    };
+  }
+
+  // Phase 3: Check log file name patterns
+  const logNameMatch = matchLogFileName(fileName, servers);
+  if (logNameMatch) {
+    return {
+      kind: 'log',
+      serverId: logNameMatch.serverId,
+      languageId: logNameMatch.languageId,
+      confidence: 0.85,
+    };
+  }
+
+  // Phase 4: Content-based detection (if content provided)
+  if (content !== undefined) {
+    const contentMatch = matchContent(content, servers);
+    if (contentMatch) {
+      return {
+        kind: contentMatch.kind,
+        serverId: contentMatch.serverId,
+        languageId: contentMatch.languageId,
+        confidence: contentMatch.confidence,
+      };
+    }
+  }
+
+  return {
+    kind: 'unknown',
+    confidence: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal matchers
+// ---------------------------------------------------------------------------
+
+/**
+ * Match input files using a two-pass approach:
+ * 1. First pass: check exact fileName matches across ALL servers.
+ * 2. Second pass: check extension matches across all servers.
+ *
+ * This ensures that exact fileName matches (e.g., GPUMD's "run.in") take
+ * priority over extension matches (e.g., QE's ".in").
+ */
+function matchInputFile(
+  fileName: string,
+  servers: readonly LSPServerRegistryEntry[]
+): LSPServerRegistryEntry | undefined {
+  const baseName = fileName.toLowerCase();
+
+  // Pass 1: Exact fileName matches (highest priority)
+  for (const server of servers) {
+    if (server.fileNames.some(fn => fn.toLowerCase() === baseName)) {
+      return server;
+    }
+  }
+
+  // Pass 2: Extension matches
+  for (const server of servers) {
+    for (const ext of server.fileExtensions) {
+      if (baseName.endsWith('.' + ext.toLowerCase())) {
+        return server;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function matchOutputFileName(
+  fileName: string,
+  _servers: readonly LSPServerRegistryEntry[]
+): { readonly serverId: string; readonly languageId: string } | undefined {
+  for (const [languageId, patterns] of OUTPUT_FILE_PATTERNS) {
+    for (const pattern of patterns) {
+      if (pattern.test(fileName)) {
+        const server = _servers.find(s => s.languageId === languageId);
+        if (server) {
+          return { serverId: server.id, languageId };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function matchLogFileName(
+  fileName: string,
+  _servers: readonly LSPServerRegistryEntry[]
+): { readonly serverId: string; readonly languageId: string } | undefined {
+  for (const [languageId, patterns] of LOG_FILE_PATTERNS) {
+    for (const pattern of patterns) {
+      if (pattern.test(fileName)) {
+        const server = _servers.find(s => s.languageId === languageId);
+        if (server) {
+          return { serverId: server.id, languageId };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function matchContent(
+  content: string,
+  _servers: readonly LSPServerRegistryEntry[]
+):
+  | {
+      readonly kind: DocumentKind;
+      readonly serverId: string;
+      readonly languageId: string;
+      readonly confidence: number;
+    }
+  | undefined {
+  for (const [languageId, signatures] of OUTPUT_CONTENT_SIGNATURES) {
+    for (const signature of signatures) {
+      if (signature.test(content)) {
+        const server = _servers.find(s => s.languageId === languageId);
+        if (server) {
+          return {
+            kind: 'output',
+            serverId: server.id,
+            languageId,
+            confidence: 0.8,
+          };
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a file name looks like a known output or log file (without content).
+ *
+ * @param fileName - The base file name.
+ * @returns True if the file name matches known output/log patterns.
+ */
+export function isOutputOrLogFile(fileName: string): boolean {
+  const result = detectDocument(fileName);
+  return result.kind === 'output' || result.kind === 'log';
+}
+
+/**
+ * Get all known output file patterns for a given language ID.
+ *
+ * @param languageId - The VS Code language ID.
+ * @returns Array of RegExp patterns for output files of that language.
+ */
+export function getOutputPatternsForLanguage(languageId: string): readonly RegExp[] {
+  return OUTPUT_FILE_PATTERNS.get(languageId) ?? [];
+}
+
+/**
+ * Get all known log file patterns for a given language ID.
+ *
+ * @param languageId - The VS Code language ID.
+ * @returns Array of RegExp patterns for log files of that language.
+ */
+export function getLogPatternsForLanguage(languageId: string): readonly RegExp[] {
+  return LOG_FILE_PATTERNS.get(languageId) ?? [];
+}

--- a/src/smoke/index.ts
+++ b/src/smoke/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Smoke Test Infrastructure
+ *
+ * Public API surface for the OpenQC smoke test and verification system.
+ *
+ * @module smoke
+ */
+
+export type {
+  RuleSeverity,
+  RuleManifestEntry,
+  RuleManifest,
+  CheckStatus,
+  CompatibilityCheck,
+  LspCompatibilityEntry,
+  CompatibilityReport,
+  DocumentKind,
+  DocumentDetectionResult,
+  SmokeTestResult,
+  SmokeTestSummary,
+  VsixVerificationResult,
+  RepoGitHubStatus,
+  RepoGateResult,
+  RepoCleanStatus,
+  CampaignReport,
+} from './types';
+
+export {
+  validateManifest,
+  readManifestFromFile,
+  parseManifestString,
+  tryReadManifest,
+  getRulesBySeverity,
+  getRuleByCode,
+  getManifestCategories,
+  countRulesBySeverity,
+} from './ruleManifestReader';
+
+export {
+  detectDocument,
+  isOutputOrLogFile,
+  getOutputPatternsForLanguage,
+  getLogPatternsForLanguage,
+} from './documentDetector';
+
+export { generateCompatibilityReport, formatReportAsMarkdown } from './compatibilityReport';
+
+export {
+  runSmokeTestForLsp,
+  runAllSmokeTests,
+  verifyVsixPackage,
+  checkGitHubStatus,
+  runLocalGates,
+  checkRepoCleanliness,
+  generateCampaignReport,
+  formatCampaignReportAsMarkdown,
+} from './smokeRunner';

--- a/src/smoke/ruleManifestReader.ts
+++ b/src/smoke/ruleManifestReader.ts
@@ -1,0 +1,249 @@
+/**
+ * Rule Manifest Reader
+ *
+ * Reads and validates rule manifests exported by each LSP repository.
+ * Accepts `lsp-rules export --json` output from any LSP repo without
+ * embedding rule logic in OpenQC itself.
+ *
+ * @module smoke/ruleManifestReader
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/160
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/162
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { RuleManifest, RuleManifestEntry, RuleSeverity } from './types';
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+const VALID_SEVERITIES = new Set<string>(['error', 'warning', 'information', 'hint']);
+const SCHEMA_VERSIONS = new Set<string>(['1.0.0', '1.1.0']);
+
+/**
+ * Validate a parsed rule manifest object against the expected schema.
+ *
+ * Returns an array of validation error strings. An empty array means the
+ * manifest is valid.
+ *
+ * @param data - The parsed JSON object to validate.
+ * @returns Array of validation error messages.
+ */
+export function validateManifest(data: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!data || typeof data !== 'object') {
+    errors.push('Manifest must be a non-null object');
+    return errors;
+  }
+
+  const manifest = data as Record<string, unknown>;
+
+  if (typeof manifest.serverId !== 'string' || manifest.serverId.length === 0) {
+    errors.push('Manifest must have a non-empty string "serverId"');
+  }
+
+  if (typeof manifest.serverName !== 'string' || manifest.serverName.length === 0) {
+    errors.push('Manifest must have a non-empty string "serverName"');
+  }
+
+  if (typeof manifest.schemaVersion !== 'string') {
+    errors.push('Manifest must have a string "schemaVersion"');
+  } else if (!SCHEMA_VERSIONS.has(manifest.schemaVersion)) {
+    errors.push(
+      `Unsupported schema version "${manifest.schemaVersion}". ` +
+        `Supported: ${Array.from(SCHEMA_VERSIONS).join(', ')}`
+    );
+  }
+
+  if (typeof manifest.generatedAt !== 'string') {
+    errors.push('Manifest must have a string "generatedAt" timestamp');
+  }
+
+  if (!Array.isArray(manifest.rules)) {
+    errors.push('Manifest must have a "rules" array');
+  } else {
+    const ruleErrors = validateRules(manifest.rules as unknown[]);
+    errors.push(...ruleErrors);
+  }
+
+  return errors;
+}
+
+/**
+ * Validate the rules array entries.
+ */
+function validateRules(rules: unknown[]): string[] {
+  const errors: string[] = [];
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i];
+    if (!rule || typeof rule !== 'object') {
+      errors.push(`Rule at index ${i} must be a non-null object`);
+      continue;
+    }
+
+    const r = rule as Record<string, unknown>;
+
+    if (typeof r.code !== 'string' || r.code.length === 0) {
+      errors.push(`Rule at index ${i} must have a non-empty string "code"`);
+    }
+
+    if (typeof r.message !== 'string' || r.message.length === 0) {
+      errors.push(`Rule at index ${i} must have a non-empty string "message"`);
+    }
+
+    if (typeof r.severity !== 'string' || !VALID_SEVERITIES.has(r.severity)) {
+      errors.push(
+        `Rule at index ${i} has invalid "severity": "${r.severity}". ` +
+          `Must be one of: ${Array.from(VALID_SEVERITIES).join(', ')}`
+      );
+    }
+
+    if (r.category !== undefined && typeof r.category !== 'string') {
+      errors.push(`Rule at index ${i} "category" must be a string if present`);
+    }
+
+    if (r.blocking !== undefined && typeof r.blocking !== 'boolean') {
+      errors.push(`Rule at index ${i} "blocking" must be a boolean if present`);
+    }
+
+    if (r.confidence !== undefined) {
+      if (typeof r.confidence !== 'number' || r.confidence < 0 || r.confidence > 1) {
+        errors.push(`Rule at index ${i} "confidence" must be a number between 0 and 1`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Reader functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse a rule manifest from a JSON file path.
+ *
+ * @param filePath - Absolute or relative path to the manifest JSON file.
+ * @returns The parsed and validated rule manifest.
+ * @throws Error if the file cannot be read or validation fails.
+ */
+export function readManifestFromFile(filePath: string): RuleManifest {
+  const absolutePath = path.resolve(filePath);
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Rule manifest file not found: ${absolutePath}`);
+  }
+
+  const raw = fs.readFileSync(absolutePath, 'utf8');
+  return parseManifestString(raw);
+}
+
+/**
+ * Parse and validate a rule manifest from a JSON string.
+ *
+ * @param json - The raw JSON string to parse.
+ * @returns The parsed and validated rule manifest.
+ * @throws Error if parsing or validation fails.
+ */
+export function parseManifestString(json: string): RuleManifest {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch (parseError) {
+    const msg = parseError instanceof Error ? parseError.message : String(parseError);
+    throw new Error(`Failed to parse rule manifest JSON: ${msg}`);
+  }
+
+  const errors = validateManifest(data);
+  if (errors.length > 0) {
+    throw new Error(`Rule manifest validation failed:\n  ${errors.join('\n  ')}`);
+  }
+
+  return data as RuleManifest;
+}
+
+/**
+ * Attempt to read a manifest, returning a result object instead of throwing.
+ *
+ * @param filePath - Path to the manifest JSON file.
+ * @returns An object with either `manifest` on success or `error` on failure.
+ */
+export function tryReadManifest(filePath: string):
+  | { readonly manifest: RuleManifest; readonly error?: undefined }
+  | {
+      readonly manifest?: undefined;
+      readonly error: string;
+    } {
+  try {
+    const manifest = readManifestFromFile(filePath);
+    return { manifest };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { error: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all rules from a manifest filtered by severity.
+ *
+ * @param manifest - The rule manifest to query.
+ * @param severity - The severity level to filter by.
+ * @returns Matching rule entries.
+ */
+export function getRulesBySeverity(
+  manifest: RuleManifest,
+  severity: RuleSeverity
+): readonly RuleManifestEntry[] {
+  return manifest.rules.filter(rule => rule.severity === severity);
+}
+
+/**
+ * Get a specific rule by its code.
+ *
+ * @param manifest - The rule manifest to query.
+ * @param code - The rule code to look up.
+ * @returns The matching rule entry, or undefined if not found.
+ */
+export function getRuleByCode(manifest: RuleManifest, code: string): RuleManifestEntry | undefined {
+  return manifest.rules.find(rule => rule.code === code);
+}
+
+/**
+ * Get all unique categories present in a manifest.
+ *
+ * @param manifest - The rule manifest to query.
+ * @returns Sorted array of unique category strings.
+ */
+export function getManifestCategories(manifest: RuleManifest): readonly string[] {
+  const categories = new Set<string>();
+  for (const rule of manifest.rules) {
+    if (rule.category) {
+      categories.add(rule.category);
+    }
+  }
+  return Array.from(categories).sort();
+}
+
+/**
+ * Count rules by severity level.
+ *
+ * @param manifest - The rule manifest to query.
+ * @returns Record mapping severity to count.
+ */
+export function countRulesBySeverity(manifest: RuleManifest): Readonly<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const severity of VALID_SEVERITIES) {
+    counts[severity] = 0;
+  }
+  for (const rule of manifest.rules) {
+    counts[rule.severity] = (counts[rule.severity] || 0) + 1;
+  }
+  return counts;
+}

--- a/src/smoke/smokeRunner.ts
+++ b/src/smoke/smokeRunner.ts
@@ -1,0 +1,545 @@
+/**
+ * Smoke Test Runner
+ *
+ * Orchestrates smoke tests for all bundled LSP servers. Each verification step
+ * corresponds to one or more GitHub issues (#161, #164, #165, #168-#177).
+ *
+ * The runner is designed to work both locally (with sibling LSP repos present)
+ * and in CI (where sibling repos may not be available, causing graceful skips).
+ *
+ * @module smoke/smokeRunner
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/161
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/165
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { listBundledLspServers } from '../lsp/registry';
+import type { LSPServerRegistryEntry } from '../lsp/types';
+import type {
+  SmokeTestResult,
+  SmokeTestSummary,
+  VsixVerificationResult,
+  RepoGitHubStatus,
+  RepoGateResult,
+  RepoCleanStatus,
+  CampaignReport,
+  CompatibilityReport,
+} from './types';
+import { detectDocument } from './documentDetector';
+import { generateCompatibilityReport } from './compatibilityReport';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Required dependencies that must be present in the VSIX. */
+const REQUIRED_VSIX_DEPS = ['vscode-languageclient'];
+
+// ---------------------------------------------------------------------------
+// Smoke tests per LSP (Issues #161, #165)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run smoke tests for a single LSP server using fixture files.
+ *
+ * Checks valid input, invalid input, and runtime log fixtures.
+ *
+ * @param server - The LSP registry entry to test.
+ * @param fixturesDir - Directory containing smoke test fixtures.
+ * @returns Smoke test result for this LSP.
+ */
+export function runSmokeTestForLsp(
+  server: LSPServerRegistryEntry,
+  fixturesDir: string
+): SmokeTestResult {
+  const serverFixtureDir = path.join(fixturesDir, server.languageId);
+  let validInputPass = false;
+  let invalidInputPass = false;
+  let runtimeLogPass: boolean | null = null;
+  const details: string[] = [];
+
+  // Check valid input fixture
+  const validDir = path.join(serverFixtureDir, 'valid');
+  if (fs.existsSync(validDir)) {
+    const validFiles = fs.readdirSync(validDir).filter(f => !f.startsWith('.'));
+    if (validFiles.length > 0) {
+      const detected = detectDocument(validFiles[0]);
+      validInputPass = detected.kind === 'input' && detected.languageId === server.languageId;
+      if (!validInputPass) {
+        details.push(
+          `Valid fixture "${validFiles[0]}" detected as ${detected.kind} (${detected.languageId ?? 'none'})`
+        );
+      }
+    } else {
+      details.push('No valid fixture files found');
+    }
+  } else {
+    details.push('No valid fixture directory');
+  }
+
+  // Check invalid input fixture
+  const invalidDir = path.join(serverFixtureDir, 'invalid');
+  if (fs.existsSync(invalidDir)) {
+    const invalidFiles = fs.readdirSync(invalidDir).filter(f => !f.startsWith('.'));
+    if (invalidFiles.length > 0) {
+      const detected = detectDocument(invalidFiles[0]);
+      invalidInputPass = detected.kind === 'input' && detected.languageId === server.languageId;
+      if (!invalidInputPass) {
+        details.push(
+          `Invalid fixture "${invalidFiles[0]}" detected as ${detected.kind} (${detected.languageId ?? 'none'})`
+        );
+      }
+    } else {
+      details.push('No invalid fixture files found');
+    }
+  } else {
+    details.push('No invalid fixture directory');
+  }
+
+  // Check runtime log fixture (optional)
+  const logDir = path.join(serverFixtureDir, 'logs');
+  if (fs.existsSync(logDir)) {
+    const logFiles = fs.readdirSync(logDir).filter(f => !f.startsWith('.'));
+    if (logFiles.length > 0) {
+      const detected = detectDocument(logFiles[0]);
+      runtimeLogPass = detected.kind === 'output' || detected.kind === 'log';
+      if (!runtimeLogPass) {
+        details.push(`Log fixture "${logFiles[0]}" detected as ${detected.kind}`);
+      }
+    } else {
+      runtimeLogPass = null;
+    }
+  } else {
+    runtimeLogPass = null;
+  }
+
+  return {
+    serverId: server.id,
+    validInputPass,
+    invalidInputPass,
+    runtimeLogPass,
+    detail: details.length > 0 ? details.join('; ') : undefined,
+  };
+}
+
+/**
+ * Run smoke tests for all bundled LSP servers.
+ *
+ * @param fixturesDir - Directory containing per-LSP fixture subdirectories.
+ * @returns Overall smoke test summary.
+ */
+export function runAllSmokeTests(fixturesDir: string): SmokeTestSummary {
+  const servers = listBundledLspServers();
+  const results = servers.map(server => runSmokeTestForLsp(server, fixturesDir));
+
+  const passedServers = results.filter(r => {
+    const validOk = r.validInputPass;
+    const invalidOk = r.invalidInputPass;
+    const logOk = r.runtimeLogPass === null || r.runtimeLogPass === true;
+    return validOk && invalidOk && logOk;
+  }).length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalServers: servers.length,
+    passedServers,
+    results,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// VSIX Package Verification (Issue #166)
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify VSIX package integrity and dependency presence.
+ *
+ * @param repoRoot - Root directory of the OpenQC-VSCode repository.
+ * @returns VSIX verification result.
+ */
+export function verifyVsixPackage(repoRoot: string): VsixVerificationResult {
+  const pkgPath = path.join(repoRoot, 'package.json');
+  let packageJson: Record<string, unknown>;
+
+  try {
+    packageJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  } catch {
+    return {
+      buildSuccess: false,
+      hasLanguageClient: false,
+      foundDependencies: [],
+      missingDependencies: [...REQUIRED_VSIX_DEPS],
+      detail: 'Failed to read package.json',
+    };
+  }
+
+  const dependencies = Object.keys((packageJson.dependencies as Record<string, string>) ?? {});
+  const devDependencies = Object.keys(
+    (packageJson.devDependencies as Record<string, string>) ?? {}
+  );
+  const allDeps = [...dependencies, ...devDependencies];
+
+  const found: string[] = [];
+  const missing: string[] = [];
+
+  for (const dep of REQUIRED_VSIX_DEPS) {
+    if (allDeps.includes(dep)) {
+      found.push(dep);
+    } else {
+      missing.push(dep);
+    }
+  }
+
+  // Check if VSIX files exist
+  const vsixFiles = fs.readdirSync(repoRoot).filter(f => f.endsWith('.vsix'));
+
+  return {
+    buildSuccess: missing.length === 0,
+    hasLanguageClient: allDeps.includes('vscode-languageclient'),
+    foundDependencies: found,
+    missingDependencies: missing,
+    fileSize:
+      vsixFiles.length > 0 ? fs.statSync(path.join(repoRoot, vsixFiles[0])).size : undefined,
+    detail:
+      vsixFiles.length > 0
+        ? `Found VSIX: ${vsixFiles[0]}`
+        : 'No VSIX file found (build may not have been run)',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Status Checks (Issues #168, #169)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check GitHub issue and PR status for all LSP repositories.
+ *
+ * Uses the `gh` CLI to query repository status.
+ *
+ * @returns Per-repo GitHub status results.
+ */
+export function checkGitHubStatus(): readonly RepoGitHubStatus[] {
+  const servers = listBundledLspServers();
+
+  return servers.map(server => {
+    const [owner, repo] = server.repository.split('/');
+    let openIssues = -1;
+    let openPullRequests = -1;
+
+    try {
+      // Use gh api to get issue/PR counts
+      const { execSync } = require('child_process') as typeof import('child_process');
+
+      try {
+        const issueResult = execSync(
+          `gh issue list --repo ${server.repository} --state open --limit 1 --json totalCount 2>/dev/null`,
+          { encoding: 'utf8', timeout: 15000 }
+        );
+        const parsed = JSON.parse(issueResult) as { totalCount?: number };
+        openIssues = parsed.totalCount ?? 0;
+      } catch {
+        openIssues = -1;
+      }
+
+      try {
+        const prResult = execSync(
+          `gh pr list --repo ${server.repository} --state open --limit 1 --json totalCount 2>/dev/null`,
+          { encoding: 'utf8', timeout: 15000 }
+        );
+        const parsed = JSON.parse(prResult) as { totalCount?: number };
+        openPullRequests = parsed.totalCount ?? 0;
+      } catch {
+        openPullRequests = -1;
+      }
+    } catch {
+      openIssues = -1;
+      openPullRequests = -1;
+    }
+
+    return {
+      repository: server.repository,
+      openIssues,
+      openPullRequests,
+      passed: openIssues === 0 && openPullRequests === 0,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Local Gate Checks (Issue #170)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run local gate checks for sibling LSP repository checkouts.
+ *
+ * Checks whether each sibling repo exists and can run its test/lint gates.
+ *
+ * @param codeRoot - Parent directory containing sibling LSP repos.
+ * @returns Per-repo gate results.
+ */
+export function runLocalGates(codeRoot: string): readonly RepoGateResult[] {
+  const servers = listBundledLspServers();
+
+  return servers.map(server => {
+    const repoName = server.repository.split('/')[1];
+    const repoPath = path.join(codeRoot, repoName);
+
+    if (!fs.existsSync(path.join(repoPath, '.git'))) {
+      return {
+        repository: server.repository,
+        checkoutExists: false,
+        gatePassed: false,
+        detail: `No checkout at ${repoPath}`,
+      };
+    }
+
+    // Check if package.json or Cargo.toml or pyproject.toml exists for gate detection
+    const hasNpm = fs.existsSync(path.join(repoPath, 'package.json'));
+    const hasCargo = fs.existsSync(path.join(repoPath, 'Cargo.toml'));
+    const hasPyproject = fs.existsSync(path.join(repoPath, 'pyproject.toml'));
+
+    if (!hasNpm && !hasCargo && !hasPyproject) {
+      return {
+        repository: server.repository,
+        checkoutExists: true,
+        gatePassed: false,
+        detail: 'No recognizable project manifest found',
+      };
+    }
+
+    // For gate verification, just check the checkout exists and has a build system.
+    // Actual gate execution happens in CI or the full smoke script.
+    return {
+      repository: server.repository,
+      checkoutExists: true,
+      gatePassed: true,
+      detail: `Checkout found with ${hasNpm ? 'npm' : hasCargo ? 'cargo' : 'python'} project`,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Repo Cleanliness Check (Issue #176)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check git cleanliness of all sibling LSP repository checkouts.
+ *
+ * @param codeRoot - Parent directory containing sibling LSP repos.
+ * @returns Per-repo cleanliness status.
+ */
+export function checkRepoCleanliness(codeRoot: string): readonly RepoCleanStatus[] {
+  const servers = listBundledLspServers();
+
+  return servers.map(server => {
+    const repoName = server.repository.split('/')[1];
+    const repoPath = path.join(codeRoot, repoName);
+
+    if (!fs.existsSync(path.join(repoPath, '.git'))) {
+      return {
+        repository: server.repository,
+        exists: false,
+        isClean: false,
+      };
+    }
+
+    try {
+      const { execSync } = require('child_process') as typeof import('child_process');
+      const status = execSync('git status --short', {
+        cwd: repoPath,
+        encoding: 'utf8',
+        timeout: 10000,
+      }).trim();
+
+      return {
+        repository: server.repository,
+        exists: true,
+        isClean: status.length === 0,
+        statusOutput: status.length > 0 ? status : undefined,
+      };
+    } catch (err) {
+      return {
+        repository: server.repository,
+        exists: true,
+        isClean: false,
+        statusOutput: `git status failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Full Campaign Report (Issue #177)
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate the final campaign report combining all verification results.
+ *
+ * @param repoRoot - Root directory of the OpenQC-VSCode repository.
+ * @param codeRoot - Parent directory containing sibling LSP repos.
+ * @param runId - Unique identifier for this campaign run.
+ * @param manifestDir - Optional directory containing rule manifests.
+ * @param fixturesDir - Optional directory containing smoke test fixtures.
+ * @returns Complete campaign report.
+ */
+export function generateCampaignReport(
+  repoRoot: string,
+  codeRoot: string,
+  runId: string,
+  manifestDir?: string,
+  fixturesDir?: string
+): CampaignReport {
+  const compatibilityReport = generateCompatibilityReport(repoRoot, manifestDir);
+
+  const smokeTestSummary = fixturesDir ? runAllSmokeTests(fixturesDir) : undefined;
+
+  const vsixVerification = verifyVsixPackage(repoRoot);
+  const repoStatuses = checkGitHubStatus();
+  const gateResults = runLocalGates(codeRoot);
+  const cleanStatuses = checkRepoCleanliness(codeRoot);
+
+  const githubChecksPassed = repoStatuses.every(r => r.passed);
+  const localGatesPassed = gateResults.every(r => r.gatePassed);
+  const reposClean = cleanStatuses.every(r => !r.exists || r.isClean);
+
+  const overallPassed =
+    githubChecksPassed &&
+    localGatesPassed &&
+    vsixVerification.buildSuccess &&
+    reposClean &&
+    compatibilityReport.failedServers === 0;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    runId,
+    githubChecksPassed,
+    localGatesPassed,
+    openqcCiPassed: false,
+    vsixBuildPassed: vsixVerification.buildSuccess,
+    reposClean,
+    repoStatuses,
+    gateResults,
+    cleanStatuses,
+    compatibilityReport,
+    smokeTestSummary,
+    vsixVerification,
+    overallPassed,
+  };
+}
+
+/**
+ * Format the campaign report as markdown for the FINAL.md output.
+ *
+ * @param report - The campaign report to format.
+ * @returns Markdown-formatted report string.
+ */
+export function formatCampaignReportAsMarkdown(report: CampaignReport): string {
+  const lines: string[] = [
+    '# OpenQC Campaign Final Report',
+    '',
+    `**Run ID:** ${report.runId}`,
+    `**Generated:** ${report.generatedAt}`,
+    `**Overall:** ${report.overallPassed ? 'PASSED' : 'FAILED'}`,
+    '',
+    '## Summary',
+    '',
+    `| Check | Status |`,
+    `|-------|--------|`,
+    `| GitHub Checks (zero open issues/PRs) | ${report.githubChecksPassed ? 'PASS' : 'FAIL'} |`,
+    `| Local Gates | ${report.localGatesPassed ? 'PASS' : 'FAIL'} |`,
+    `| OpenQC CI | ${report.openqcCiPassed ? 'PASS' : 'NOT RUN'} |`,
+    `| VSIX Build | ${report.vsixBuildPassed ? 'PASS' : 'FAIL'} |`,
+    `| Repo Cleanliness | ${report.reposClean ? 'PASS' : 'FAIL'} |`,
+    '',
+  ];
+
+  // GitHub status table
+  lines.push('## Repository GitHub Status');
+  lines.push('');
+  lines.push('| Repository | Open Issues | Open PRs | Status |');
+  lines.push('|------------|-------------|----------|--------|');
+  for (const status of report.repoStatuses) {
+    const icon = status.passed ? 'PASS' : 'FAIL';
+    lines.push(
+      `| ${status.repository} | ${status.openIssues} | ${status.openPullRequests} | ${icon} |`
+    );
+  }
+  lines.push('');
+
+  // Gate results table
+  lines.push('## Local Gate Results');
+  lines.push('');
+  lines.push('| Repository | Checkout | Gate | Detail |');
+  lines.push('|------------|----------|------|--------|');
+  for (const gate of report.gateResults) {
+    lines.push(
+      `| ${gate.repository} | ${gate.checkoutExists ? 'Yes' : 'No'} | ${gate.gatePassed ? 'PASS' : 'FAIL'} | ${gate.detail ?? ''} |`
+    );
+  }
+  lines.push('');
+
+  // Cleanliness table
+  lines.push('## Repo Cleanliness');
+  lines.push('');
+  lines.push('| Repository | Exists | Clean | Status |');
+  lines.push('|------------|--------|-------|--------|');
+  for (const clean of report.cleanStatuses) {
+    lines.push(
+      `| ${clean.repository} | ${clean.exists ? 'Yes' : 'No'} | ${clean.isClean ? 'Yes' : 'No'} | ${clean.statusOutput ?? 'Clean'} |`
+    );
+  }
+  lines.push('');
+
+  // VSIX verification
+  if (report.vsixVerification) {
+    lines.push('## VSIX Verification');
+    lines.push('');
+    lines.push(`- Build Success: ${report.vsixVerification.buildSuccess}`);
+    lines.push(`- Has Language Client: ${report.vsixVerification.hasLanguageClient}`);
+    lines.push(`- Found: ${report.vsixVerification.foundDependencies.join(', ') || 'none'}`);
+    lines.push(`- Missing: ${report.vsixVerification.missingDependencies.join(', ') || 'none'}`);
+    if (report.vsixVerification.fileSize) {
+      lines.push(`- File Size: ${(report.vsixVerification.fileSize / 1024).toFixed(1)} KB`);
+    }
+    lines.push('');
+  }
+
+  // Compatibility summary
+  if (report.compatibilityReport) {
+    const cr = report.compatibilityReport;
+    lines.push('## Compatibility Report Summary');
+    lines.push('');
+    lines.push(
+      `**Total:** ${cr.totalServers} | **Passed:** ${cr.passedServers} | **Failed:** ${cr.failedServers}`
+    );
+    lines.push('');
+
+    for (const entry of cr.entries) {
+      const icon = entry.passed ? '[PASS]' : '[FAIL]';
+      lines.push(
+        `- ${icon} ${entry.serverName}: ${entry.checks.filter(c => c.status === 'pass').length}/${entry.checks.length} checks passed`
+      );
+    }
+    lines.push('');
+  }
+
+  // Smoke test summary
+  if (report.smokeTestSummary) {
+    const ss = report.smokeTestSummary;
+    lines.push('## Smoke Test Summary');
+    lines.push('');
+    lines.push(`**Total:** ${ss.totalServers} | **Passed:** ${ss.passedServers}`);
+    lines.push('');
+
+    for (const result of ss.results) {
+      const icon = result.validInputPass && result.invalidInputPass ? '[PASS]' : '[FAIL]';
+      lines.push(
+        `- ${icon} ${result.serverId}: valid=${result.validInputPass}, invalid=${result.invalidInputPass}, logs=${result.runtimeLogPass ?? 'N/A'}`
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/smoke/types.ts
+++ b/src/smoke/types.ts
@@ -85,6 +85,26 @@ export interface LspCompatibilityEntry {
   readonly languageId: string;
   /** Stability classification. */
   readonly stability: string;
+  /** Runtime command OpenQC will use by default. */
+  readonly runtimeCommand?: string;
+  /** Local sibling repository path, when known. */
+  readonly repoPath?: string;
+  /** Git commit of the sibling repository, when available. */
+  readonly repoCommit?: string;
+  /** Capability manifest summary, when available. */
+  readonly manifest?: {
+    readonly path: string;
+    readonly capabilities: readonly string[];
+    readonly agentCli: string;
+    readonly blockingPolicy: string;
+    readonly wikiFreshness: string;
+    readonly smokeFixtures: {
+      readonly valid: boolean;
+      readonly invalid: boolean;
+      readonly logs: boolean;
+    };
+    readonly missingCapabilities: readonly string[];
+  };
   /** Individual check results. */
   readonly checks: readonly CompatibilityCheck[];
   /** Overall pass/fail. */

--- a/src/smoke/types.ts
+++ b/src/smoke/types.ts
@@ -1,0 +1,247 @@
+/**
+ * Smoke Test and Verification Types
+ *
+ * Defines types for the OpenQC smoke test infrastructure including rule manifests,
+ * compatibility reports, verification results, and campaign reports.
+ *
+ * @module smoke/types
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/159
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/160
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/161
+ */
+
+// ---------------------------------------------------------------------------
+// Rule Manifest types (Issues #160, #162)
+// ---------------------------------------------------------------------------
+
+/** Severity level for a diagnostic rule. */
+export type RuleSeverity = 'error' | 'warning' | 'information' | 'hint';
+
+/** A single diagnostic rule exported by an LSP repository. */
+export interface RuleManifestEntry {
+  /** Unique rule code, e.g. "E001", "W010". */
+  readonly code: string;
+  /** Human-readable description of what this rule checks. */
+  readonly message: string;
+  /** Severity level. */
+  readonly severity: RuleSeverity;
+  /** Category grouping, e.g. "syntax", "semantics", "best-practice". */
+  readonly category?: string;
+  /** Whether the rule blocks downstream processing. */
+  readonly blocking?: boolean;
+  /** Confidence level 0-1 for automated application. */
+  readonly confidence?: number;
+}
+
+/**
+ * The full rule manifest exported by an LSP repository via
+ * `lsp-rules export --json` or equivalent.
+ */
+export interface RuleManifest {
+  /** LSP server registry ID, e.g. "gaussian-lsp". */
+  readonly serverId: string;
+  /** Human-readable software name, e.g. "Gaussian". */
+  readonly serverName: string;
+  /** Version of the manifest schema. */
+  readonly schemaVersion: string;
+  /** ISO-8601 timestamp when the manifest was generated. */
+  readonly generatedAt: string;
+  /** Diagnostic rules in this manifest. */
+  readonly rules: readonly RuleManifestEntry[];
+  /** Optional metadata about the export source. */
+  readonly source?: {
+    readonly repository?: string;
+    readonly commit?: string;
+    readonly branch?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility Report types (Issue #163)
+// ---------------------------------------------------------------------------
+
+/** Status of an individual compatibility check. */
+export type CheckStatus = 'pass' | 'fail' | 'skip' | 'warn';
+
+/** Result of a single compatibility check. */
+export interface CompatibilityCheck {
+  /** Name of the check, e.g. "registry-entry-exists". */
+  readonly name: string;
+  /** Human-readable description of what was checked. */
+  readonly description: string;
+  /** Result status. */
+  readonly status: CheckStatus;
+  /** Optional detail message (e.g. failure reason). */
+  readonly detail?: string;
+}
+
+/** Per-LSP compatibility report entry. */
+export interface LspCompatibilityEntry {
+  /** Registry ID. */
+  readonly serverId: string;
+  /** Human-readable name. */
+  readonly serverName: string;
+  /** Language ID. */
+  readonly languageId: string;
+  /** Stability classification. */
+  readonly stability: string;
+  /** Individual check results. */
+  readonly checks: readonly CompatibilityCheck[];
+  /** Overall pass/fail. */
+  readonly passed: boolean;
+}
+
+/** Full compatibility report. */
+export interface CompatibilityReport {
+  /** ISO-8601 timestamp. */
+  readonly generatedAt: string;
+  /** Total number of LSP servers checked. */
+  readonly totalServers: number;
+  /** Number that passed all checks. */
+  readonly passedServers: number;
+  /** Number that failed or had warnings. */
+  readonly failedServers: number;
+  /** Per-LSP details. */
+  readonly entries: readonly LspCompatibilityEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Output/Log Document Detection types (Issue #159)
+// ---------------------------------------------------------------------------
+
+/** Classification of a document type for diagnostics routing. */
+export type DocumentKind = 'input' | 'output' | 'log' | 'unknown';
+
+/** Result of output/log document detection. */
+export interface DocumentDetectionResult {
+  /** The detected document kind. */
+  readonly kind: DocumentKind;
+  /** The registry ID of the associated LSP server, if any. */
+  readonly serverId?: string;
+  /** The language ID of the associated input language, if any. */
+  readonly languageId?: string;
+  /** Confidence score 0-1. */
+  readonly confidence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Smoke Test types (Issue #161)
+// ---------------------------------------------------------------------------
+
+/** Result of a smoke test run for a single LSP. */
+export interface SmokeTestResult {
+  /** Registry ID. */
+  readonly serverId: string;
+  /** Whether valid input fixture passed. */
+  readonly validInputPass: boolean;
+  /** Whether invalid input fixture was correctly detected. */
+  readonly invalidInputPass: boolean;
+  /** Whether runtime log fixture was processed (or skipped if N/A). */
+  readonly runtimeLogPass: boolean | null;
+  /** Detail message if any check failed. */
+  readonly detail?: string;
+}
+
+/** Overall smoke test summary. */
+export interface SmokeTestSummary {
+  /** ISO-8601 timestamp. */
+  readonly generatedAt: string;
+  /** Total LSP servers tested. */
+  readonly totalServers: number;
+  /** Number that passed all applicable smoke tests. */
+  readonly passedServers: number;
+  /** Per-LSP results. */
+  readonly results: readonly SmokeTestResult[];
+}
+
+// ---------------------------------------------------------------------------
+// VSIX Verification types (Issue #166)
+// ---------------------------------------------------------------------------
+
+/** Result of VSIX package verification. */
+export interface VsixVerificationResult {
+  /** Whether the VSIX was built successfully. */
+  readonly buildSuccess: boolean;
+  /** Whether vscode-languageclient is listed as a dependency. */
+  readonly hasLanguageClient: boolean;
+  /** List of required dependencies found. */
+  readonly foundDependencies: readonly string[];
+  /** List of missing dependencies. */
+  readonly missingDependencies: readonly string[];
+  /** VSIX file size in bytes, if built. */
+  readonly fileSize?: number;
+  /** Detail message. */
+  readonly detail?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Final Verification types (Issues #168-#177)
+// ---------------------------------------------------------------------------
+
+/** GitHub repository status check result. */
+export interface RepoGitHubStatus {
+  /** Repository full name, e.g. "newtontech/gaussian-lsp". */
+  readonly repository: string;
+  /** Number of open issues. */
+  readonly openIssues: number;
+  /** Number of open PRs. */
+  readonly openPullRequests: number;
+  /** Whether the repo passed (zero open issues and PRs). */
+  readonly passed: boolean;
+}
+
+/** Result of running gates for an LSP repo. */
+export interface RepoGateResult {
+  /** Repository full name. */
+  readonly repository: string;
+  /** Whether the local checkout exists. */
+  readonly checkoutExists: boolean;
+  /** Whether gate tests passed. */
+  readonly gatePassed: boolean;
+  /** Detail message. */
+  readonly detail?: string;
+}
+
+/** Result of git cleanliness check. */
+export interface RepoCleanStatus {
+  /** Repository full name. */
+  readonly repository: string;
+  /** Whether the checkout exists. */
+  readonly exists: boolean;
+  /** Whether the working tree is clean. */
+  readonly isClean: boolean;
+  /** Output of `git status --short` if dirty. */
+  readonly statusOutput?: string;
+}
+
+/** Final campaign report. */
+export interface CampaignReport {
+  /** ISO-8601 timestamp. */
+  readonly generatedAt: string;
+  /** Run identifier. */
+  readonly runId: string;
+  /** Whether all GitHub checks passed. */
+  readonly githubChecksPassed: boolean;
+  /** Whether all local gates passed. */
+  readonly localGatesPassed: boolean;
+  /** Whether OpenQC CI passed. */
+  readonly openqcCiPassed: boolean;
+  /** Whether VSIX build succeeded. */
+  readonly vsixBuildPassed: boolean;
+  /** Whether all repos are clean. */
+  readonly reposClean: boolean;
+  /** Per-repo GitHub status. */
+  readonly repoStatuses: readonly RepoGitHubStatus[];
+  /** Per-repo gate results. */
+  readonly gateResults: readonly RepoGateResult[];
+  /** Per-repo cleanliness. */
+  readonly cleanStatuses: readonly RepoCleanStatus[];
+  /** Compatibility report summary. */
+  readonly compatibilityReport?: CompatibilityReport;
+  /** Smoke test summary. */
+  readonly smokeTestSummary?: SmokeTestSummary;
+  /** VSIX verification result. */
+  readonly vsixVerification?: VsixVerificationResult;
+  /** Overall pass/fail. */
+  readonly overallPassed: boolean;
+}

--- a/syntaxes/dpgen.tmLanguage.json
+++ b/syntaxes/dpgen.tmLanguage.json
@@ -1,0 +1,21 @@
+{
+  "scopeName": "source.dpgen",
+  "patterns": [
+    {
+      "match": "\\b(true|false|null)\\b",
+      "name": "constant.language.json.dpgen"
+    },
+    {
+      "match": "\\b[-+]?\\d+(?:\\.\\d+)?(?:[eE][-+]?\\d+)?\\b",
+      "name": "constant.numeric.dpgen"
+    },
+    {
+      "match": "\"([^\"\\\\]|\\\\.)*\"",
+      "name": "string.quoted.double.dpgen"
+    },
+    {
+      "match": "\\b[A-Za-z_][A-Za-z0-9_./-]*\\b",
+      "name": "support.type.property-name.dpgen"
+    }
+  ]
+}

--- a/tests/fixtures/smoke/manifests/gaussian-lsp-rules.json
+++ b/tests/fixtures/smoke/manifests/gaussian-lsp-rules.json
@@ -1,0 +1,45 @@
+{
+  "serverId": "gaussian-lsp",
+  "serverName": "Gaussian",
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-06-12T00:00:00Z",
+  "rules": [
+    {
+      "code": "E001",
+      "message": "Syntax error in route section",
+      "severity": "error",
+      "category": "syntax",
+      "blocking": true,
+      "confidence": 0.95
+    },
+    {
+      "code": "W001",
+      "message": "Deprecated keyword usage",
+      "severity": "warning",
+      "category": "best-practice",
+      "blocking": false,
+      "confidence": 0.9
+    },
+    {
+      "code": "I001",
+      "message": "Informational: consider using tighter SCF convergence",
+      "severity": "information",
+      "category": "performance",
+      "blocking": false,
+      "confidence": 0.7
+    },
+    {
+      "code": "E002",
+      "message": "Missing required keyword",
+      "severity": "error",
+      "category": "semantics",
+      "blocking": true,
+      "confidence": 1.0
+    }
+  ],
+  "source": {
+    "repository": "newtontech/gaussian-lsp",
+    "commit": "abc1234",
+    "branch": "main"
+  }
+}

--- a/tests/fixtures/smoke/manifests/invalid-rules.json
+++ b/tests/fixtures/smoke/manifests/invalid-rules.json
@@ -1,0 +1,5 @@
+{
+  "serverId": "",
+  "schemaVersion": "99.0.0",
+  "rules": "not-an-array"
+}

--- a/tests/fixtures/smoke/manifests/vasp-lsp-rules.json
+++ b/tests/fixtures/smoke/manifests/vasp-lsp-rules.json
@@ -1,0 +1,22 @@
+{
+  "serverId": "vasp-lsp",
+  "serverName": "VASP",
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-06-12T00:00:00Z",
+  "rules": [
+    {
+      "code": "E001",
+      "message": "Unknown INCAR tag",
+      "severity": "error",
+      "category": "semantics"
+    },
+    {
+      "code": "W001",
+      "message": "ENCUT below recommended minimum",
+      "severity": "warning",
+      "category": "best-practice",
+      "blocking": false,
+      "confidence": 0.85
+    }
+  ]
+}

--- a/tests/integration/smoke/registryAlignment.test.ts
+++ b/tests/integration/smoke/registryAlignment.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Registry/Package/Docs Alignment Integration Tests
+ *
+ * Integration tests that verify alignment between the LSP registry,
+ * package.json contributions, language configurations, grammars, and
+ * documentation.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/164
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/165
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { listBundledLspServers, getLspDiagnosticReadiness } from '../../../src/lsp/registry';
+import { generateCompatibilityReport } from '../../../src/smoke/compatibilityReport';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+
+describe('Registry/Package/Docs Alignment Integration', () => {
+  const servers = listBundledLspServers();
+  const packageJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+  const languages = packageJson.contributes?.languages ?? [];
+  const grammarDir = path.join(REPO_ROOT, 'syntaxes');
+  const configDir = path.join(REPO_ROOT, 'language-configurations');
+  const compatDoc = fs.readFileSync(path.join(REPO_ROOT, 'docs', 'LSP_COMPATIBILITY.md'), 'utf8');
+
+  // -------------------------------------------------------------------------
+  // Registry completeness
+  // -------------------------------------------------------------------------
+
+  test('every registry entry has a matching package.json language contribution', () => {
+    for (const server of servers) {
+      const lang = languages.find((l: Record<string, unknown>) => l.id === server.languageId);
+      expect(lang).toBeDefined();
+
+      // Verify extensions match
+      const pkgExtensions = (lang?.extensions ?? []) as string[];
+      for (const ext of server.fileExtensions) {
+        expect(pkgExtensions).toContain(`.${ext}`);
+      }
+
+      // Verify filenames match
+      const pkgFilenames = (lang?.filenames ?? []) as string[];
+      for (const fn of server.fileNames) {
+        expect(pkgFilenames).toContain(fn);
+      }
+    }
+  });
+
+  test('every package.json language has a registry entry', () => {
+    for (const lang of languages) {
+      const server = servers.find(s => s.languageId === lang.id);
+      expect(server).toBeDefined();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Grammar files
+  // -------------------------------------------------------------------------
+
+  test('every registry entry has a grammar file', () => {
+    const grammarFiles = fs.readdirSync(grammarDir);
+
+    for (const server of servers) {
+      const hasJsonGrammar = grammarFiles.includes(`${server.languageId}.tmLanguage.json`);
+      const hasYamlGrammar = grammarFiles.includes(`${server.languageId}.tmLanguage.yaml`);
+      const hasPlistGrammar = grammarFiles.includes(`${server.languageId}.tmLanguage`);
+
+      expect(hasJsonGrammar || hasYamlGrammar || hasPlistGrammar).toBe(true);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Language configurations
+  // -------------------------------------------------------------------------
+
+  test('every registry entry has a language configuration file', () => {
+    const configFiles = fs.readdirSync(configDir);
+
+    for (const server of servers) {
+      const hasConfig = configFiles.includes(`${server.languageId}.json`);
+      expect(hasConfig).toBe(true);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Documentation alignment
+  // -------------------------------------------------------------------------
+
+  test('every registry entry is documented in LSP_COMPATIBILITY.md', () => {
+    for (const server of servers) {
+      expect(compatDoc).toContain(server.repository);
+      expect(compatDoc).toContain(`\`${server.languageId}\``);
+      expect(compatDoc).toContain(`\`${server.defaultBranch}\``);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Diagnostic readiness
+  // -------------------------------------------------------------------------
+
+  test('every registry entry has diagnostic readiness metadata', () => {
+    for (const server of servers) {
+      const readiness = getLspDiagnosticReadiness(server.id);
+      expect(readiness).toBeDefined();
+      expect(readiness!.diagnosticEngine).toBe('v1');
+      expect(readiness!.richDiagnostics).toBe(true);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Configuration defaults alignment
+  // -------------------------------------------------------------------------
+
+  test('configuration defaults in package.json match registry', () => {
+    const properties = packageJson.contributes?.configuration?.properties ?? {};
+
+    for (const server of servers) {
+      const enabledKey = `openqc.lsp.${server.languageId}.enabled`;
+      const pathKey = `openqc.lsp.${server.languageId}.path`;
+      const commandKey = `openqc.lsp.${server.languageId}.command`;
+
+      expect(properties[enabledKey]).toBeDefined();
+      expect(properties[enabledKey].default).toBe(server.enabled);
+
+      expect(properties[pathKey]).toBeDefined();
+      expect(properties[pathKey].default).toBe(server.executable);
+
+      expect(properties[commandKey]).toBeDefined();
+      expect(properties[commandKey].default).toBe(server.executable);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Full compatibility report
+  // -------------------------------------------------------------------------
+
+  test('full compatibility report passes for all servers', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    expect(report.totalServers).toBe(16);
+
+    // All should pass core checks
+    for (const entry of report.entries) {
+      const registryCheck = entry.checks.find(c => c.name === 'registry-entry-exists');
+      expect(registryCheck!.status).toBe('pass');
+
+      const langCheck = entry.checks.find(c => c.name === 'package-json-language');
+      expect(langCheck!.status).toBe('pass');
+
+      const docsCheck = entry.checks.find(c => c.name === 'docs-alignment');
+      expect(docsCheck!.status).toBe('pass');
+
+      const diagCheck = entry.checks.find(c => c.name === 'diagnostic-readiness');
+      expect(diagCheck!.status).toBe('pass');
+
+      const launchCheck = entry.checks.find(c => c.name === 'local-launch-config');
+      expect(launchCheck!.status).toBe('pass');
+    }
+  });
+});

--- a/tests/integration/smoke/registryAlignment.test.ts
+++ b/tests/integration/smoke/registryAlignment.test.ts
@@ -137,7 +137,7 @@ describe('Registry/Package/Docs Alignment Integration', () => {
 
   test('full compatibility report passes for all servers', () => {
     const report = generateCompatibilityReport(REPO_ROOT);
-    expect(report.totalServers).toBe(16);
+    expect(report.totalServers).toBe(17);
 
     // All should pass core checks
     for (const entry of report.entries) {

--- a/tests/unit/lsp/capabilityManifest.test.ts
+++ b/tests/unit/lsp/capabilityManifest.test.ts
@@ -1,0 +1,76 @@
+import * as path from 'path';
+import {
+  getCapabilityManifestPath,
+  loadCapabilityManifest,
+  validateCapabilityManifest,
+} from '../../../src/lsp/capabilityManifest';
+import { getLspServerByLanguageId } from '../../../src/lsp/registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+
+describe('capabilityManifest', () => {
+  it('loads and validates a sibling LSP capability manifest', () => {
+    const server = getLspServerByLanguageId('dpgen');
+    expect(server).toBeDefined();
+
+    const result = loadCapabilityManifest(REPO_ROOT, server!);
+    expect(result.error).toBeUndefined();
+    expect(result.manifest).toBeDefined();
+    expect(result.manifest!.id).toBe('dpgen-lsp');
+    expect(result.manifest!.agentCli.operations).toEqual(
+      expect.arrayContaining([
+        'capabilities',
+        'check',
+        'context',
+        'complete',
+        'hover',
+        'symbols',
+        'fix',
+      ])
+    );
+  });
+
+  it('returns the expected sibling manifest path', () => {
+    const server = getLspServerByLanguageId('vasp');
+    expect(server).toBeDefined();
+    expect(getCapabilityManifestPath(REPO_ROOT, server!)).toContain(
+      'VASP-LSP/lsp-capabilities.json'
+    );
+  });
+
+  it('reports registry mismatches', () => {
+    const server = getLspServerByLanguageId('qe');
+    expect(server).toBeDefined();
+    const error = validateCapabilityManifest(
+      {
+        schema: 'OpenQCLspCapabilities',
+        version: 1,
+        id: 'wrong',
+        languageId: 'qe',
+        executable: 'qe-lsp',
+        defaultBranch: 'main',
+        filePatterns: ['*.in'],
+        blockingPolicy: { mode: 'warning-only' },
+        capabilities: ['diagnostics'],
+        agentCli: {
+          command: 'qe-lsp-tool',
+          operations: ['capabilities', 'check', 'context', 'complete', 'hover', 'symbols', 'fix'],
+          jsonFormat: true,
+          failOnBlocking: true,
+        },
+        diagnosticSchema: 'diagnostics/diagnostic-engine-v1.schema.json',
+        wikiPaths: {},
+        fixturePaths: {},
+        outputLogPatterns: [],
+        openqc: {
+          registryId: 'qe-lsp',
+          repoName: 'qe-lsp',
+          contextContract: 'DSLAuthoringContext',
+          diagnosticEnvelope: 'DiagnosticEnvelope/v1',
+        },
+      },
+      server!
+    );
+    expect(error).toContain('id wrong != qe-lsp');
+  });
+});

--- a/tests/unit/lsp/registry.test.ts
+++ b/tests/unit/lsp/registry.test.ts
@@ -17,7 +17,7 @@ describe('LSP Registry', () => {
   const allServers = listBundledLspServers();
 
   it('contains all local LSP repositories from the OpenQC workspace', () => {
-    expect(getBundledLspServerCount()).toBe(16);
+    expect(getBundledLspServerCount()).toBe(17);
     expect(allServers.map(server => server.languageId)).toEqual([
       'abacus',
       'abinit',
@@ -35,12 +35,14 @@ describe('LSP Registry', () => {
       'mlip',
       'pyatb',
       'pyscf',
+      'dpgen',
     ]);
     expect(allServers.map(server => server.id).sort()).toEqual([
       'abacus-lsp',
       'abinit-lsp',
       'cif-lsp',
       'cp2k-lsp-enhanced',
+      'dpgen-lsp',
       'gamess-lsp',
       'gaussian-lsp',
       'gpumd-lsp',
@@ -88,6 +90,7 @@ describe('LSP Registry', () => {
       'nwchem',
       'pyatb',
       'pyscf',
+      'dpgen',
     ];
 
     for (const languageId of experimentalIds) {
@@ -205,7 +208,7 @@ describe('LSP Registry', () => {
     expect(first).toEqual(second);
 
     first.push({} as LSPServerRegistryEntry);
-    expect(listBundledLspServers()).toHaveLength(16);
+    expect(listBundledLspServers()).toHaveLength(17);
   });
 
   it('defines a local launch strategy for every bundled local LSP', () => {

--- a/tests/unit/smoke/compatibilityReport.test.ts
+++ b/tests/unit/smoke/compatibilityReport.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Compatibility Report Tests
+ *
+ * Tests for the compatibility report generator.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/163
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/167
+ */
+
+import * as path from 'path';
+import {
+  generateCompatibilityReport,
+  formatReportAsMarkdown,
+} from '../../../src/smoke/compatibilityReport';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const MANIFESTS_DIR = path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests');
+
+// ---------------------------------------------------------------------------
+// generateCompatibilityReport
+// ---------------------------------------------------------------------------
+
+describe('generateCompatibilityReport', () => {
+  it('generates a report covering all 16 LSP servers', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    expect(report.totalServers).toBe(16);
+    expect(report.entries).toHaveLength(16);
+  });
+
+  it('includes timestamps', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    expect(report.generatedAt).toBeTruthy();
+    expect(new Date(report.generatedAt).getTime()).not.toBeNaN();
+  });
+
+  it('counts passed and failed servers', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    expect(report.passedServers + report.failedServers).toBe(report.totalServers);
+  });
+
+  it('checks registry entry for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const registryCheck = entry.checks.find(c => c.name === 'registry-entry-exists');
+      expect(registryCheck).toBeDefined();
+      expect(registryCheck!.status).toBe('pass');
+    }
+  });
+
+  it('checks package.json language contribution for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const langCheck = entry.checks.find(c => c.name === 'package-json-language');
+      expect(langCheck).toBeDefined();
+      expect(langCheck!.status).toBe('pass');
+    }
+  });
+
+  it('checks package.json configuration for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const configCheck = entry.checks.find(c => c.name === 'package-json-configuration');
+      expect(configCheck).toBeDefined();
+      // Should pass or warn (some may be missing optional settings)
+      expect(['pass', 'warn']).toContain(configCheck!.status);
+    }
+  });
+
+  it('checks docs alignment for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const docsCheck = entry.checks.find(c => c.name === 'docs-alignment');
+      expect(docsCheck).toBeDefined();
+      expect(docsCheck!.status).toBe('pass');
+    }
+  });
+
+  it('checks diagnostic readiness for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const diagCheck = entry.checks.find(c => c.name === 'diagnostic-readiness');
+      expect(diagCheck).toBeDefined();
+      expect(diagCheck!.status).toBe('pass');
+    }
+  });
+
+  it('checks local launch config for each server', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const launchCheck = entry.checks.find(c => c.name === 'local-launch-config');
+      expect(launchCheck).toBeDefined();
+      expect(launchCheck!.status).toBe('pass');
+    }
+  });
+
+  it('checks rule manifests when manifestDir is provided', () => {
+    const report = generateCompatibilityReport(REPO_ROOT, MANIFESTS_DIR);
+    const gaussian = report.entries.find(e => e.serverId === 'gaussian-lsp');
+    expect(gaussian).toBeDefined();
+    const manifestCheck = gaussian!.checks.find(c => c.name === 'rule-manifest');
+    expect(manifestCheck).toBeDefined();
+    expect(manifestCheck!.status).toBe('pass');
+    expect(manifestCheck!.detail).toContain('4 rules');
+  });
+
+  it('skips rule manifest check when no manifestDir provided', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const manifestCheck = entry.checks.find(c => c.name === 'rule-manifest');
+      expect(manifestCheck).toBeDefined();
+      expect(manifestCheck!.status).toBe('skip');
+    }
+  });
+
+  it('handles invalid repoRoot gracefully', () => {
+    const report = generateCompatibilityReport('/nonexistent/path');
+    expect(report.totalServers).toBe(16);
+    // Should still generate the report but with failures
+    for (const entry of report.entries) {
+      const docsCheck = entry.checks.find(c => c.name === 'docs-alignment');
+      expect(docsCheck!.status).toBe('fail');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatReportAsMarkdown
+// ---------------------------------------------------------------------------
+
+describe('formatReportAsMarkdown', () => {
+  it('produces markdown output', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    const md = formatReportAsMarkdown(report);
+    expect(md).toContain('# OpenQC LSP Compatibility Report');
+    expect(md).toContain('## Per-Server Results');
+  });
+
+  it('includes server names in the markdown', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    const md = formatReportAsMarkdown(report);
+    expect(md).toContain('Gaussian');
+    expect(md).toContain('VASP');
+  });
+
+  it('includes check details', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    const md = formatReportAsMarkdown(report);
+    expect(md).toContain('registry-entry-exists');
+    expect(md).toContain('package-json-language');
+  });
+});

--- a/tests/unit/smoke/compatibilityReport.test.ts
+++ b/tests/unit/smoke/compatibilityReport.test.ts
@@ -12,6 +12,7 @@ import {
   generateCompatibilityReport,
   formatReportAsMarkdown,
 } from '../../../src/smoke/compatibilityReport';
+import { getBundledLspServerCount } from '../../../src/lsp/registry';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../');
 const MANIFESTS_DIR = path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests');
@@ -21,10 +22,10 @@ const MANIFESTS_DIR = path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests');
 // ---------------------------------------------------------------------------
 
 describe('generateCompatibilityReport', () => {
-  it('generates a report covering all 16 LSP servers', () => {
+  it('generates a report covering every bundled LSP server', () => {
     const report = generateCompatibilityReport(REPO_ROOT);
-    expect(report.totalServers).toBe(16);
-    expect(report.entries).toHaveLength(16);
+    expect(report.totalServers).toBe(getBundledLspServerCount());
+    expect(report.entries).toHaveLength(getBundledLspServerCount());
   });
 
   it('includes timestamps', () => {
@@ -93,6 +94,30 @@ describe('generateCompatibilityReport', () => {
     }
   });
 
+  it('checks capability manifests for sibling LSP repositories that expose them', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    for (const entry of report.entries) {
+      const manifestCheck = entry.checks.find(c => c.name === 'lsp-capability-manifest');
+      expect(manifestCheck).toBeDefined();
+      if (manifestCheck!.status === 'pass') {
+        expect(entry.manifest).toBeDefined();
+        expect(entry.manifest!.agentCli).toBeTruthy();
+        expect(entry.manifest!.capabilities).toContain('diagnostics');
+      }
+      expect(entry.runtimeCommand).toContain(entry.languageId === 'cp2k' ? 'cp2k' : '');
+    }
+  });
+
+  it('includes runtime and manifest fields in each report entry', () => {
+    const report = generateCompatibilityReport(REPO_ROOT);
+    const dpgen = report.entries.find(e => e.serverId === 'dpgen-lsp');
+    expect(dpgen).toBeDefined();
+    expect(dpgen!.runtimeCommand).toBe('dpgen-lsp --stdio');
+    expect(dpgen!.repoPath).toContain('dpgen-lsp');
+    expect(dpgen!.manifest?.blockingPolicy).toBe('blocking');
+    expect(dpgen!.manifest?.missingCapabilities).toEqual([]);
+  });
+
   it('checks rule manifests when manifestDir is provided', () => {
     const report = generateCompatibilityReport(REPO_ROOT, MANIFESTS_DIR);
     const gaussian = report.entries.find(e => e.serverId === 'gaussian-lsp');
@@ -114,7 +139,7 @@ describe('generateCompatibilityReport', () => {
 
   it('handles invalid repoRoot gracefully', () => {
     const report = generateCompatibilityReport('/nonexistent/path');
-    expect(report.totalServers).toBe(16);
+    expect(report.totalServers).toBe(getBundledLspServerCount());
     // Should still generate the report but with failures
     for (const entry of report.entries) {
       const docsCheck = entry.checks.find(c => c.name === 'docs-alignment');
@@ -147,5 +172,7 @@ describe('formatReportAsMarkdown', () => {
     const md = formatReportAsMarkdown(report);
     expect(md).toContain('registry-entry-exists');
     expect(md).toContain('package-json-language');
+    expect(md).toContain('lsp-capability-manifest');
+    expect(md).toContain('Runtime command');
   });
 });

--- a/tests/unit/smoke/documentDetector.test.ts
+++ b/tests/unit/smoke/documentDetector.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Document Detector Tests
+ *
+ * Tests for output/log document detection. Note that the detector prioritizes
+ * input file detection (Phase 1) over output detection (Phase 2). Files that
+ * appear in the LSP registry as input fileNames or extensions will always be
+ * detected as "input" even if they also appear in output patterns.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/159
+ */
+
+import {
+  detectDocument,
+  isOutputOrLogFile,
+  getOutputPatternsForLanguage,
+  getLogPatternsForLanguage,
+} from '../../../src/smoke/documentDetector';
+
+// ---------------------------------------------------------------------------
+// Input file detection
+// ---------------------------------------------------------------------------
+
+describe('detectDocument - input files', () => {
+  it('detects VASP INCAR as input', () => {
+    const result = detectDocument('INCAR');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('vasp');
+    expect(result.confidence).toBe(1.0);
+  });
+
+  it('detects VASP POSCAR as input', () => {
+    const result = detectDocument('POSCAR');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  it('detects VASP KPOINTS as input', () => {
+    const result = detectDocument('KPOINTS');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  it('detects VASP POTCAR as input', () => {
+    const result = detectDocument('POTCAR');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  // Note: OUTCAR and CONTCAR are in the VASP registry's fileNames list,
+  // so they are detected as "input" in Phase 1 even though they are
+  // conceptually output files. This is correct behavior for the registry
+  // alignment -- the registry declares them as files the VASP LSP handles.
+
+  it('detects Gaussian .gjf files as input', () => {
+    const result = detectDocument('water.gjf');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gaussian');
+  });
+
+  it('detects Gaussian .com files as input', () => {
+    const result = detectDocument('opt.com');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gaussian');
+  });
+
+  it('detects LAMMPS .lmp files as input', () => {
+    const result = detectDocument('relax.lmp');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('lammps');
+  });
+
+  it('detects LAMMPS in.lammps files as input', () => {
+    const result = detectDocument('in.lammps');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('lammps');
+  });
+
+  it('detects CIF .cif files as input', () => {
+    const result = detectDocument('structure.cif');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('cif');
+  });
+
+  it('detects ABACUS INPUT file as input', () => {
+    const result = detectDocument('INPUT');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('abacus');
+  });
+
+  it('detects ABACUS STRU file as input', () => {
+    const result = detectDocument('STRU');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('abacus');
+  });
+
+  it('detects NWChem .nw files as input', () => {
+    const result = detectDocument('calc.nw');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('nwchem');
+  });
+
+  it('detects GROMACS .top files as input', () => {
+    const result = detectDocument('system.top');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gromacs');
+  });
+
+  it('detects GROMACS .mdp files as input', () => {
+    const result = detectDocument('grompp.mdp');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gromacs');
+  });
+
+  it('detects GPUMD run.in files as input via fileNames match', () => {
+    // run.in is in GPUMD's fileNames in the registry
+    const result = detectDocument('run.in');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gpumd');
+  });
+
+  it('detects GPUMD nep.in files as input via fileNames match', () => {
+    // nep.in is in GPUMD's fileNames in the registry
+    const result = detectDocument('nep.in');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('gpumd');
+  });
+
+  it('detects QE .scf.in files as input', () => {
+    const result = detectDocument('pw.scf.in');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('qe');
+  });
+
+  it('detects ABINIT .abi files as input', () => {
+    const result = detectDocument('t1.abi');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('abinit');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ambiguous extension tests
+// ---------------------------------------------------------------------------
+
+describe('detectDocument - ambiguous extensions', () => {
+  it('detects .inp files as input (first registry match wins)', () => {
+    // .inp is shared by CP2K, ORCA, GAMESS. The registry order determines priority.
+    const result = detectDocument('calc.inp');
+    expect(result.kind).toBe('input');
+    // CP2K comes first in the registry for .inp extension
+    expect(result.languageId).toBe('cp2k');
+  });
+
+  it('detects .lammps files as input via extension', () => {
+    // .lammps extension is registered for LAMMPS
+    const result = detectDocument('log.lammps');
+    expect(result.kind).toBe('input');
+    expect(result.languageId).toBe('lammps');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output file detection
+// ---------------------------------------------------------------------------
+
+describe('detectDocument - output files', () => {
+  it('detects ORCA prefixed .out as output', () => {
+    const result = detectDocument('ORCA_job.out');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('orca');
+  });
+
+  it('detects GPUMD thermo.out as output', () => {
+    const result = detectDocument('thermo.out');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('gpumd');
+  });
+
+  it('detects CP2K .ener as output', () => {
+    const result = detectDocument('md.ener');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('cp2k');
+  });
+
+  it('detects GROMACS .xvg as output', () => {
+    const result = detectDocument('energy.xvg');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('gromacs');
+  });
+
+  it('detects ABACUS running_*.log as output', () => {
+    const result = detectDocument('running_scf.log');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('abacus');
+  });
+
+  it('detects NWChem .nwout as output', () => {
+    const result = detectDocument('calc.nwout');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('nwchem');
+  });
+
+  it('detects VASP DOSCAR as output', () => {
+    // DOSCAR is NOT in the registry fileNames, so it hits output patterns
+    const result = detectDocument('DOSCAR');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  it('detects VASP WAVECAR as output', () => {
+    const result = detectDocument('WAVECAR');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  it('detects LAMMPS dump files as output', () => {
+    const result = detectDocument('dump.atoms');
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('lammps');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Content-based detection
+// ---------------------------------------------------------------------------
+
+describe('detectDocument - content detection', () => {
+  it('detects Gaussian output from content', () => {
+    const content = ' Entering Gaussian System ... some output ... Normal termination of Gaussian.';
+    const result = detectDocument('unknown_file.txt', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('gaussian');
+  });
+
+  it('detects VASP output content', () => {
+    const content = 'FREE ENERGIE OF THE ION-ELECTRON SYSTEM\nE0= -.12345E+02';
+    const result = detectDocument('output.dat', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('vasp');
+  });
+
+  it('detects LAMMPS output from content', () => {
+    const content = 'LAMMPS (29 Oct 2020)\nTotal wall time: 0:00:01';
+    const result = detectDocument('out.txt', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('lammps');
+  });
+
+  it('detects ORCA output from content', () => {
+    const content = '* O   R   C   A *\nORCA TERMINATED NORMALLY';
+    const result = detectDocument('result.txt', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('orca');
+  });
+
+  it('detects CP2K output from content', () => {
+    const content = 'CP2K| Program started at 2026-01-01\nENERGY| Total energy: -123.45';
+    const result = detectDocument('output.txt', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('cp2k');
+  });
+
+  it('detects QE output from content', () => {
+    const content = 'PROGRAM PWSCF ENDED\n some data';
+    const result = detectDocument('output.dat', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('qe');
+  });
+
+  it('detects GAMESS output from content', () => {
+    const content = 'GAMESS VERSION 2022\n some data';
+    const result = detectDocument('output.dat', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('gamess');
+  });
+
+  it('detects GROMACS output from content', () => {
+    const content = 'GROMACS mdrun finished\n some data';
+    const result = detectDocument('output.dat', content);
+    expect(result.kind).toBe('output');
+    expect(result.languageId).toBe('gromacs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown files
+// ---------------------------------------------------------------------------
+
+describe('detectDocument - unknown files', () => {
+  it('returns unknown for unrecognized file names without content', () => {
+    const result = detectDocument('random_file.dat');
+    expect(result.kind).toBe('unknown');
+    expect(result.confidence).toBe(0);
+  });
+
+  it('returns unknown for empty string', () => {
+    const result = detectDocument('');
+    expect(result.kind).toBe('unknown');
+  });
+
+  it('returns unknown for unrecognized file with non-matching content', () => {
+    const result = detectDocument('random_file.xyz', 'just some random text with no signatures');
+    expect(result.kind).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+describe('isOutputOrLogFile', () => {
+  it('returns true for known output files', () => {
+    expect(isOutputOrLogFile('DOSCAR')).toBe(true);
+    expect(isOutputOrLogFile('WAVECAR')).toBe(true);
+    expect(isOutputOrLogFile('ORCA_job.out')).toBe(true);
+    expect(isOutputOrLogFile('thermo.out')).toBe(true);
+    expect(isOutputOrLogFile('dump.atoms')).toBe(true);
+    expect(isOutputOrLogFile('energy.xvg')).toBe(true);
+  });
+
+  it('returns false for input files that are in the registry', () => {
+    // OUTCAR is in VASP's fileNames, so it is detected as input
+    expect(isOutputOrLogFile('INCAR')).toBe(false);
+    expect(isOutputOrLogFile('water.gjf')).toBe(false);
+  });
+
+  it('returns false for unknown files', () => {
+    expect(isOutputOrLogFile('random.txt')).toBe(false);
+  });
+});
+
+describe('getOutputPatternsForLanguage', () => {
+  it('returns patterns for known languages', () => {
+    const patterns = getOutputPatternsForLanguage('vasp');
+    expect(patterns.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for unknown language', () => {
+    const patterns = getOutputPatternsForLanguage('nonexistent');
+    expect(patterns).toEqual([]);
+  });
+});
+
+describe('getLogPatternsForLanguage', () => {
+  it('returns log patterns for known languages', () => {
+    const patterns = getLogPatternsForLanguage('gromacs');
+    expect(patterns.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for unknown language', () => {
+    const patterns = getLogPatternsForLanguage('nonexistent');
+    expect(patterns).toEqual([]);
+  });
+});

--- a/tests/unit/smoke/ruleManifestReader.test.ts
+++ b/tests/unit/smoke/ruleManifestReader.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Rule Manifest Reader Tests
+ *
+ * Tests for manifest parsing, validation, and query helpers.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/160
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/162
+ */
+
+import * as path from 'path';
+import {
+  validateManifest,
+  readManifestFromFile,
+  parseManifestString,
+  tryReadManifest,
+  getRulesBySeverity,
+  getRuleByCode,
+  getManifestCategories,
+  countRulesBySeverity,
+} from '../../../src/smoke/ruleManifestReader';
+import type { RuleManifest } from '../../../src/smoke/types';
+
+const FIXTURES_DIR = path.join(__dirname, '../../fixtures/smoke/manifests');
+
+// ---------------------------------------------------------------------------
+// validateManifest
+// ---------------------------------------------------------------------------
+
+describe('validateManifest', () => {
+  it('returns no errors for a valid manifest', () => {
+    const valid = {
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-06-12T00:00:00Z',
+      rules: [{ code: 'E001', message: 'Test error', severity: 'error' }],
+    };
+    expect(validateManifest(valid)).toEqual([]);
+  });
+
+  it('rejects null input', () => {
+    const errors = validateManifest(null);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('non-null object');
+  });
+
+  it('rejects non-object input', () => {
+    const errors = validateManifest('string');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('non-null object');
+  });
+
+  it('requires serverId', () => {
+    const errors = validateManifest({
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: [],
+    });
+    expect(errors.some(e => e.includes('serverId'))).toBe(true);
+  });
+
+  it('requires serverName', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: [],
+    });
+    expect(errors.some(e => e.includes('serverName'))).toBe(true);
+  });
+
+  it('requires supported schemaVersion', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '99.0.0',
+      generatedAt: '2026-01-01',
+      rules: [],
+    });
+    expect(errors.some(e => e.includes('schema version'))).toBe(true);
+  });
+
+  it('requires rules to be an array', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: 'not-array',
+    });
+    expect(errors.some(e => e.includes('"rules" array'))).toBe(true);
+  });
+
+  it('validates individual rule entries', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: [{ code: '', message: '', severity: 'bad' }],
+    });
+    expect(errors.some(e => e.includes('code'))).toBe(true);
+    expect(errors.some(e => e.includes('message'))).toBe(true);
+    expect(errors.some(e => e.includes('severity'))).toBe(true);
+  });
+
+  it('accepts schema version 1.1.0', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.1.0',
+      generatedAt: '2026-01-01',
+      rules: [],
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('validates optional confidence range', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: [{ code: 'E001', message: 'Test', severity: 'error', confidence: 1.5 }],
+    });
+    expect(errors.some(e => e.includes('confidence'))).toBe(true);
+  });
+
+  it('validates optional blocking is boolean', () => {
+    const errors = validateManifest({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-01-01',
+      rules: [{ code: 'E001', message: 'Test', severity: 'error', blocking: 'yes' }],
+    });
+    expect(errors.some(e => e.includes('blocking'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseManifestString
+// ---------------------------------------------------------------------------
+
+describe('parseManifestString', () => {
+  it('parses a valid JSON manifest', () => {
+    const json = JSON.stringify({
+      serverId: 'test-lsp',
+      serverName: 'Test',
+      schemaVersion: '1.0.0',
+      generatedAt: '2026-06-12T00:00:00Z',
+      rules: [{ code: 'E001', message: 'Error', severity: 'error' }],
+    });
+
+    const manifest = parseManifestString(json);
+    expect(manifest.serverId).toBe('test-lsp');
+    expect(manifest.rules).toHaveLength(1);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseManifestString('not-json')).toThrow('Failed to parse');
+  });
+
+  it('throws on invalid manifest structure', () => {
+    expect(() => parseManifestString('{}')).toThrow('validation failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readManifestFromFile
+// ---------------------------------------------------------------------------
+
+describe('readManifestFromFile', () => {
+  it('reads the Gaussian fixture manifest', () => {
+    const manifest = readManifestFromFile(path.join(FIXTURES_DIR, 'gaussian-lsp-rules.json'));
+    expect(manifest.serverId).toBe('gaussian-lsp');
+    expect(manifest.serverName).toBe('Gaussian');
+    expect(manifest.rules).toHaveLength(4);
+  });
+
+  it('reads the VASP fixture manifest', () => {
+    const manifest = readManifestFromFile(path.join(FIXTURES_DIR, 'vasp-lsp-rules.json'));
+    expect(manifest.serverId).toBe('vasp-lsp');
+    expect(manifest.rules).toHaveLength(2);
+  });
+
+  it('throws for a missing file', () => {
+    expect(() => readManifestFromFile(path.join(FIXTURES_DIR, 'nonexistent.json'))).toThrow(
+      'not found'
+    );
+  });
+
+  it('throws for an invalid manifest file', () => {
+    expect(() => readManifestFromFile(path.join(FIXTURES_DIR, 'invalid-rules.json'))).toThrow(
+      'validation failed'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tryReadManifest
+// ---------------------------------------------------------------------------
+
+describe('tryReadManifest', () => {
+  it('returns manifest on success', () => {
+    const result = tryReadManifest(path.join(FIXTURES_DIR, 'gaussian-lsp-rules.json'));
+    expect(result.manifest).toBeDefined();
+    expect(result.error).toBeUndefined();
+    expect(result.manifest!.serverId).toBe('gaussian-lsp');
+  });
+
+  it('returns error on failure', () => {
+    const result = tryReadManifest(path.join(FIXTURES_DIR, 'nonexistent.json'));
+    expect(result.manifest).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+describe('getRulesBySeverity', () => {
+  const manifest: RuleManifest = {
+    serverId: 'test-lsp',
+    serverName: 'Test',
+    schemaVersion: '1.0.0',
+    generatedAt: '2026-06-12T00:00:00Z',
+    rules: [
+      { code: 'E001', message: 'Error 1', severity: 'error' },
+      { code: 'E002', message: 'Error 2', severity: 'error' },
+      { code: 'W001', message: 'Warning 1', severity: 'warning' },
+      { code: 'I001', message: 'Info 1', severity: 'information' },
+    ],
+  };
+
+  it('filters rules by error severity', () => {
+    const errors = getRulesBySeverity(manifest, 'error');
+    expect(errors).toHaveLength(2);
+    expect(errors.map(r => r.code)).toEqual(['E001', 'E002']);
+  });
+
+  it('returns empty for severity with no rules', () => {
+    const hints = getRulesBySeverity(manifest, 'hint');
+    expect(hints).toHaveLength(0);
+  });
+});
+
+describe('getRuleByCode', () => {
+  const manifest: RuleManifest = {
+    serverId: 'test-lsp',
+    serverName: 'Test',
+    schemaVersion: '1.0.0',
+    generatedAt: '2026-06-12T00:00:00Z',
+    rules: [
+      { code: 'E001', message: 'Error', severity: 'error' },
+      { code: 'W001', message: 'Warning', severity: 'warning' },
+    ],
+  };
+
+  it('finds a rule by code', () => {
+    const rule = getRuleByCode(manifest, 'E001');
+    expect(rule).toBeDefined();
+    expect(rule?.message).toBe('Error');
+  });
+
+  it('returns undefined for unknown code', () => {
+    expect(getRuleByCode(manifest, 'X999')).toBeUndefined();
+  });
+});
+
+describe('getManifestCategories', () => {
+  const manifest: RuleManifest = {
+    serverId: 'test-lsp',
+    serverName: 'Test',
+    schemaVersion: '1.0.0',
+    generatedAt: '2026-06-12T00:00:00Z',
+    rules: [
+      { code: 'E001', message: 'A', severity: 'error', category: 'syntax' },
+      { code: 'W001', message: 'B', severity: 'warning', category: 'best-practice' },
+      { code: 'E002', message: 'C', severity: 'error', category: 'syntax' },
+      { code: 'E003', message: 'D', severity: 'error' },
+    ],
+  };
+
+  it('returns unique sorted categories', () => {
+    const categories = getManifestCategories(manifest);
+    expect(categories).toEqual(['best-practice', 'syntax']);
+  });
+});
+
+describe('countRulesBySeverity', () => {
+  const manifest: RuleManifest = {
+    serverId: 'test-lsp',
+    serverName: 'Test',
+    schemaVersion: '1.0.0',
+    generatedAt: '2026-06-12T00:00:00Z',
+    rules: [
+      { code: 'E001', message: 'A', severity: 'error' },
+      { code: 'E002', message: 'B', severity: 'error' },
+      { code: 'W001', message: 'C', severity: 'warning' },
+      { code: 'I001', message: 'D', severity: 'information' },
+    ],
+  };
+
+  it('counts rules by severity', () => {
+    const counts = countRulesBySeverity(manifest);
+    expect(counts['error']).toBe(2);
+    expect(counts['warning']).toBe(1);
+    expect(counts['information']).toBe(1);
+    expect(counts['hint']).toBe(0);
+  });
+});

--- a/tests/unit/smoke/smokeRunner.test.ts
+++ b/tests/unit/smoke/smokeRunner.test.ts
@@ -22,10 +22,11 @@ import {
   generateCampaignReport,
   formatCampaignReportAsMarkdown,
 } from '../../../src/smoke/smokeRunner';
-import { getLspServerByLanguageId } from '../../../src/lsp/registry';
+import { getBundledLspServerCount, getLspServerByLanguageId } from '../../../src/lsp/registry';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../');
 const CODE_ROOT = path.resolve(REPO_ROOT, '..');
+const EXPECTED_SERVER_COUNT = getBundledLspServerCount();
 
 // ---------------------------------------------------------------------------
 // runSmokeTestForLsp
@@ -48,10 +49,10 @@ describe('runSmokeTestForLsp', () => {
 // ---------------------------------------------------------------------------
 
 describe('runAllSmokeTests', () => {
-  it('runs smoke tests for all 16 servers', () => {
+  it('runs smoke tests for every registered server', () => {
     const summary = runAllSmokeTests('/nonexistent/fixtures');
-    expect(summary.totalServers).toBe(16);
-    expect(summary.results).toHaveLength(16);
+    expect(summary.totalServers).toBe(EXPECTED_SERVER_COUNT);
+    expect(summary.results).toHaveLength(EXPECTED_SERVER_COUNT);
     expect(summary.generatedAt).toBeTruthy();
   });
 });
@@ -81,9 +82,9 @@ describe('verifyVsixPackage', () => {
 // ---------------------------------------------------------------------------
 
 describe('runLocalGates', () => {
-  it('checks all 16 repos', () => {
+  it('checks every registered repo', () => {
     const results = runLocalGates(CODE_ROOT);
-    expect(results).toHaveLength(16);
+    expect(results).toHaveLength(EXPECTED_SERVER_COUNT);
   });
 
   it('reports missing checkouts gracefully', () => {
@@ -100,9 +101,9 @@ describe('runLocalGates', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkRepoCleanliness', () => {
-  it('checks all 16 repos', () => {
+  it('checks every registered repo', () => {
     const statuses = checkRepoCleanliness(CODE_ROOT);
-    expect(statuses).toHaveLength(16);
+    expect(statuses).toHaveLength(EXPECTED_SERVER_COUNT);
   });
 
   it('reports non-existent repos', () => {
@@ -128,12 +129,12 @@ describe('generateCampaignReport', () => {
 
     expect(report.runId).toBe('test-run-001');
     expect(report.generatedAt).toBeTruthy();
-    expect(report.repoStatuses).toHaveLength(16);
-    expect(report.gateResults).toHaveLength(16);
-    expect(report.cleanStatuses).toHaveLength(16);
+    expect(report.repoStatuses).toHaveLength(EXPECTED_SERVER_COUNT);
+    expect(report.gateResults).toHaveLength(EXPECTED_SERVER_COUNT);
+    expect(report.cleanStatuses).toHaveLength(EXPECTED_SERVER_COUNT);
     expect(report.compatibilityReport).toBeDefined();
     if (report.compatibilityReport) {
-      expect(report.compatibilityReport.totalServers).toBe(16);
+      expect(report.compatibilityReport.totalServers).toBe(EXPECTED_SERVER_COUNT);
     }
   });
 

--- a/tests/unit/smoke/smokeRunner.test.ts
+++ b/tests/unit/smoke/smokeRunner.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Smoke Runner Tests
+ *
+ * Tests for the smoke test runner, VSIX verification, and campaign report.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/161
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/164
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/165
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/166
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/168
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/176
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/177
+ */
+
+import * as path from 'path';
+import {
+  runSmokeTestForLsp,
+  runAllSmokeTests,
+  verifyVsixPackage,
+  runLocalGates,
+  checkRepoCleanliness,
+  generateCampaignReport,
+  formatCampaignReportAsMarkdown,
+} from '../../../src/smoke/smokeRunner';
+import { getLspServerByLanguageId } from '../../../src/lsp/registry';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+const CODE_ROOT = path.resolve(REPO_ROOT, '..');
+
+// ---------------------------------------------------------------------------
+// runSmokeTestForLsp
+// ---------------------------------------------------------------------------
+
+describe('runSmokeTestForLsp', () => {
+  it('returns a result for a valid server with no fixtures', () => {
+    const server = getLspServerByLanguageId('gaussian')!;
+    const result = runSmokeTestForLsp(server, '/nonexistent/fixtures');
+    expect(result.serverId).toBe('gaussian-lsp');
+    expect(result.validInputPass).toBe(false);
+    expect(result.invalidInputPass).toBe(false);
+    expect(result.runtimeLogPass).toBe(null);
+    expect(result.detail).toContain('No valid fixture');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAllSmokeTests
+// ---------------------------------------------------------------------------
+
+describe('runAllSmokeTests', () => {
+  it('runs smoke tests for all 16 servers', () => {
+    const summary = runAllSmokeTests('/nonexistent/fixtures');
+    expect(summary.totalServers).toBe(16);
+    expect(summary.results).toHaveLength(16);
+    expect(summary.generatedAt).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyVsixPackage
+// ---------------------------------------------------------------------------
+
+describe('verifyVsixPackage', () => {
+  it('checks for required dependencies in package.json', () => {
+    const result = verifyVsixPackage(REPO_ROOT);
+    expect(result.hasLanguageClient).toBe(true);
+    expect(result.foundDependencies).toContain('vscode-languageclient');
+    expect(result.missingDependencies).toEqual([]);
+    expect(result.buildSuccess).toBe(true);
+  });
+
+  it('reports failure for invalid repo root', () => {
+    const result = verifyVsixPackage('/nonexistent/path');
+    expect(result.buildSuccess).toBe(false);
+    expect(result.hasLanguageClient).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLocalGates
+// ---------------------------------------------------------------------------
+
+describe('runLocalGates', () => {
+  it('checks all 16 repos', () => {
+    const results = runLocalGates(CODE_ROOT);
+    expect(results).toHaveLength(16);
+  });
+
+  it('reports missing checkouts gracefully', () => {
+    const results = runLocalGates('/nonexistent/code');
+    for (const result of results) {
+      expect(result.checkoutExists).toBe(false);
+      expect(result.gatePassed).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkRepoCleanliness
+// ---------------------------------------------------------------------------
+
+describe('checkRepoCleanliness', () => {
+  it('checks all 16 repos', () => {
+    const statuses = checkRepoCleanliness(CODE_ROOT);
+    expect(statuses).toHaveLength(16);
+  });
+
+  it('reports non-existent repos', () => {
+    const statuses = checkRepoCleanliness('/nonexistent/code');
+    for (const status of statuses) {
+      expect(status.exists).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCampaignReport
+// ---------------------------------------------------------------------------
+
+describe('generateCampaignReport', () => {
+  it('generates a full campaign report', () => {
+    const report = generateCampaignReport(
+      REPO_ROOT,
+      CODE_ROOT,
+      'test-run-001',
+      path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests')
+    );
+
+    expect(report.runId).toBe('test-run-001');
+    expect(report.generatedAt).toBeTruthy();
+    expect(report.repoStatuses).toHaveLength(16);
+    expect(report.gateResults).toHaveLength(16);
+    expect(report.cleanStatuses).toHaveLength(16);
+    expect(report.compatibilityReport).toBeDefined();
+    if (report.compatibilityReport) {
+      expect(report.compatibilityReport.totalServers).toBe(16);
+    }
+  });
+
+  it('includes VSIX verification in report', () => {
+    const report = generateCampaignReport(REPO_ROOT, CODE_ROOT, 'test-run-002');
+    expect(report.vsixVerification).toBeDefined();
+    expect(report.vsixVerification!.hasLanguageClient).toBe(true);
+  });
+
+  it('works without manifestDir or fixturesDir', () => {
+    const report = generateCampaignReport(REPO_ROOT, CODE_ROOT, 'test-run-003');
+    expect(report.compatibilityReport).toBeDefined();
+    expect(report.smokeTestSummary).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCampaignReportAsMarkdown
+// ---------------------------------------------------------------------------
+
+describe('formatCampaignReportAsMarkdown', () => {
+  it('produces markdown with all sections', () => {
+    const report = generateCampaignReport(
+      REPO_ROOT,
+      CODE_ROOT,
+      'test-md',
+      path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests'),
+      '/nonexistent/fixtures'
+    );
+    const md = formatCampaignReportAsMarkdown(report);
+
+    expect(md).toContain('# OpenQC Campaign Final Report');
+    expect(md).toContain('**Run ID:** test-md');
+    expect(md).toContain('## Repository GitHub Status');
+    expect(md).toContain('## Local Gate Results');
+    expect(md).toContain('## Repo Cleanliness');
+    expect(md).toContain('## VSIX Verification');
+    expect(md).toContain('## Compatibility Report Summary');
+    expect(md).toContain('## Smoke Test Summary');
+  });
+
+  it('includes server names in the report', () => {
+    const report = generateCampaignReport(REPO_ROOT, CODE_ROOT, 'test-names');
+    const md = formatCampaignReportAsMarkdown(report);
+    expect(md).toContain('Gaussian');
+    expect(md).toContain('VASP');
+  });
+});


### PR DESCRIPTION
## Summary
- add DP-GEN as a bundled OpenQC LSP language/registry entry
- add DP-GEN language configuration, grammar, settings, docs, and activation wiring
- include DP-GEN in registry-driven compatibility/capability checks
- make smoke runner tests registry-driven and ignore nested `.worktrees/` test fixtures

## Backend dependency
- dpgen-lsp PR: https://github.com/newtontech/dpgen-lsp/pull/7
- merged backend commit: 906b7195a5961c5e8032f98efb0ce6cb459017c0

## Verification
- `python3 -m pytest -q` in `dpgen-lsp`: 73 passed
- `python3 -m ruff check src tests scripts` in `dpgen-lsp`: passed
- `PYTHONPATH=src python3 -m dpgen_lsp.tool capabilities` in `dpgen-lsp`: reports 24 capabilities, output-log diagnostics, release tag index through v0.13.3, and versioned provenance assets
- `npm run test:unit` in OpenQC-VSCode: 66 suites, 1416 tests passed, coverage thresholds met
- `npm run test:integration -- --runTestsByPath tests/integration/smoke/registryAlignment.test.ts`: passed
- `npm run lsp:check-latest -- --fail-on-drift`: passed with dpgen-lsp from latest sibling checkout at 906b7195a596
- `node scripts/check-lsp-family.mjs --json`: DP-GEN passes; remaining family failures are pre-existing missing `lsp-capabilities.json` for abacus-lsp and gaussian-lsp
