### PR TITLE
chore(lsp): mark ORCA readiness from runtime evidence

### DIFF
--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -14,7 +14,7 @@ Last updated: 2026-06-15. Latest support is tracked against each repository defa
 | [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | `cp2k` | `develop` | v0.9.1 | CP2K | `.inp` | Experimental | Syntax, file detection, direct LSP startup |
 | [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP) | `vasp` | `main` | 0.4.4 | VASP | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`, `CONTCAR`, `OSZICAR`, `OUTCAR`, `vasprun.xml` | Stable | Syntax, file detection, direct LSP startup |
 | [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp) | `gaussian` | `main` | 0.2.11 | Gaussian | `.gjf`, `.com` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp) | `orca` | `main` | 0.5.4 | ORCA | `.inp` | Stable | Syntax, file detection, direct LSP startup |
+| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp) | `orca` | `main` | 0.5.5 | ORCA | `.inp` | Stable | Syntax, file detection, direct LSP startup |
 | [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp) | `qe` | `main` | 0.1.0 | Quantum ESPRESSO | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | Stable | Syntax, file detection, direct LSP startup |
 | [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp) | `gamess` | `main` | 0.1.0 | GAMESS | `.inp` | Stable | Syntax, file detection, direct LSP startup |
 | [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp) | `nwchem` | `main` | v0.3.0 / local 0.5.0 | NWChem | `.nw`, `.nwinp` | Experimental | Syntax, file detection, direct LSP startup |
@@ -43,7 +43,7 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 | `lammps-lsp` | v1 | `lammps-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
 | `mlip-lsp` | v1 | `mlip-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `nwchem-lsp` | v1 | `nwchem-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `orca-lsp` | v1 | `orca-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
+| `orca-lsp` | v1 | `orca-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `pyatb-lsp` | v1 | `pyatb-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `pyscf-lsp` | v1 | `pyscf-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `dpgen-lsp` | v1 | `dpgen-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |

--- a/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
+++ b/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
@@ -60,7 +60,7 @@ The OpenQC family gate has no blocking errors, but it still reports these maturi
 | `cp2k-lsp-enhanced` | No current family-gate warnings. |
 | `VASP-LSP` | No git tags. |
 | `gaussian-lsp` | Missing canonical capabilities section; no git tags; closed-loop support still planned. |
-| `orca-lsp` | No git tags; closed-loop support still planned. |
+| `orca-lsp` | No git tags. Closed-loop repair previews and log diagnostics are now wired, but exhaustive ORCA version/rule coverage is still open. |
 | `qe-lsp` | No git tags. |
 | `gamess-lsp` | No git tags; closed-loop support still planned. |
 | `nwchem-lsp` | No invalid fixture files detected by the family gate; closed-loop support still planned. |
@@ -121,4 +121,3 @@ A repo can be treated as mature only when all of the following are true:
 - OpenQC `lsp:check-latest -- --fail-on-drift` passes.
 - OpenQC `lsp:check-family -- --strict` passes with zero blocking gaps.
 - Remaining warnings are either zero or documented as non-blocking product decisions.
-

--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -396,7 +396,7 @@ export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadine
   'lammps-lsp': diagnosticReadiness('lammps-lsp-tool', 'partial'),
   'mlip-lsp': diagnosticReadiness('mlip-lsp-tool', 'partial', 'passing'),
   'nwchem-lsp': diagnosticReadiness('nwchem-lsp-tool', 'partial', 'passing'),
-  'orca-lsp': diagnosticReadiness('orca-lsp-tool', 'planned'),
+  'orca-lsp': diagnosticReadiness('orca-lsp-tool', 'partial', 'passing'),
   'pyatb-lsp': diagnosticReadiness('pyatb-lsp-tool', 'partial', 'passing'),
   'pyscf-lsp': diagnosticReadiness('pyscf-lsp-tool', 'planned'),
   'qe-lsp': diagnosticReadiness('qe-lsp-tool', 'partial'),


### PR DESCRIPTION
## Summary
- mark ORCA diagnostic readiness as partial with passing agent CLI smoke after newtontech/orca-lsp#94
- update the compatibility matrix to ORCA 0.5.5
- document that ORCA closed-loop repair previews and log diagnostics are wired, while exhaustive version/rule coverage remains open

## Test Plan
- npm run typecheck
- npm run test:unit -- --coverage=false --runTestsByPath tests/unit/lsp/registry.test.ts tests/unit/lsp/bohriumRegistryAlignment.test.ts
- npm run lsp:check-family -- --strict --report-path /tmp/lsp-family-report-20260615-007-orca-readiness-latest.json
- npm run lsp:check-latest -- --fail-on-drift
- npm run lsp:check-bohrium-registry -- --strict --bohrium-registry /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml

## No-test justification
Registry metadata-only readiness update; existing registry and Bohrium alignment tests cover the contract, and no new runtime behavior or parser path was added in OpenQC.

Fixes #209
Refs newtontech/orca-lsp#92
Refs newtontech/orca-lsp#94