### PR TITLE
chore: mark DP-GEN LSP readiness from smoke evidence

### DIFF
--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -388,7 +388,7 @@ export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadine
   'abinit-lsp': diagnosticReadiness('abinit-lsp-tool', 'planned'),
   'cif-lsp': diagnosticReadiness('cif-lsp-tool', 'planned'),
   'cp2k-lsp-enhanced': diagnosticReadiness('cp2k-lsp-tool', 'partial'),
-  'dpgen-lsp': diagnosticReadiness('dpgen-lsp-tool', 'planned'),
+  'dpgen-lsp': diagnosticReadiness('dpgen-lsp-tool', 'partial', 'passing'),
   'gamess-lsp': diagnosticReadiness('gamess-lsp-tool', 'planned'),
   'gaussian-lsp': diagnosticReadiness('gaussian-lsp-tool', 'planned'),
   'gpumd-lsp': diagnosticReadiness('gpumd-lsp-tool', 'planned'),


### PR DESCRIPTION
Fixes #200

## Summary
- mark DP-GEN closed-loop readiness as `partial`
- mark DP-GEN agent CLI smoke status as `passing`
- keeps OpenQC readiness aligned with merged DP-GEN smoke/runtime-log evidence

## No-test justification
This is a registry metadata-only update. The existing registry, integration, latest-LSP, and family-gate tests cover the behavior, and no new test fixture is needed for a one-line readiness state change.

## Tests
- `npm run test:unit -- --coverage=false --runTestsByPath tests/unit/lsp/registry.test.ts`: 19 passed
- `npm run test:integration -- --runTestsByPath tests/integration/smoke/registryAlignment.test.ts`: 8 passed
- `npm run lsp:check-latest -- --fail-on-drift`: 17/17 latest or latest-via-worktree; DP-GEN at 77d6c969bd32 with `dpgen-lsp-tool` help passing
- `node scripts/check-lsp-family.mjs --json`: DP-GEN manifest/provenance/fixtures/smoke/diagnosticReadiness all pass with no warning gaps
- pre-commit: ESLint/typecheck/unit coverage/format all passed; 67 suites, 1421 tests

Note: local Bohrium registry alignment required syncing `bohrium_skills/lsp-skills/references/lsp_backends.yaml` to the already-updated `bohrium_skills` `origin/main`, which includes `dpgen-lsp`.
