### PR TITLE
test: harden OpenQC LSP family smoke gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ site/
 # Test fixtures (generated)
 tests/fixtures/generated/
 .claude/
+.worktrees/

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,10 @@ module.exports = {
   },
   roots: ['<rootDir>'],
   testMatch: ['**/tests/**/*.test.ts'],
-  testPathIgnorePatterns: ['<rootDir>/tests/unit/visualizers/ThreeJsRenderer.test.ts'],
+  testPathIgnorePatterns: [
+    '<rootDir>/.worktrees/',
+    '<rootDir>/tests/unit/visualizers/ThreeJsRenderer.test.ts',
+  ],
   moduleNameMapper: {
     '^vscode$': '<rootDir>/tests/mocks/vscode.ts',
   },

--- a/tests/unit/smoke/compatibilityReport.test.ts
+++ b/tests/unit/smoke/compatibilityReport.test.ts
@@ -12,19 +12,21 @@ import {
   generateCompatibilityReport,
   formatReportAsMarkdown,
 } from '../../../src/smoke/compatibilityReport';
+import { getBundledLspServerCount } from '../../../src/lsp/registry';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../');
 const MANIFESTS_DIR = path.join(REPO_ROOT, 'tests/fixtures/smoke/manifests');
+const EXPECTED_SERVER_COUNT = getBundledLspServerCount();
 
 // ---------------------------------------------------------------------------
 // generateCompatibilityReport
 // ---------------------------------------------------------------------------
 
 describe('generateCompatibilityReport', () => {
-  it('generates a report covering all 17 LSP servers', () => {
+  it('generates a report covering every bundled LSP server', () => {
     const report = generateCompatibilityReport(REPO_ROOT);
-    expect(report.totalServers).toBe(17);
-    expect(report.entries).toHaveLength(17);
+    expect(report.totalServers).toBe(EXPECTED_SERVER_COUNT);
+    expect(report.entries).toHaveLength(EXPECTED_SERVER_COUNT);
   });
 
   it('includes timestamps', () => {
@@ -114,7 +116,7 @@ describe('generateCompatibilityReport', () => {
 
   it('handles invalid repoRoot gracefully', () => {
     const report = generateCompatibilityReport('/nonexistent/path');
-    expect(report.totalServers).toBe(17);
+    expect(report.totalServers).toBe(EXPECTED_SERVER_COUNT);
     // Should still generate the report but with failures
     for (const entry of report.entries) {
       const docsCheck = entry.checks.find(c => c.name === 'docs-alignment');

--- a/tests/unit/smoke/smokeRunner.test.ts
+++ b/tests/unit/smoke/smokeRunner.test.ts
@@ -22,10 +22,11 @@ import {
   generateCampaignReport,
   formatCampaignReportAsMarkdown,
 } from '../../../src/smoke/smokeRunner';
-import { getLspServerByLanguageId } from '../../../src/lsp/registry';
+import { getBundledLspServerCount, getLspServerByLanguageId } from '../../../src/lsp/registry';
 
 const REPO_ROOT = path.resolve(__dirname, '../../../');
 const CODE_ROOT = path.resolve(REPO_ROOT, '..');
+const EXPECTED_SERVER_COUNT = getBundledLspServerCount();
 
 // ---------------------------------------------------------------------------
 // runSmokeTestForLsp
@@ -48,10 +49,10 @@ describe('runSmokeTestForLsp', () => {
 // ---------------------------------------------------------------------------
 
 describe('runAllSmokeTests', () => {
-  it('runs smoke tests for all 17 servers', () => {
+  it('runs smoke tests for every registered server', () => {
     const summary = runAllSmokeTests('/nonexistent/fixtures');
-    expect(summary.totalServers).toBe(17);
-    expect(summary.results).toHaveLength(17);
+    expect(summary.totalServers).toBe(EXPECTED_SERVER_COUNT);
+    expect(summary.results).toHaveLength(EXPECTED_SERVER_COUNT);
     expect(summary.generatedAt).toBeTruthy();
   });
 });
@@ -81,9 +82,9 @@ describe('verifyVsixPackage', () => {
 // ---------------------------------------------------------------------------
 
 describe('runLocalGates', () => {
-  it('checks all 17 repos', () => {
+  it('checks every registered repo', () => {
     const results = runLocalGates(CODE_ROOT);
-    expect(results).toHaveLength(17);
+    expect(results).toHaveLength(EXPECTED_SERVER_COUNT);
   });
 
   it('reports missing checkouts gracefully', () => {
@@ -100,9 +101,9 @@ describe('runLocalGates', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkRepoCleanliness', () => {
-  it('checks all 17 repos', () => {
+  it('checks every registered repo', () => {
     const statuses = checkRepoCleanliness(CODE_ROOT);
-    expect(statuses).toHaveLength(17);
+    expect(statuses).toHaveLength(EXPECTED_SERVER_COUNT);
   });
 
   it('reports non-existent repos', () => {
@@ -128,12 +129,12 @@ describe('generateCampaignReport', () => {
 
     expect(report.runId).toBe('test-run-001');
     expect(report.generatedAt).toBeTruthy();
-    expect(report.repoStatuses).toHaveLength(17);
-    expect(report.gateResults).toHaveLength(17);
-    expect(report.cleanStatuses).toHaveLength(17);
+    expect(report.repoStatuses).toHaveLength(EXPECTED_SERVER_COUNT);
+    expect(report.gateResults).toHaveLength(EXPECTED_SERVER_COUNT);
+    expect(report.cleanStatuses).toHaveLength(EXPECTED_SERVER_COUNT);
     expect(report.compatibilityReport).toBeDefined();
     if (report.compatibilityReport) {
-      expect(report.compatibilityReport.totalServers).toBe(17);
+      expect(report.compatibilityReport.totalServers).toBe(EXPECTED_SERVER_COUNT);
     }
   });
 


### PR DESCRIPTION
Fixes #199

## Summary
- make OpenQC LSP family smoke tests use the bundled registry count instead of hard-coded server totals
- ignore nested `.worktrees/` in Jest so local issue/worktree checkouts are not collected as current-branch tests
- keep the current `master` DP-GEN integration intact without replaying the older conflicting branch

## DP-GEN backend state
- dpgen-lsp PR: https://github.com/newtontech/dpgen-lsp/pull/7
- merged backend commit: 906b7195a5961c5e8032f98efb0ce6cb459017c0

## Tests
- `npm run test:unit -- --coverage=false --runTestsByPath tests/unit/smoke/smokeRunner.test.ts tests/unit/smoke/compatibilityReport.test.ts`: 28 passed
- pre-commit: ESLint/typecheck/unit coverage/format all passed
- `npm run test:unit`: 66 suites, 1418 tests passed, coverage thresholds met
- `npm run test:integration -- --runTestsByPath tests/integration/smoke/registryAlignment.test.ts`: 8 passed
- `node scripts/check-lsp-family.mjs --json`: 17/17 passing, 0 blocking gaps
- `npm run lsp:check-latest -- --fail-on-drift`: 17/17 latest or latest-via-worktree; DP-GEN at 906b7195a596 with `dpgen-lsp-tool` help passing

Supersedes the conflicting branch PR #197, which was based on an older OpenQC baseline after DP-GEN registration had already landed on `master`.
