### PR TITLE
feat(lsp): surface traceability gaps in family gate

### DIFF
--- a/docs/LSP_COMPATIBILITY.md
+++ b/docs/LSP_COMPATIBILITY.md
@@ -1,54 +1,117 @@
 # LSP Compatibility Matrix
 
-This matrix is the OpenQC-facing contract for the newtontech LSP family. The source of truth is `src/lsp/registry.ts`; `package.json`, language configurations, TextMate grammars, and this document must stay aligned with that registry.
+This document is generated from `src/lsp/registry.ts` and the LSP family gate report.
+Regenerate it with `npm run lsp:generate-compatibility-doc` after registry, backend, or gate changes.
 
-Last updated: 2026-06-15. Latest support is tracked against each repository default branch unless a release tag is listed below. OpenQC does not pin old server binaries; it launches the configured executable or sibling local repository, so users can run the newest server available in their environment.
+## Release Gate Summary
 
-## Quick Reference
+| Metric | Value |
+|--------|-------|
+| Backends | 17 |
+| Passing | 17 |
+| Blocking gaps | 0 |
+| Warnings | 18 |
+| Graduation score | 78/100 |
 
-| LSP Server | Language ID | Default Branch | Latest Release/Local Version | Domain | File Types | Stability | OpenQC Integration |
-|------------|-------------|----------------|------------------------------|--------|------------|-----------|--------------------|
-| [newtontech/abacus-lsp](https://github.com/newtontech/abacus-lsp) | `abacus` | `main` | 0.1.0 | ABACUS | `INPUT`, `STRU`, `KPT` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/abinit-lsp](https://github.com/newtontech/abinit-lsp) | `abinit` | `main` | 0.1.0 | ABINIT | `.abi`, `.abinit` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/cif-lsp](https://github.com/newtontech/cif-lsp) | `cif` | `master` | v1.0.2 | CIF | `.cif` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | `cp2k` | `develop` | v0.9.1 | CP2K | `.inp` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP) | `vasp` | `main` | 0.4.4 | VASP | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`, `CONTCAR`, `OSZICAR`, `OUTCAR`, `vasprun.xml` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp) | `gaussian` | `main` | 0.2.11 | Gaussian | `.gjf`, `.com` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp) | `orca` | `main` | 0.5.5 | ORCA | `.inp` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp) | `qe` | `main` | 0.1.0 | Quantum ESPRESSO | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp) | `gamess` | `main` | 0.1.0 | GAMESS | `.inp` | Stable | Syntax, file detection, direct LSP startup |
-| [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp) | `nwchem` | `main` | v0.3.0 / local 0.5.0 | NWChem | `.nw`, `.nwinp` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/gpumd-lsp](https://github.com/newtontech/gpumd-lsp) | `gpumd` | `main` | 0.1.0 | GPUMD | `run.in`, `nep.in` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/gromacs-lsp](https://github.com/newtontech/gromacs-lsp) | `gromacs` | `main` | v0.0.2 | GROMACS | `.top`, `.itp`, `.mdp`, `.gro` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/lammps-lsp](https://github.com/newtontech/lammps-lsp) | `lammps` | `master` | 0.1.0-pre-release-3 | LAMMPS | `.lmp`, `.lammps`, `.lmps`, `in.lammps` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/mlip-lsp](https://github.com/newtontech/mlip-lsp) | `mlip` | `main` | 0.1.0 | MLIP | `.mlip.json`, `.mlip.yaml`, `.mlip.yml`, `mlip.json`, `mlip.yaml`, `mlip.yml` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/pyatb-lsp](https://github.com/newtontech/pyatb-lsp) | `pyatb` | `main` | 0.1.0 | PyATB | `.pyatb.py`, `run_pyatb.py` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/pyscf-lsp](https://github.com/newtontech/pyscf-lsp) | `pyscf` | `main` | 0.1.0 | PySCF | `.pyscf.py`, `run_pyscf.py` | Experimental | Syntax, file detection, direct LSP startup |
-| [newtontech/dpgen-lsp](https://github.com/newtontech/dpgen-lsp) | `dpgen` | `main` | 0.1.0 | DP-GEN | `param.json`, `machine.json` | Experimental | Syntax, file detection, direct LSP startup |
+## Backend Matrix
 
-## Diagnostic Engine v1 Readiness
+| Backend | Language | Branch | File Types | Registry Stability | Gate Maturity | Release Evidence | Manifest | Provenance | Fixtures | Smoke | Diagnostics | Traceability |
+|---------|----------|--------|------------|--------------------|---------------|------------------|----------|------------|----------|-------|-------------|--------------|
+| [newtontech/abacus-lsp](https://github.com/newtontech/abacus-lsp) | `abacus` | `main` | `INPUT`, `STRU`, `KPT` | experimental | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `1e5d05f91b3f` | pass | pass | pass | pass | pass | missing |
+| [newtontech/abinit-lsp](https://github.com/newtontech/abinit-lsp) | `abinit` | `main` | `.abi`, `.abinit` | experimental | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `7612aeda243b` | pass | pass | pass | pass | pass | missing |
+| [newtontech/cif-lsp](https://github.com/newtontech/cif-lsp) | `cif` | `master` | `.cif` | experimental | stable | `v1.0.2`<br>HEAD `b3784d69cece` | pass | pass | pass | pass | pass | missing |
+| [newtontech/cp2k-lsp-enhanced](https://github.com/newtontech/cp2k-lsp-enhanced) | `cp2k` | `develop` | `.inp` | experimental | stable | `v0.9.1`<br>HEAD `c38db0a58344` | pass | pass | pass | pass | pass | missing |
+| [newtontech/VASP-LSP](https://github.com/newtontech/VASP-LSP) | `vasp` | `main` | `INCAR`, `POSCAR`, `KPOINTS`, `POTCAR`, `CONTCAR`, `OSZICAR`, `OUTCAR`, `vasprun.xml` | stable | stable | `v0.4.4`<br>VERSION `0.4.4`<br>HEAD `587fd094f7a7` | pass | pass | pass | pass | pass | missing |
+| [newtontech/gaussian-lsp](https://github.com/newtontech/gaussian-lsp) | `gaussian` | `main` | `.gjf`, `.com` | stable | stable | `v0.2.11`<br>VERSION `0.2.11`<br>HEAD `e886a6553cd9` | pass | pass | pass | pass | pass | missing |
+| [newtontech/orca-lsp](https://github.com/newtontech/orca-lsp) | `orca` | `main` | `.inp` | stable | stable | `v0.5.5`<br>VERSION `0.5.5`<br>HEAD `ecd4cabdba75` | pass | pass | pass | pass | pass | missing |
+| [newtontech/qe-lsp](https://github.com/newtontech/qe-lsp) | `qe` | `main` | `.in`, `.pw.in`, `.relax.in`, `.vc-relax.in`, `.scf.in`, `.nscf.in`, `.bands.in`, `.ph.in`, `.dos.in` | stable | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `ab0c4ac6cee1` | pass | pass | pass | pass | pass | missing |
+| [newtontech/gamess-lsp](https://github.com/newtontech/gamess-lsp) | `gamess` | `main` | `.inp` | stable | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `1dd85afa3d85` | pass | pass | pass | pass | pass | missing |
+| [newtontech/nwchem-lsp](https://github.com/newtontech/nwchem-lsp) | `nwchem` | `main` | `.nw`, `.nwinp` | experimental | stable | `v0.3.0`<br>HEAD `a9109413251e` | pass | pass | pass | pass | pass | missing |
+| [newtontech/gpumd-lsp](https://github.com/newtontech/gpumd-lsp) | `gpumd` | `main` | `run.in`, `nep.in` | experimental | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `882a582a23dd` | pass | pass | pass | pass | pass | missing |
+| [newtontech/gromacs-lsp](https://github.com/newtontech/gromacs-lsp) | `gromacs` | `main` | `.top`, `.itp`, `.mdp`, `.gro` | experimental | stable | `v0.0.3`<br>VERSION `0.0.3`<br>HEAD `3074ac19d5a7` | pass | pass | pass | pass | pass | missing |
+| [newtontech/lammps-lsp](https://github.com/newtontech/lammps-lsp) | `lammps` | `master` | `.lmp`, `.lammps`, `.lmps`, `in.lammps` | experimental | stable | `0.1.0-pre-release-3`<br>HEAD `8d77f45d8229` | pass | pass | pass | pass | pass | missing |
+| [newtontech/mlip-lsp](https://github.com/newtontech/mlip-lsp) | `mlip` | `main` | `.mlip.json`, `.mlip.yaml`, `.mlip.yml`, `mlip.json`, `mlip.yaml`, `mlip.yml` | experimental | stable | `v0.2.0`<br>VERSION `0.2.0`<br>HEAD `74599859d2da` | pass | pass | pass | pass | pass | missing |
+| [newtontech/pyatb-lsp](https://github.com/newtontech/pyatb-lsp) | `pyatb` | `main` | `.pyatb.py`, `run_pyatb.py` | experimental | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `beacd3141616` | pass | pass | pass | pass | pass | missing |
+| [newtontech/pyscf-lsp](https://github.com/newtontech/pyscf-lsp) | `pyscf` | `main` | `.pyscf.py`, `run_pyscf.py` | experimental | stable | `v0.1.0`<br>VERSION `0.1.0`<br>HEAD `766cf71b9e20` | pass | pass | pass | pass | pass | missing |
+| [newtontech/dpgen-lsp](https://github.com/newtontech/dpgen-lsp) | `dpgen` | `main` | `param.json`, `machine.json` | experimental | stable | `v0.1.0` local-only<br>VERSION `0.1.0`<br>HEAD `89daa8c2d125` | pass | partial | pass | pass | pass | missing |
 
-Every standalone LSP exposes the same agent CLI operation set: `check`, `context`, `complete`, `hover`, `symbols`, and `fix`. Optional provider depth can vary by backend, but unavailable provider data must be reported explicitly in JSON instead of returning reserved placeholders.
+## Agent CLI Readiness
 
-| LSP Server | Diagnostic Engine | Agent CLI | Agent Operations | Help Smoke | Closed Loop |
-|------------|-------------------|-----------|------------------|------------|-------------|
-| `abacus-lsp` | v1 | `abacus-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
-| `abinit-lsp` | v1 | `abinit-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
-| `cif-lsp` | v1 | `cif-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `cp2k-lsp-enhanced` | v1 | `cp2k-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
-| `gamess-lsp` | v1 | `gamess-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `gaussian-lsp` | v1 | `gaussian-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
-| `gpumd-lsp` | v1 | `gpumd-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `gromacs-lsp` | v1 | `gromacs-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `lammps-lsp` | v1 | `lammps-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
-| `mlip-lsp` | v1 | `mlip-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `nwchem-lsp` | v1 | `nwchem-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `orca-lsp` | v1 | `orca-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
-| `pyatb-lsp` | v1 | `pyatb-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `pyscf-lsp` | v1 | `pyscf-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Passing | Partial |
-| `dpgen-lsp` | v1 | `dpgen-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Planned |
-| `qe-lsp` | v1 | `qe-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
-| `vasp-lsp` | v1 | `vasp-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | Pending | Partial |
+| Backend | Agent CLI | Operations | Help Smoke | Closed Loop |
+|---------|-----------|------------|------------|-------------|
+| `abacus-lsp` | `abacus-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `abinit-lsp` | `abinit-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `cif-lsp` | `cif-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `cp2k-lsp-enhanced` | `cp2k-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `vasp-lsp` | `vasp-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `gaussian-lsp` | `gaussian-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `orca-lsp` | `orca-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `qe-lsp` | `qe-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `gamess-lsp` | `gamess-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `nwchem-lsp` | `nwchem-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `gpumd-lsp` | `gpumd-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `gromacs-lsp` | `gromacs-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `lammps-lsp` | `lammps-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `mlip-lsp` | `mlip-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `pyatb-lsp` | `pyatb-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `pyscf-lsp` | `pyscf-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+| `dpgen-lsp` | `dpgen-lsp-tool` | `check`, `context`, `complete`, `hover`, `symbols`, `fix` | pass | partial |
+
+## Actionable Gate Gaps
+
+### abacus-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### abinit-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### cif-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### cp2k-lsp-enhanced
+- WARN: No docstring/wiki/raw traceability report found
+
+### vasp-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### gaussian-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### orca-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### qe-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### gamess-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### nwchem-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### gpumd-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### gromacs-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### lammps-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### mlip-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### pyatb-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### pyscf-lsp
+- WARN: No docstring/wiki/raw traceability report found
+
+### dpgen-lsp
+- WARN: Latest local tag v0.1.0 is not present on origin
+- WARN: No docstring/wiki/raw traceability report found
+- Action: Push tag v0.1.0 to origin or retag the verified remote commit.
+
 
 ## OpenQC Integration Guarantees
 
@@ -58,25 +121,14 @@ Every standalone LSP exposes the same agent CLI operation set: `check`, `context
 | Grammar contribution | Every language has a TextMate grammar under `syntaxes/`. |
 | Configuration | Every language exposes `enabled`, `path`, `command`, `args`, and `env` settings under `openqc.lsp.<languageId>.*`. |
 | Startup | OpenQC starts the configured command over stdio and can prefer sibling local repositories when no user override is set. |
-| Latest tracking | Every registry entry records the upstream default branch used for latest-version checks. |
-| Agent CLI probe | `npm run lsp:check-latest -- --fail-on-drift` verifies remote HEAD, local worktree cleanliness, and source-backed `*-lsp-tool --help`. |
-| Bohrium registry alignment | `npm run lsp:check-bohrium-registry` compares OpenQC bundled ids/agent CLIs with `bohrium_skills/.../lsp_backends.yaml` and fails on drift. OpenQC editor integration and Bohrium skill routing are reported separately. |
-
-## Release Verification
-
-Before publishing a VSIX or Marketplace release:
-
-1. Run `npm run typecheck`.
-2. Run `npm run test:unit -- --runTestsByPath tests/unit/lsp/registry.test.ts`.
-3. Run `npm run lsp:check-latest -- --fail-on-drift` to compare sibling LSP checkouts with each configured remote default-branch HEAD and verify source-backed `*-lsp-tool --help`.
-4. Run `npm run lsp:check-bohrium-registry` to compare OpenQC bundled registry ids with the Bohrium skill backend registry.
-5. Run `OpenQC LSP: Generate Compatibility Report` from VS Code and save the report with the release notes.
-6. For each LSP, smoke test one valid file and one intentionally invalid file on the latest configured executable or sibling repository checkout.
-7. Record the exact LSP version, release tag, or commit SHA used for the release smoke test.
+| Latest tracking | `npm run lsp:check-latest -- --fail-on-drift` verifies local checkout cleanliness, remote HEAD parity, and agent CLI help. |
+| Family maturity | `npm run lsp:check-family -- --strict` verifies manifest, provenance, fixture, smoke, and Diagnostic Engine readiness. |
+| Traceability aggregation | `npm run lsp:check-family -- --strict` consumes backend docstring/wiki/raw traceability reports when present and reports missing or broken evidence links. |
+| Bohrium routing | `npm run lsp:check-bohrium-registry` verifies OpenQC and Bohrium backend ids and agent CLI names stay aligned. |
 
 ## Known Limits
 
-- The matrix records OpenQC integration support, not a promise that every standalone LSP implements every optional LSP method.
-- `cp2k-lsp-enhanced` uses `develop` as its latest upstream branch.
-- `cif-lsp` and `lammps-lsp` use `master` as their latest upstream branch.
-- Experimental entries are wired for startup and language support, but may have narrower standalone server capabilities than the stable chemistry LSPs.
+- This gate proves OpenQC integration readiness and the shared agent-facing contract; it does not prove exhaustive grammar coverage for every historical software release.
+- Complete version-aware parser/rule coverage and official-doc ingestion remain tracked in each backend repository issue queue.
+- Runtime scientific correctness still requires backend-specific fixture suites and, where available, real executable/log smoke tests.
+- OpenQC launches the configured executable or sibling checkout; it does not vendor or pin standalone backend binaries.

--- a/package.json
+++ b/package.json
@@ -1565,6 +1565,7 @@
     "lsp:check-latest": "node scripts/check-lsp-latest.mjs",
     "lsp:check-family": "node scripts/check-lsp-family.mjs",
     "lsp:check-bohrium-registry": "node scripts/check-bohrium-registry-alignment.mjs --strict",
+    "lsp:generate-compatibility-doc": "node scripts/generate-lsp-compatibility-doc.mjs",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-lsp-family.mjs
+++ b/scripts/check-lsp-family.mjs
@@ -105,6 +105,12 @@ const WARNING_CATEGORIES = {
     description: 'Agent CLI, closed-loop support',
     graduationWeight: 3,
   },
+  TRACEABILITY: {
+    id: 'traceability',
+    label: 'Docstring/Wiki/Raw Traceability',
+    description: 'Code docstrings link to LLM Wiki nodes and raw evidence',
+    graduationWeight: 3,
+  },
   CHECKOUT: {
     id: 'checkout',
     label: 'Local Checkout',
@@ -129,6 +135,9 @@ function categorizeWarning(message) {
   }
   if (lower.includes('closed-loop') || lower.includes('diagnostic') || lower.includes('agent cli')) {
     return WARNING_CATEGORIES.DIAGNOSTIC;
+  }
+  if (lower.includes('traceability') || lower.includes('docstring') || lower.includes('wiki') || lower.includes('raw')) {
+    return WARNING_CATEGORIES.TRACEABILITY;
   }
   if (lower.includes('checkout') || lower.includes('local')) {
     return WARNING_CATEGORIES.CHECKOUT;
@@ -292,29 +301,94 @@ function checkProvenance(entry) {
   const localPath = findLocalCheckout(entry);
 
   if (!localPath) {
-    return { status: 'missing', gaps: [{ severity: SEVERITY.WARNING, message: 'No local checkout found' }] };
+    return {
+      status: 'missing',
+      gaps: [{ severity: SEVERITY.WARNING, message: 'No local checkout found' }],
+      evidence: {
+        localPath: null,
+        head: null,
+        latestTag: null,
+        remoteTagPresent: null,
+        versionFiles: [],
+        changelogPaths: [],
+        manifestPath: null,
+        manifestReleaseVersion: null,
+        sourceProvenanceCount: 0,
+      },
+      actions: ['Refresh .worktrees-lsp-latest or create a sibling checkout for this backend.'],
+    };
   }
 
   const gaps = [];
+  const actions = [];
+  const manifestPath = join(localPath, 'lsp-capabilities.json');
+  const manifest = readJsonIfExists(manifestPath);
+  const sourceProvenance = getSourceProvenance(manifest);
+  const head = git(['-C', localPath, 'rev-parse', 'HEAD'], { quiet: true }) || null;
+  let latestTag = null;
+  let remoteTagPresent = null;
 
   // Check for version/tag
   try {
     const tags = git(['-C', localPath, 'tag', '--sort=-version:refname'], { quiet: true });
     if (tags.trim().length === 0) {
       gaps.push({ severity: SEVERITY.WARNING, message: 'No git tags found (no release version)' });
+      actions.push('Create and push a semver release tag for the commit verified by the family gate.');
+    } else {
+      latestTag = tags.split(/\r?\n/).find(Boolean) ?? null;
+      if (!isSemverTag(latestTag)) {
+        gaps.push({ severity: SEVERITY.WARNING, message: `Latest git tag is not semver-like: ${latestTag}` });
+        actions.push('Create a semver-like release tag such as v0.1.0 for the verified commit.');
+      }
+      remoteTagPresent = hasRemoteTag(localPath, latestTag);
+      if (remoteTagPresent === false) {
+        gaps.push({ severity: SEVERITY.WARNING, message: `Latest local tag ${latestTag} is not present on origin` });
+        actions.push(`Push tag ${latestTag} to origin or retag the verified remote commit.`);
+      }
     }
   } catch {
     gaps.push({ severity: SEVERITY.INFO, message: 'Could not read tags' });
+    actions.push('Verify git tag metadata is available in the local checkout.');
   }
 
   // Check for CHANGELOG or version file
-  const hasChangelog = existsSync(join(localPath, 'CHANGELOG.md')) || existsSync(join(localPath, 'CHANGELOG'));
-  const hasVersion = existsSync(join(localPath, 'VERSION')) || existsSync(join(localPath, 'version.txt'));
+  const changelogPaths = ['CHANGELOG.md', 'CHANGELOG']
+    .map(file => join(localPath, file))
+    .filter(path => existsSync(path));
+  const versionFiles = ['VERSION', 'version.txt']
+    .map(file => join(localPath, file))
+    .filter(path => existsSync(path));
+  const hasChangelog = changelogPaths.length > 0;
+  const hasVersion = versionFiles.length > 0;
   if (!hasChangelog && !hasVersion) {
     gaps.push({ severity: SEVERITY.WARNING, message: 'No CHANGELOG.md or VERSION file' });
+    actions.push('Add CHANGELOG.md or VERSION so release evidence is visible without inspecting git tags.');
   }
 
-  return { status: gaps.length === 0 ? 'pass' : 'partial', gaps };
+  if (existsSync(manifestPath) && sourceProvenance.length === 0) {
+    gaps.push({
+      severity: SEVERITY.WARNING,
+      message: 'No sourceProvenance entries in lsp-capabilities.json',
+    });
+    actions.push('Add sourceProvenance entries linking rule coverage to upstream manuals, examples, or generated indexes.');
+  }
+
+  return {
+    status: gaps.length === 0 ? 'pass' : 'partial',
+    gaps,
+    evidence: {
+      localPath,
+      head,
+      latestTag,
+      remoteTagPresent,
+      versionFiles,
+      changelogPaths,
+      manifestPath: existsSync(manifestPath) ? manifestPath : null,
+      manifestReleaseVersion: manifestReleaseVersion(manifest),
+      sourceProvenanceCount: sourceProvenance.length,
+    },
+    actions,
+  };
 }
 
 /**
@@ -410,6 +484,101 @@ function checkDiagnosticReadiness(entry) {
   };
 }
 
+/**
+ * Check for backend-provided docstring -> LLM Wiki -> raw provenance reports.
+ *
+ * This is intentionally an aggregation contract: backend repos own language
+ * parsing and docstring scanning, while OpenQC consumes their deterministic
+ * report and makes missing/broken provenance visible in the family gate.
+ */
+function checkTraceability(entry) {
+  const localPath = findLocalCheckout(entry);
+
+  if (!localPath) {
+    return {
+      status: 'missing',
+      reportPath: null,
+      evidence: null,
+      gaps: [{ severity: SEVERITY.WARNING, message: 'No local checkout; cannot check docstring/wiki/raw traceability' }],
+      actions: ['Refresh the latest backend checkout before running the traceability gate.'],
+    };
+  }
+
+  const reportPath = traceabilityReportCandidates(localPath).find(path => existsSync(path)) ?? null;
+  if (!reportPath) {
+    return {
+      status: 'missing',
+      reportPath: null,
+      evidence: {
+        localPath,
+        searchedPaths: traceabilityReportCandidates(localPath),
+      },
+      gaps: [{
+        severity: SEVERITY.WARNING,
+        message: 'No docstring/wiki/raw traceability report found',
+      }],
+      actions: [
+        'Add a backend traceability checker that emits a deterministic report consumed by OpenQC.',
+        'Verify every scientific docstring links to a specific wiki node and every wiki source links to raw evidence.',
+      ],
+    };
+  }
+
+  const report = readJsonIfExists(reportPath);
+  if (!report) {
+    return {
+      status: 'invalid',
+      reportPath,
+      evidence: { localPath, reportPath },
+      gaps: [{ severity: SEVERITY.ERROR, message: `Invalid traceability report JSON: ${reportPath}` }],
+      actions: ['Regenerate the traceability report as valid JSON.'],
+    };
+  }
+
+  const counts = traceabilityCounts(report);
+  const gaps = [];
+  const actions = [];
+
+  if (counts.docstringsTotal === null || counts.docstringsLinked === null) {
+    gaps.push({
+      severity: SEVERITY.WARNING,
+      message: 'Traceability report missing docstring scan counts',
+    });
+    actions.push('Emit docstringsTotal and docstringsLinked counts from the backend checker.');
+  } else if (counts.docstringsLinked < counts.docstringsTotal) {
+    gaps.push({
+      severity: SEVERITY.ERROR,
+      message: `Unlinked docstrings: ${counts.docstringsTotal - counts.docstringsLinked}`,
+    });
+    actions.push('Link every scientific docstring/doc comment to a specific LLM Wiki node.');
+  }
+
+  if (counts.brokenWikiLinks > 0) {
+    gaps.push({ severity: SEVERITY.ERROR, message: `Broken wiki links: ${counts.brokenWikiLinks}` });
+    actions.push('Repair broken docstring-to-wiki references.');
+  }
+  if (counts.wikiSourcesWithoutRaw > 0) {
+    gaps.push({ severity: SEVERITY.ERROR, message: `Wiki source nodes without raw evidence: ${counts.wikiSourcesWithoutRaw}` });
+    actions.push('Link every wiki source node to raw/ evidence or raw/assets/manifest.json stable ids.');
+  }
+  if (counts.rawManifestFailures > 0) {
+    gaps.push({ severity: SEVERITY.ERROR, message: `Raw manifest failures: ${counts.rawManifestFailures}` });
+    actions.push('Fix raw/assets/manifest.json entries, checksums, and missing raw artifact paths.');
+  }
+
+  return {
+    status: gaps.length === 0 ? 'pass' : 'partial',
+    reportPath,
+    evidence: {
+      localPath,
+      reportPath,
+      counts,
+    },
+    gaps,
+    actions,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -462,6 +631,88 @@ function listFilesRecursive(dir, files = []) {
     }
   }
   return files;
+}
+
+function traceabilityReportCandidates(localPath) {
+  return [
+    join(localPath, 'traceability-report.json'),
+    join(localPath, 'docstring-traceability.json'),
+    join(localPath, 'reports', 'traceability.json'),
+    join(localPath, 'reports', 'docstring-wiki-raw-traceability.json'),
+    join(localPath, 'docs', 'traceability-report.json'),
+    join(localPath, 'raw', 'assets', 'traceability-report.json'),
+  ];
+}
+
+function traceabilityCounts(report) {
+  const summary = report.summary ?? report.traceability ?? report;
+  return {
+    docstringsTotal: numberOrNull(summary.docstringsTotal ?? summary.docstrings_total ?? summary.totalDocstrings),
+    docstringsLinked: numberOrNull(summary.docstringsLinked ?? summary.docstrings_linked ?? summary.linkedDocstrings),
+    brokenWikiLinks: numberOrZero(summary.brokenWikiLinks ?? summary.broken_wiki_links ?? summary.brokenLinks),
+    wikiSourcesWithoutRaw: numberOrZero(
+      summary.wikiSourcesWithoutRaw
+      ?? summary.wiki_sources_without_raw
+      ?? summary.wikiSourcesMissingRaw
+    ),
+    rawManifestFailures: numberOrZero(
+      summary.rawManifestFailures
+      ?? summary.raw_manifest_failures
+      ?? summary.rawManifestErrors
+    ),
+  };
+}
+
+function numberOrNull(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function numberOrZero(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function readJsonIfExists(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function manifestReleaseVersion(manifest) {
+  if (!manifest || typeof manifest !== 'object') return null;
+  return manifest.releaseVersion
+    ?? manifest.release_version
+    ?? manifest.softwareVersion
+    ?? manifest.software_version
+    ?? null;
+}
+
+function getSourceProvenance(manifest) {
+  if (!manifest || typeof manifest !== 'object') return [];
+  const value = manifest.sourceProvenance
+    ?? manifest.source_provenance
+    ?? manifest.provenance
+    ?? manifest.sources
+    ?? [];
+  return Array.isArray(value) ? value : value ? [value] : [];
+}
+
+function isSemverTag(tag) {
+  return typeof tag === 'string' && /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(tag);
+}
+
+function hasRemoteTag(localPath, tag) {
+  if (!tag) return null;
+  try {
+    const remoteTags = git(['-C', localPath, 'ls-remote', '--tags', 'origin', `refs/tags/${tag}`], { quiet: true });
+    return remoteTags.trim().length > 0;
+  } catch {
+    return null;
+  }
 }
 
 function agentHelpProbe(entry, localPath) {
@@ -527,6 +778,7 @@ function checkRepo(entry) {
   const fixtures = checkFixtures(entry);
   const smoke = checkSmoke(entry);
   const diagReadiness = checkDiagnosticReadiness(entry);
+  const traceability = checkTraceability(entry);
 
   const allGaps = [
     ...manifest.gaps,
@@ -534,6 +786,7 @@ function checkRepo(entry) {
     ...fixtures.gaps,
     ...smoke.gaps,
     ...diagReadiness.gaps,
+    ...traceability.gaps,
   ];
 
   const hasBlocking = allGaps.some(g => g.severity === SEVERITY.ERROR);
@@ -547,9 +800,15 @@ function checkRepo(entry) {
     manifest: manifest.status,
     manifestPath: manifest.path,
     provenance: provenance.status,
+    provenanceEvidence: provenance.evidence,
+    provenanceActions: provenance.actions,
     fixtures: fixtures.status,
     smoke: smoke.status,
     diagnosticReadiness: diagReadiness.status,
+    traceability: traceability.status,
+    traceabilityReportPath: traceability.reportPath,
+    traceabilityEvidence: traceability.evidence,
+    traceabilityActions: traceability.actions,
     maturity,
     gaps: allGaps,
     blockingGaps: allGaps.filter(g => g.severity === SEVERITY.ERROR),
@@ -618,7 +877,7 @@ if (jsonMode) {
   for (const r of results) {
     const icon = r.blockingGaps.length > 0 ? 'FAIL' : r.warningGaps.length > 0 ? 'WARN' : 'PASS';
     console.log(`[${icon}] ${r.id} (${r.languageId})`);
-    console.log(`    manifest: ${r.manifest} | provenance: ${r.provenance} | fixtures: ${r.fixtures} | smoke: ${r.smoke} | diag: ${r.diagnosticReadiness}`);
+    console.log(`    manifest: ${r.manifest} | provenance: ${r.provenance} | fixtures: ${r.fixtures} | smoke: ${r.smoke} | diag: ${r.diagnosticReadiness} | trace: ${r.traceability}`);
 
     if (verbose || r.blockingGaps.length > 0) {
       for (const gap of r.blockingGaps) {
@@ -628,6 +887,12 @@ if (jsonMode) {
     if (verbose) {
       for (const gap of r.warningGaps) {
         console.log(`    WARN:  ${gap.message}`);
+      }
+      for (const action of r.provenanceActions ?? []) {
+        console.log(`    ACTION: ${action}`);
+      }
+      for (const action of r.traceabilityActions ?? []) {
+        console.log(`    ACTION: ${action}`);
       }
     }
     console.log('');

--- a/scripts/generate-lsp-compatibility-doc.mjs
+++ b/scripts/generate-lsp-compatibility-doc.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+/**
+ * Generate the OpenQC-facing LSP compatibility and maturity document from the
+ * registry plus the family gate report.
+ *
+ * Usage:
+ *   node scripts/generate-lsp-compatibility-doc.mjs
+ *   node scripts/generate-lsp-compatibility-doc.mjs --family-report /tmp/report.json
+ *   node scripts/generate-lsp-compatibility-doc.mjs --check
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const codeRoot = resolve(repoRoot, '..');
+
+const args = process.argv.slice(2);
+const checkMode = args.includes('--check');
+const dryRun = args.includes('--dry-run');
+const outputPath = resolve(readFlag('--output') ?? join(repoRoot, 'docs', 'LSP_COMPATIBILITY.md'));
+const familyReportPath = readFlag('--family-report');
+
+const registryPath = join(repoRoot, 'src', 'lsp', 'registry.ts');
+const registrySource = readFileSync(registryPath, 'utf8');
+const registryEntries = parseRegistry(registrySource);
+const readiness = parseReadiness(registrySource);
+const familyReport = loadFamilyReport(familyReportPath);
+const familyById = new Map((familyReport.results ?? []).map(result => [result.id, result]));
+
+if (registryEntries.length === 0) {
+  throw new Error(`No bundled LSP registry entries found in ${registryPath}`);
+}
+
+const markdown = renderDocument(registryEntries, readiness, familyById, familyReport);
+
+if (checkMode) {
+  const existing = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : '';
+  if (existing !== markdown) {
+    console.error(`${relative(repoRoot, outputPath)} is out of date. Run npm run lsp:generate-compatibility-doc.`);
+    process.exit(1);
+  }
+  console.log(`${relative(repoRoot, outputPath)} is up to date.`);
+} else if (dryRun) {
+  process.stdout.write(markdown);
+} else {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, markdown);
+  console.log(`Wrote ${relative(repoRoot, outputPath)} for ${registryEntries.length} LSP backends.`);
+}
+
+function readFlag(name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+function loadFamilyReport(path) {
+  if (path) {
+    return JSON.parse(readFileSync(resolve(path), 'utf8'));
+  }
+
+  const output = execFileSync(process.execPath, [join(__dirname, 'check-lsp-family.mjs'), '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  return JSON.parse(output);
+}
+
+function parseRegistry(source) {
+  const marker = 'const BUNDLED_LSP_SERVERS';
+  const start = source.indexOf(marker);
+  if (start === -1) return [];
+
+  const arrayStart = source.indexOf('[', start);
+  const arrayEnd = source.indexOf('] as const', arrayStart);
+  const arraySource = source.slice(arrayStart, arrayEnd);
+
+  const blocks = [];
+  let depth = 0;
+  let blockStart = -1;
+  for (let i = 0; i < arraySource.length; i++) {
+    const char = arraySource[i];
+    if (char === '{') {
+      if (depth === 0) blockStart = i;
+      depth++;
+    } else if (char === '}') {
+      depth--;
+      if (depth === 0 && blockStart !== -1) {
+        blocks.push(arraySource.slice(blockStart, i + 1));
+        blockStart = -1;
+      }
+    }
+  }
+
+  return blocks.map(block => ({
+    id: readStringField(block, 'id'),
+    name: readStringField(block, 'name'),
+    repository: readStringField(block, 'repository'),
+    executable: readStringField(block, 'executable'),
+    languageId: readStringField(block, 'languageId'),
+    fileExtensions: readStringArray(block, 'fileExtensions'),
+    fileNames: readStringArray(block, 'fileNames'),
+    stability: readStringField(block, 'stability'),
+    defaultBranch: readStringField(block, 'defaultBranch'),
+  })).filter(entry => entry.id);
+}
+
+function parseReadiness(source) {
+  const map = new Map();
+  const pattern = /'([^']+)': diagnosticReadiness\('([^']+)', '([^']+)'(?:, '([^']+)')?\)/g;
+  for (const match of source.matchAll(pattern)) {
+    map.set(match[1], {
+      agentCli: match[2],
+      closedLoop: match[3],
+      agentCliSmokeStatus: match[4] ?? 'pending',
+    });
+  }
+  return map;
+}
+
+function readStringField(block, field) {
+  const match = block.match(new RegExp(`\\b${field}:\\s*'([^']*)'`));
+  return match?.[1] ?? '';
+}
+
+function readStringArray(block, field) {
+  const start = block.search(new RegExp(`\\b${field}:\\s*\\[`));
+  if (start === -1) return [];
+  const open = block.indexOf('[', start);
+  let depth = 0;
+  for (let i = open; i < block.length; i++) {
+    if (block[i] === '[') depth++;
+    if (block[i] === ']') {
+      depth--;
+      if (depth === 0) {
+        return [...block.slice(open + 1, i).matchAll(/'([^']+)'/g)].map(match => match[1]);
+      }
+    }
+  }
+  return [];
+}
+
+function renderDocument(entries, readiness, familyById, report) {
+  const lines = [
+    '# LSP Compatibility Matrix',
+    '',
+    'This document is generated from `src/lsp/registry.ts` and the LSP family gate report.',
+    'Regenerate it with `npm run lsp:generate-compatibility-doc` after registry, backend, or gate changes.',
+    '',
+    '## Release Gate Summary',
+    '',
+    `| Metric | Value |`,
+    `|--------|-------|`,
+    `| Backends | ${report.totalRepos ?? entries.length} |`,
+    `| Passing | ${report.passing ?? 'unknown'} |`,
+    `| Blocking gaps | ${report.blockingGaps ?? 'unknown'} |`,
+    `| Warnings | ${report.warningGaps ?? 'unknown'} |`,
+    `| Graduation score | ${report.graduationScore ?? 'unknown'}/100 |`,
+    '',
+    '## Backend Matrix',
+    '',
+    '| Backend | Language | Branch | File Types | Registry Stability | Gate Maturity | Release Evidence | Manifest | Provenance | Fixtures | Smoke | Diagnostics | Traceability |',
+    '|---------|----------|--------|------------|--------------------|---------------|------------------|----------|------------|----------|-------|-------------|--------------|',
+  ];
+
+  for (const entry of entries) {
+    const family = familyById.get(entry.id);
+    const evidence = family?.provenanceEvidence ?? buildLocalProvenanceEvidence(entry);
+    lines.push([
+      repoLink(entry),
+      code(entry.languageId),
+      code(entry.defaultBranch),
+      formatFileTypes(entry),
+      entry.stability,
+      family?.maturity ?? 'unknown',
+      formatReleaseEvidence(evidence),
+      statusCell(family?.manifest),
+      statusCell(family?.provenance),
+      statusCell(family?.fixtures),
+      statusCell(family?.smoke),
+      statusCell(family?.diagnosticReadiness),
+      statusCell(family?.traceability),
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push(
+    '',
+    '## Agent CLI Readiness',
+    '',
+    '| Backend | Agent CLI | Operations | Help Smoke | Closed Loop |',
+    '|---------|-----------|------------|------------|-------------|'
+  );
+
+  for (const entry of entries) {
+    const ready = readiness.get(entry.id) ?? {};
+    const family = familyById.get(entry.id);
+    lines.push([
+      code(entry.id),
+      code(ready.agentCli ?? 'unconfigured'),
+      '`check`, `context`, `complete`, `hover`, `symbols`, `fix`',
+      family?.smoke ?? ready.agentCliSmokeStatus ?? 'unknown',
+      ready.closedLoop ?? 'unknown',
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push('', '## Actionable Gate Gaps', '');
+  const gapLines = [];
+  for (const entry of entries) {
+    const family = familyById.get(entry.id);
+    const gaps = [
+      ...(family?.blockingGaps ?? []).map(gap => `ERROR: ${gap.message}`),
+      ...(family?.warningGaps ?? []).map(gap => `WARN: ${gap.message}`),
+    ];
+    const actions = family?.provenanceActions ?? [];
+    if (gaps.length === 0 && actions.length === 0) continue;
+    gapLines.push(`### ${entry.id}`);
+    for (const gap of gaps) gapLines.push(`- ${gap}`);
+    for (const action of actions) gapLines.push(`- Action: ${action}`);
+    gapLines.push('');
+  }
+  if (gapLines.length === 0) {
+    lines.push('No blocking or warning gaps are reported by `scripts/check-lsp-family.mjs`.');
+  } else {
+    lines.push(...gapLines);
+  }
+
+  lines.push(
+    '',
+    '## OpenQC Integration Guarantees',
+    '',
+    '| Capability | OpenQC guarantee |',
+    '|------------|------------------|',
+    '| Language contribution | Every registry entry has a matching `contributes.languages` item in `package.json`. |',
+    '| Grammar contribution | Every language has a TextMate grammar under `syntaxes/`. |',
+    '| Configuration | Every language exposes `enabled`, `path`, `command`, `args`, and `env` settings under `openqc.lsp.<languageId>.*`. |',
+    '| Startup | OpenQC starts the configured command over stdio and can prefer sibling local repositories when no user override is set. |',
+    '| Latest tracking | `npm run lsp:check-latest -- --fail-on-drift` verifies local checkout cleanliness, remote HEAD parity, and agent CLI help. |',
+    '| Family maturity | `npm run lsp:check-family -- --strict` verifies manifest, provenance, fixture, smoke, and Diagnostic Engine readiness. |',
+    '| Traceability aggregation | `npm run lsp:check-family -- --strict` consumes backend docstring/wiki/raw traceability reports when present and reports missing or broken evidence links. |',
+    '| Bohrium routing | `npm run lsp:check-bohrium-registry` verifies OpenQC and Bohrium backend ids and agent CLI names stay aligned. |',
+    '',
+    '## Known Limits',
+    '',
+    '- This gate proves OpenQC integration readiness and the shared agent-facing contract; it does not prove exhaustive grammar coverage for every historical software release.',
+    '- Complete version-aware parser/rule coverage and official-doc ingestion remain tracked in each backend repository issue queue.',
+    '- Runtime scientific correctness still requires backend-specific fixture suites and, where available, real executable/log smoke tests.',
+    '- OpenQC launches the configured executable or sibling checkout; it does not vendor or pin standalone backend binaries.'
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function repoLink(entry) {
+  return `[${entry.repository}](https://github.com/${entry.repository})`;
+}
+
+function code(value) {
+  return `\`${value}\``;
+}
+
+function formatFileTypes(entry) {
+  const extensions = entry.fileExtensions.map(ext => code(ext.startsWith('.') ? ext : `.${ext}`));
+  const names = entry.fileNames.map(name => code(name));
+  const values = [...extensions, ...names];
+  return values.length > 0 ? values.join(', ') : 'none';
+}
+
+function statusCell(status) {
+  if (!status) return 'unknown';
+  return status === 'pass' ? 'pass' : status;
+}
+
+function formatReleaseEvidence(evidence) {
+  const tag = evidence?.latestTag;
+  const versionFile = firstExistingEvidencePath(evidence?.versionFiles);
+  const version = versionFile ? readFirstLine(versionFile) : null;
+  const manifestVersion = evidence?.manifestReleaseVersion;
+  const head = evidence?.head ? String(evidence.head).slice(0, 12) : null;
+  const parts = [];
+  if (tag) {
+    const remoteState = evidence?.remoteTagPresent === false ? ' local-only' : '';
+    parts.push(`${code(tag)}${remoteState}`);
+  }
+  if (version) parts.push(`VERSION ${code(version)}`);
+  if (!tag && manifestVersion) parts.push(`manifest ${code(manifestVersion)}`);
+  if (head) parts.push(`HEAD ${code(head)}`);
+  return parts.length > 0 ? parts.join('<br>') : 'unreleased/local';
+}
+
+function firstExistingEvidencePath(paths = []) {
+  return paths.find(path => typeof path === 'string' && existsSync(path)) ?? null;
+}
+
+function readFirstLine(path) {
+  try {
+    return readFileSync(path, 'utf8').split(/\r?\n/).find(Boolean)?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function buildLocalProvenanceEvidence(entry) {
+  const localPath = findLocalCheckout(entry);
+  if (!localPath) {
+    return {};
+  }
+  const latestTag = git(['-C', localPath, 'tag', '--sort=-version:refname']).split(/\r?\n/).find(Boolean) ?? null;
+  return {
+    localPath,
+    head: git(['-C', localPath, 'rev-parse', 'HEAD']),
+    latestTag,
+    remoteTagPresent: hasRemoteTag(localPath, latestTag),
+    versionFiles: ['VERSION', 'version.txt'].map(file => join(localPath, file)).filter(path => existsSync(path)),
+    changelogPaths: ['CHANGELOG.md', 'CHANGELOG'].map(file => join(localPath, file)).filter(path => existsSync(path)),
+    manifestPath: existsSync(join(localPath, 'lsp-capabilities.json')) ? join(localPath, 'lsp-capabilities.json') : null,
+  };
+}
+
+function findLocalCheckout(entry) {
+  const repoName = entry.repository.split('/')[1];
+  const candidates = [
+    join(codeRoot, '.worktrees-lsp-latest', repoName),
+    join(codeRoot, repoName),
+    join(codeRoot, '.worktrees-lsp-wiki-agent-cli-20260612', repoName),
+  ];
+  return candidates.find(path => existsSync(join(path, '.git'))) ?? null;
+}
+
+function git(args) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10000,
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function hasRemoteTag(localPath, tag) {
+  if (!tag) return null;
+  return git(['-C', localPath, 'ls-remote', '--tags', 'origin', `refs/tags/${tag}`]).length > 0;
+}


### PR DESCRIPTION
## Summary

- extends the LSP family gate with actionable provenance evidence, including origin tag presence
- adds backend docstring/wiki/raw traceability aggregation as a family warning category
- generates docs/LSP_COMPATIBILITY.md from the registry plus family report, including traceability status

## Test Plan

- npm run lsp:check-family -- --strict --verbose --report-path /tmp/lsp-family-report-20260615-traceability.json
- npm run lsp:generate-compatibility-doc -- --family-report /tmp/lsp-family-report-20260615-traceability.json --check
- npm run typecheck
- npm run lsp:check-latest -- --fail-on-drift
- npm run lsp:check-bohrium-registry -- --strict --report-path /tmp/lsp-bohrium-registry-20260615-traceability.json
- pre-commit: lint, typecheck, tests/unit coverage, format:check

Fixes #214
Fixes #215
Refs #222