### PR TITLE
chore(lsp): mark runtime readiness for ABINIT Gaussian PySCF

### DIFF
--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -33,11 +33,11 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 | LSP Server | Diagnostic Engine | Agent CLI | Agent Operations | Help Smoke | Closed Loop |
 |------------|-------------------|-----------|------------------|------------|-------------|
 | `abacus-lsp` | v1 | `abacus-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `abinit-lsp` | v1 | `abinit-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
+| `abinit-lsp` | v1 | `abinit-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `cif-lsp` | v1 | `cif-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `cp2k-lsp-enhanced` | v1 | `cp2k-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
 | `gamess-lsp` | v1 | `gamess-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `gaussian-lsp` | v1 | `gaussian-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
+| `gaussian-lsp` | v1 | `gaussian-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `gpumd-lsp` | v1 | `gpumd-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `gromacs-lsp` | v1 | `gromacs-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `lammps-lsp` | v1 | `lammps-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
@@ -45,7 +45,7 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 | `nwchem-lsp` | v1 | `nwchem-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `orca-lsp` | v1 | `orca-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `pyatb-lsp` | v1 | `pyatb-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `pyscf-lsp` | v1 | `pyscf-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
+| `pyscf-lsp` | v1 | `pyscf-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `dpgen-lsp` | v1 | `dpgen-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `qe-lsp` | v1 | `qe-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
 | `vasp-lsp` | v1 | `vasp-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |

--- a/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
+++ b/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
@@ -55,11 +55,11 @@ The OpenQC family gate has no blocking errors, but it still reports these maturi
 | Repo | Remaining warnings |
 |------|--------------------|
 | `abacus-lsp` | Missing canonical capabilities section; no git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
-| `abinit-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
+| `abinit-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`. Runtime/log diagnostics and fix-hint envelopes are now wired, but exhaustive ABINIT version/rule coverage is still open. |
 | `cif-lsp` | Closed-loop support still planned. |
 | `cp2k-lsp-enhanced` | No current family-gate warnings. |
 | `VASP-LSP` | No git tags. |
-| `gaussian-lsp` | Missing canonical capabilities section; no git tags; closed-loop support still planned. |
+| `gaussian-lsp` | No git tags. Runtime-log diagnostics, parse-log routing, and unsafe-fix refusals are now wired, but exhaustive Gaussian rule/version coverage is still open. |
 | `orca-lsp` | No git tags. Closed-loop repair previews and log diagnostics are now wired, but exhaustive ORCA version/rule coverage is still open. |
 | `qe-lsp` | No git tags. |
 | `gamess-lsp` | No git tags; closed-loop support still planned. |
@@ -69,7 +69,7 @@ The OpenQC family gate has no blocking errors, but it still reports these maturi
 | `lammps-lsp` | No current family-gate warnings. |
 | `mlip-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
 | `pyatb-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
-| `pyscf-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
+| `pyscf-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`. Traceback/log diagnostics and fix previews are now wired, but exhaustive PySCF API/version coverage is still open. |
 | `dpgen-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`; no valid/invalid fixtures detected by the family gate; closed-loop support still planned. |
 
 ## Open Issue Summary

--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -385,12 +385,12 @@ const BUNDLED_LSP_SERVERS: readonly LSPServerRegistryEntry[] = [
 
 export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadiness>> = {
   'abacus-lsp': diagnosticReadiness('abacus-lsp-tool', 'planned'),
-  'abinit-lsp': diagnosticReadiness('abinit-lsp-tool', 'planned'),
+  'abinit-lsp': diagnosticReadiness('abinit-lsp-tool', 'partial', 'passing'),
   'cif-lsp': diagnosticReadiness('cif-lsp-tool', 'partial', 'passing'),
   'cp2k-lsp-enhanced': diagnosticReadiness('cp2k-lsp-tool', 'partial'),
   'dpgen-lsp': diagnosticReadiness('dpgen-lsp-tool', 'partial', 'passing'),
   'gamess-lsp': diagnosticReadiness('gamess-lsp-tool', 'partial', 'passing'),
-  'gaussian-lsp': diagnosticReadiness('gaussian-lsp-tool', 'planned'),
+  'gaussian-lsp': diagnosticReadiness('gaussian-lsp-tool', 'partial', 'passing'),
   'gpumd-lsp': diagnosticReadiness('gpumd-lsp-tool', 'partial', 'passing'),
   'gromacs-lsp': diagnosticReadiness('gromacs-lsp-tool', 'partial', 'passing'),
   'lammps-lsp': diagnosticReadiness('lammps-lsp-tool', 'partial'),
@@ -398,7 +398,7 @@ export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadine
   'nwchem-lsp': diagnosticReadiness('nwchem-lsp-tool', 'partial', 'passing'),
   'orca-lsp': diagnosticReadiness('orca-lsp-tool', 'partial', 'passing'),
   'pyatb-lsp': diagnosticReadiness('pyatb-lsp-tool', 'partial', 'passing'),
-  'pyscf-lsp': diagnosticReadiness('pyscf-lsp-tool', 'planned'),
+  'pyscf-lsp': diagnosticReadiness('pyscf-lsp-tool', 'partial', 'passing'),
   'qe-lsp': diagnosticReadiness('qe-lsp-tool', 'partial'),
   'vasp-lsp': diagnosticReadiness('vasp-lsp-tool', 'partial'),
 } as const;


### PR DESCRIPTION
## Summary
- mark ABINIT, Gaussian, and PySCF diagnostic readiness as partial with passing agent CLI smoke
- update the LSP compatibility matrix to reflect runtime/fix-preview evidence
- update the maturity audit notes so these repos no longer read as closed-loop planned

## Test Plan
- npm run typecheck
- npm run test:unit -- --coverage=false --runTestsByPath tests/unit/lsp/registry.test.ts tests/unit/lsp/bohriumRegistryAlignment.test.ts
- npm run lsp:check-family -- --strict --report-path /tmp/lsp-family-report-20260615-007-runtime-readiness.json
- npm run lsp:check-latest -- --fail-on-drift
- npm run lsp:check-bohrium-registry -- --strict --bohrium-registry /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml
- python3 /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/scripts/lsp_skill_probe.py --root /Users/yhm/Desktop/code/.worktrees-lsp-latest --json

## No-test justification
Registry metadata-only readiness update; existing registry and Bohrium alignment tests cover the contract, and no OpenQC runtime parser/editor behavior was changed.

Fixes #210
Refs newtontech/abinit-lsp#42
Refs newtontech/abinit-lsp#44
Refs newtontech/gaussian-lsp#86
Refs newtontech/gaussian-lsp#88
Refs newtontech/pyscf-lsp#40
Refs newtontech/pyscf-lsp#42