### PR TITLE
chore(lsp): mark PyATB readiness from fix-preview evidence

### DIFF
--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -397,7 +397,7 @@ export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadine
   'mlip-lsp': diagnosticReadiness('mlip-lsp-tool', 'partial', 'passing'),
   'nwchem-lsp': diagnosticReadiness('nwchem-lsp-tool', 'partial', 'passing'),
   'orca-lsp': diagnosticReadiness('orca-lsp-tool', 'planned'),
-  'pyatb-lsp': diagnosticReadiness('pyatb-lsp-tool', 'planned'),
+  'pyatb-lsp': diagnosticReadiness('pyatb-lsp-tool', 'partial', 'passing'),
   'pyscf-lsp': diagnosticReadiness('pyscf-lsp-tool', 'planned'),
   'qe-lsp': diagnosticReadiness('qe-lsp-tool', 'partial'),
   'vasp-lsp': diagnosticReadiness('vasp-lsp-tool', 'partial'),


### PR DESCRIPTION
## Summary
- Mark `pyatb-lsp` closed-loop readiness as `partial` with passing smoke evidence after `pyatb-lsp#41` merged.
- Keep PyATB partial because provenance/versioned schema trackers remain open.
- Reduce OpenQC diagnostic readiness warnings from 6 to 5 and family score from 76 to 78.

Fixes #206
Refs #187
Refs newtontech/pyatb-lsp#40
Refs newtontech/pyatb-lsp#41

## Test Plan
- [x] `npm run lsp:check-family -- --strict --report-path /tmp/lsp-family-report-20260615-007-pyatb-readiness.json`
- [x] `npm run lsp:check-latest -- --fail-on-drift`
- [x] `npm run lsp:check-bohrium-registry -- --strict --bohrium-registry /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml`

## No-Test Justification
No-test justification: this PR updates OpenQC registry readiness metadata only. The behavior is covered by the family/latest/Bohrium gates listed above; no parser, runtime, or UI logic is introduced.