### PR TITLE
chore(lsp): mark ABACUS readiness from runtime evidence

### DIFF
--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -32,7 +32,7 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 
 | LSP Server | Diagnostic Engine | Agent CLI | Agent Operations | Help Smoke | Closed Loop |
 |------------|-------------------|-----------|------------------|------------|-------------|
-| `abacus-lsp` | v1 | `abacus-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
+| `abacus-lsp` | v1 | `abacus-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `abinit-lsp` | v1 | `abinit-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
 | `cif-lsp` | v1 | `cif-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
 | `cp2k-lsp-enhanced` | v1 | `cp2k-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |

--- a/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
+++ b/docs/LSP_FAMILY_MATURITY_AUDIT_2026-06-15.md
@@ -54,7 +54,7 @@ The OpenQC family gate has no blocking errors, but it still reports these maturi
 
 | Repo | Remaining warnings |
 |------|--------------------|
-| `abacus-lsp` | Missing canonical capabilities section; no git tags; no `CHANGELOG.md` or `VERSION`; closed-loop support still planned. |
+| `abacus-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`. INPUT/STRU/KPT runtime diagnostics and fix-preview/refusal envelopes are now wired, but exhaustive ABACUS version/rule coverage is still open. |
 | `abinit-lsp` | No git tags; no `CHANGELOG.md` or `VERSION`. Runtime/log diagnostics and fix-hint envelopes are now wired, but exhaustive ABINIT version/rule coverage is still open. |
 | `cif-lsp` | Closed-loop support still planned. |
 | `cp2k-lsp-enhanced` | No current family-gate warnings. |

--- a/src/lsp/registry.ts
+++ b/src/lsp/registry.ts
@@ -384,7 +384,7 @@ const BUNDLED_LSP_SERVERS: readonly LSPServerRegistryEntry[] = [
 ] as const;
 
 export const LSP_DIAGNOSTIC_READINESS: Readonly<Record<string, DiagnosticReadiness>> = {
-  'abacus-lsp': diagnosticReadiness('abacus-lsp-tool', 'planned'),
+  'abacus-lsp': diagnosticReadiness('abacus-lsp-tool', 'partial', 'passing'),
   'abinit-lsp': diagnosticReadiness('abinit-lsp-tool', 'partial', 'passing'),
   'cif-lsp': diagnosticReadiness('cif-lsp-tool', 'partial', 'passing'),
   'cp2k-lsp-enhanced': diagnosticReadiness('cp2k-lsp-tool', 'partial'),


### PR DESCRIPTION
## Summary
- mark ABACUS diagnostic readiness as partial with passing agent CLI smoke
- update the LSP compatibility matrix for ABACUS closed-loop readiness
- update the maturity audit note now that INPUT/STRU/KPT runtime diagnostics and fix previews are wired

## Test Plan
- npm run typecheck
- npm run test:unit -- --coverage=false --runTestsByPath tests/unit/lsp/registry.test.ts tests/unit/lsp/bohriumRegistryAlignment.test.ts
- npm run lsp:check-family -- --strict --report-path /tmp/lsp-family-report-20260615-007-abacus-readiness.json
- npm run lsp:check-latest -- --fail-on-drift
- npm run lsp:check-bohrium-registry -- --strict --bohrium-registry /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/references/lsp_backends.yaml
- python3 /Users/yhm/Desktop/code/.worktrees-lsp-latest/bohrium_skills/bohrium_skills/lsp-skills/scripts/lsp_skill_probe.py --root /Users/yhm/Desktop/code/.worktrees-lsp-latest --json

## No-test justification
Registry metadata-only readiness update; existing registry and Bohrium alignment tests cover the contract, and no OpenQC runtime parser/editor behavior was changed.

Fixes #212
Refs newtontech/abacus-lsp#70
Refs newtontech/abacus-lsp#72