### PR TITLE
Standardize LSP traceability report contract

### DIFF
--- a/docs/lsp-traceability-report-contract.md
+++ b/docs/lsp-traceability-report-contract.md
@@ -1,0 +1,79 @@
+# LSP Traceability Report Contract
+
+OpenQC consumes backend reports that prove scientific docstrings link to LLM
+Wiki nodes and that wiki source claims link to raw evidence assets. Backend
+repositories own language-specific scanning; OpenQC owns the shared report
+contract and family gate.
+
+Schema file: `docs/schemas/lsp-traceability-report.schema.json`
+
+## Required Report
+
+Backends should write one JSON report at one of the paths consumed by
+`scripts/check-lsp-family.mjs`, preferably:
+
+```text
+reports/docstring-wiki-raw-traceability.json
+```
+
+The report must use:
+
+```json
+{
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "cp2k-lsp-enhanced",
+  "repository": "newtontech/cp2k-lsp-enhanced",
+  "languageId": "cp2k",
+  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "summary": {
+    "docstringsTotal": 2,
+    "docstringsLinked": 2,
+    "brokenWikiLinks": 0,
+    "wikiSourcesWithoutRaw": 0,
+    "rawManifestFailures": 0
+  },
+  "docstrings": [],
+  "wikiSources": [],
+  "ruleIds": [],
+  "sourceUrls": [],
+  "rawManifest": {
+    "path": "raw/assets/manifest.json",
+    "ok": true
+  }
+}
+```
+
+## Rule IDs
+
+Rule IDs must use:
+
+```text
+<BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN
+```
+
+Examples:
+
+- `CP2K-INPUT-SYNTAX-001`
+- `DPGEN-MACHINE-SCHEMA-001`
+
+`BACKEND`, `FILE_ROLE`, and `CATEGORY` are uppercase alphanumeric tokens. Use
+underscores inside a token when needed.
+
+## Path Rules
+
+Reports must not require hidden local absolute paths. Use repository-relative
+paths for code, wiki, and raw evidence:
+
+- `src/...` for code docstrings and rule sources
+- `wiki/...` or `docs/...` for LLM Wiki nodes
+- `raw/...` or `raw/assets/...` for raw assets and manifests
+
+Remote source claims must also include a raw evidence path, not only a URL.
+
+## OpenQC Gate
+
+`npm run lsp:check-family -- --strict` validates the report shape when a
+backend report is present. Missing reports remain warnings during rollout;
+invalid schema, server ID mismatch, unlinked docstrings, broken wiki links,
+missing raw evidence links, and raw manifest failures are reported as
+traceability gaps with explicit remediation actions.

--- a/docs/schemas/lsp-traceability-report.schema.json
+++ b/docs/schemas/lsp-traceability-report.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/newtontech/OpenQC-VSCode/docs/schemas/lsp-traceability-report.schema.json",
+  "title": "OpenQC LSP Traceability Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "serverId",
+    "repository",
+    "languageId",
+    "generatedAt",
+    "summary",
+    "docstrings",
+    "wikiSources",
+    "ruleIds",
+    "sourceUrls",
+    "rawManifest"
+  ],
+  "$defs": {
+    "repoRelativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!file:)(?!.*(?:^|[\\\\/])\\.\\.(?:[\\\\/]|$)).+"
+    }
+  },
+  "properties": {
+    "schemaVersion": {
+      "const": "openqc.lsp.traceability.v1"
+    },
+    "serverId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repository": {
+      "type": "string",
+      "minLength": 1
+    },
+    "languageId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "docstringsTotal",
+        "docstringsLinked",
+        "brokenWikiLinks",
+        "wikiSourcesWithoutRaw",
+        "rawManifestFailures"
+      ],
+      "properties": {
+        "docstringsTotal": { "type": "integer", "minimum": 0 },
+        "docstringsLinked": { "type": "integer", "minimum": 0 },
+        "brokenWikiLinks": { "type": "integer", "minimum": 0 },
+        "wikiSourcesWithoutRaw": { "type": "integer", "minimum": 0 },
+        "rawManifestFailures": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "docstrings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "symbol", "wikiPath"],
+        "properties": {
+          "path": { "$ref": "#/$defs/repoRelativePath" },
+          "symbol": { "type": "string", "minLength": 1 },
+          "wikiPath": { "$ref": "#/$defs/repoRelativePath" }
+        }
+      }
+    },
+    "wikiSources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["wikiPath", "sourceUrl", "rawPath"],
+        "properties": {
+          "wikiPath": { "$ref": "#/$defs/repoRelativePath" },
+          "sourceUrl": { "type": "string", "minLength": 1 },
+          "rawPath": { "$ref": "#/$defs/repoRelativePath" }
+        }
+      }
+    },
+    "ruleIds": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "sourcePath"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Z0-9]+-[A-Z0-9_]+-[A-Z0-9_]+-[0-9]{3}$"
+          },
+          "sourcePath": { "$ref": "#/$defs/repoRelativePath" }
+        }
+      }
+    },
+    "sourceUrls": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["url", "rawPath"],
+        "properties": {
+          "url": { "type": "string", "minLength": 1 },
+          "rawPath": { "$ref": "#/$defs/repoRelativePath" },
+          "kind": { "type": "string" }
+        }
+      }
+    },
+    "rawManifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "ok"],
+      "properties": {
+        "path": { "$ref": "#/$defs/repoRelativePath" },
+        "ok": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/scripts/check-lsp-family.mjs
+++ b/scripts/check-lsp-family.mjs
@@ -20,12 +20,12 @@
 
 import { execFileSync } from 'child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
-const codeRoot = resolve(repoRoot, '..');
+const codeRoot = resolveCodeRoot(repoRoot);
 
 // ---------------------------------------------------------------------------
 // CLI flags
@@ -75,6 +75,9 @@ const SEVERITY = {
   WARNING: 'warning',   // maturity gap, does not block
   INFO: 'info',         // informational
 };
+
+const TRACEABILITY_REPORT_SCHEMA_VERSION = 'openqc.lsp.traceability.v1';
+const TRACEABILITY_RULE_ID_PATTERN = /^[A-Z0-9]+-[A-Z0-9_]+-[A-Z0-9_]+-\d{3}$/;
 
 // ---------------------------------------------------------------------------
 // Warning categories for actionable maturity tracking
@@ -535,9 +538,23 @@ function checkTraceability(entry) {
     };
   }
 
-  const counts = traceabilityCounts(report);
   const gaps = [];
   const actions = [];
+  const schemaErrors = validateTraceabilityReportContract(entry, report);
+
+  for (const error of schemaErrors) {
+    gaps.push({
+      severity: SEVERITY.ERROR,
+      message: `Traceability schema compatibility failure: ${error}`,
+    });
+  }
+  if (schemaErrors.length > 0) {
+    actions.push(
+      `Regenerate the backend traceability report with schemaVersion ${TRACEABILITY_REPORT_SCHEMA_VERSION} and repo-relative wiki/raw links.`
+    );
+  }
+
+  const counts = traceabilityCounts(report);
 
   if (counts.docstringsTotal === null || counts.docstringsLinked === null) {
     gaps.push({
@@ -594,6 +611,11 @@ function git(args, options = {}) {
   } catch {
     return '';
   }
+}
+
+function resolveCodeRoot(root) {
+  const parent = resolve(root, '..');
+  return basename(parent) === '.worktrees' ? resolve(parent, '..') : parent;
 }
 
 function findLocalCheckout(entry) {
@@ -663,6 +685,138 @@ function traceabilityCounts(report) {
   };
 }
 
+function validateTraceabilityReportContract(entry, report) {
+  const errors = [];
+  if (!isObject(report)) {
+    return ['report must be a non-null object'];
+  }
+
+  if (report.schemaVersion !== TRACEABILITY_REPORT_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion must be "${TRACEABILITY_REPORT_SCHEMA_VERSION}", got ${JSON.stringify(report.schemaVersion)}`
+    );
+  }
+
+  if (!nonEmptyString(report.serverId)) {
+    errors.push('serverId must be a non-empty string');
+  } else if (report.serverId !== entry.id) {
+    errors.push(`serverId mismatch: expected "${entry.id}", got "${report.serverId}"`);
+  }
+
+  for (const field of ['repository', 'languageId', 'generatedAt']) {
+    if (!nonEmptyString(report[field])) {
+      errors.push(`${field} must be a non-empty string`);
+    }
+  }
+  if (nonEmptyString(report.generatedAt) && Number.isNaN(Date.parse(report.generatedAt))) {
+    errors.push('generatedAt must be an ISO-8601 timestamp');
+  }
+
+  validateTraceabilitySummary(report.summary, errors);
+  validateTraceabilityPathArray(report.docstrings, 'docstrings', ['path', 'wikiPath'], ['symbol'], errors);
+  validateTraceabilityPathArray(report.wikiSources, 'wikiSources', ['wikiPath', 'rawPath'], ['sourceUrl'], errors);
+  validateTraceabilityRuleIds(report.ruleIds, errors);
+  validateTraceabilityPathArray(report.sourceUrls, 'sourceUrls', ['rawPath'], ['url'], errors);
+  validateTraceabilityRawManifest(report.rawManifest, errors);
+
+  return errors;
+}
+
+function validateTraceabilitySummary(value, errors) {
+  if (!isObject(value)) {
+    errors.push('summary must be an object');
+    return;
+  }
+
+  for (const field of [
+    'docstringsTotal',
+    'docstringsLinked',
+    'brokenWikiLinks',
+    'wikiSourcesWithoutRaw',
+    'rawManifestFailures',
+  ]) {
+    if (!nonNegativeInteger(value[field])) {
+      errors.push(`summary.${field} must be a non-negative integer`);
+    }
+  }
+
+  if (
+    nonNegativeInteger(value.docstringsTotal)
+    && nonNegativeInteger(value.docstringsLinked)
+    && value.docstringsLinked > value.docstringsTotal
+  ) {
+    errors.push('summary.docstringsLinked cannot exceed summary.docstringsTotal');
+  }
+}
+
+function validateTraceabilityPathArray(value, fieldName, pathFields, stringFields, errors) {
+  if (!Array.isArray(value)) {
+    errors.push(`${fieldName} must be an array`);
+    return;
+  }
+
+  value.forEach((item, index) => {
+    const prefix = `${fieldName}[${index}]`;
+    if (!isObject(item)) {
+      errors.push(`${prefix} must be an object`);
+      return;
+    }
+
+    for (const field of stringFields) {
+      if (!nonEmptyString(item[field])) {
+        errors.push(`${prefix}.${field} must be a non-empty string`);
+      }
+    }
+    for (const field of pathFields) {
+      validateTraceabilityRepoRelativePath(item, field, prefix, errors);
+    }
+  });
+}
+
+function validateTraceabilityRuleIds(value, errors) {
+  if (!Array.isArray(value)) {
+    errors.push('ruleIds must be an array');
+    return;
+  }
+
+  value.forEach((item, index) => {
+    const prefix = `ruleIds[${index}]`;
+    if (!isObject(item)) {
+      errors.push(`${prefix} must be an object`);
+      return;
+    }
+
+    if (!nonEmptyString(item.code)) {
+      errors.push(`${prefix}.code must be a non-empty string`);
+    } else if (!TRACEABILITY_RULE_ID_PATTERN.test(item.code)) {
+      errors.push(`${prefix}.code must match <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN`);
+    }
+    validateTraceabilityRepoRelativePath(item, 'sourcePath', prefix, errors);
+  });
+}
+
+function validateTraceabilityRawManifest(value, errors) {
+  if (!isObject(value)) {
+    errors.push('rawManifest must be an object');
+    return;
+  }
+
+  validateTraceabilityRepoRelativePath(value, 'path', 'rawManifest', errors);
+  if (typeof value.ok !== 'boolean') {
+    errors.push('rawManifest.ok must be a boolean');
+  }
+}
+
+function validateTraceabilityRepoRelativePath(item, field, prefix, errors) {
+  if (!nonEmptyString(item[field])) {
+    errors.push(`${prefix}.${field} must be a non-empty string`);
+    return;
+  }
+  if (!isRepoRelativePath(item[field])) {
+    errors.push(`${prefix}.${field} must be a repository-relative path`);
+  }
+}
+
 function numberOrNull(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
@@ -680,6 +834,27 @@ function readJsonIfExists(path) {
   } catch {
     return null;
   }
+}
+
+function isObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function nonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isRepoRelativePath(value) {
+  return (
+    !value.startsWith('/')
+    && !/^[A-Za-z]:[\\/]/.test(value)
+    && !value.startsWith('file:')
+    && !value.split(/[\\/]+/).includes('..')
+  );
 }
 
 function manifestReleaseVersion(manifest) {

--- a/scripts/check-lsp-latest.mjs
+++ b/scripts/check-lsp-latest.mjs
@@ -2,13 +2,13 @@
 
 import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
-const codeRoot = resolve(repoRoot, '..');
+const codeRoot = resolveCodeRoot(repoRoot);
 const registryPath = join(repoRoot, 'src/lsp/registry.ts');
 const failOnDrift = process.argv.includes('--fail-on-drift');
 
@@ -42,6 +42,11 @@ function git(args, options = {}) {
     stdio: ['ignore', 'pipe', options.quiet ? 'ignore' : 'pipe'],
     ...options,
   }).trim();
+}
+
+function resolveCodeRoot(root) {
+  const parent = resolve(root, '..');
+  return basename(parent) === '.worktrees' ? resolve(parent, '..') : parent;
 }
 
 function remoteHead(entry) {

--- a/src/smoke/index.ts
+++ b/src/smoke/index.ts
@@ -14,6 +14,8 @@ export type {
   CompatibilityCheck,
   LspCompatibilityEntry,
   CompatibilityReport,
+  TraceabilityReportSummary,
+  TraceabilityReport,
   DocumentKind,
   DocumentDetectionResult,
   SmokeTestResult,
@@ -35,6 +37,11 @@ export {
   getManifestCategories,
   countRulesBySeverity,
 } from './ruleManifestReader';
+
+export {
+  TRACEABILITY_REPORT_SCHEMA_VERSION,
+  validateTraceabilityReport,
+} from './traceabilityReport';
 
 export {
   detectDocument,

--- a/src/smoke/traceabilityReport.ts
+++ b/src/smoke/traceabilityReport.ts
@@ -1,0 +1,260 @@
+/**
+ * LSP traceability report contract.
+ *
+ * Backend repositories emit this report after checking that scientific
+ * docstrings link to LLM Wiki nodes and wiki source claims link to raw assets.
+ *
+ * @module smoke/traceabilityReport
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/233
+ */
+
+export const TRACEABILITY_REPORT_SCHEMA_VERSION = 'openqc.lsp.traceability.v1';
+
+const RULE_ID_PATTERN = /^[A-Z0-9]+-[A-Z0-9_]+-[A-Z0-9_]+-\d{3}$/;
+
+export interface TraceabilityReportSummary {
+  readonly docstringsTotal: number;
+  readonly docstringsLinked: number;
+  readonly brokenWikiLinks: number;
+  readonly wikiSourcesWithoutRaw: number;
+  readonly rawManifestFailures: number;
+}
+
+export interface TraceabilityReportDocstring {
+  readonly path: string;
+  readonly symbol: string;
+  readonly wikiPath: string;
+}
+
+export interface TraceabilityReportWikiSource {
+  readonly wikiPath: string;
+  readonly sourceUrl: string;
+  readonly rawPath: string;
+}
+
+export interface TraceabilityReportRuleId {
+  readonly code: string;
+  readonly sourcePath: string;
+}
+
+export interface TraceabilityReportSourceUrl {
+  readonly url: string;
+  readonly rawPath: string;
+  readonly kind?: string;
+}
+
+export interface TraceabilityReport {
+  readonly schemaVersion: typeof TRACEABILITY_REPORT_SCHEMA_VERSION;
+  readonly serverId: string;
+  readonly repository: string;
+  readonly languageId: string;
+  readonly generatedAt: string;
+  readonly summary: TraceabilityReportSummary;
+  readonly docstrings: readonly TraceabilityReportDocstring[];
+  readonly wikiSources: readonly TraceabilityReportWikiSource[];
+  readonly ruleIds: readonly TraceabilityReportRuleId[];
+  readonly sourceUrls: readonly TraceabilityReportSourceUrl[];
+  readonly rawManifest: {
+    readonly path: string;
+    readonly ok: boolean;
+  };
+}
+
+export interface TraceabilityValidationOptions {
+  readonly expectedServerId?: string;
+}
+
+export function validateTraceabilityReport(
+  data: unknown,
+  options: TraceabilityValidationOptions = {}
+): string[] {
+  const errors: string[] = [];
+  if (!isRecord(data)) {
+    return ['Traceability report must be a non-null object'];
+  }
+
+  const schemaVersion = data.schemaVersion;
+  if (schemaVersion !== TRACEABILITY_REPORT_SCHEMA_VERSION) {
+    errors.push(
+      `schemaVersion must be "${TRACEABILITY_REPORT_SCHEMA_VERSION}", got ${JSON.stringify(schemaVersion)}`
+    );
+  }
+
+  const serverId = data.serverId;
+  if (!nonEmptyString(serverId)) {
+    errors.push('serverId must be a non-empty string');
+  } else if (options.expectedServerId && serverId !== options.expectedServerId) {
+    errors.push(`serverId mismatch: expected "${options.expectedServerId}", got "${serverId}"`);
+  }
+
+  for (const field of ['repository', 'languageId', 'generatedAt'] as const) {
+    if (!nonEmptyString(data[field])) {
+      errors.push(`${field} must be a non-empty string`);
+    }
+  }
+  if (nonEmptyString(data.generatedAt) && Number.isNaN(Date.parse(data.generatedAt))) {
+    errors.push('generatedAt must be an ISO-8601 timestamp');
+  }
+
+  validateSummary(data.summary, errors);
+  validateDocstrings(data.docstrings, errors);
+  validateWikiSources(data.wikiSources, errors);
+  validateRuleIds(data.ruleIds, errors);
+  validateSourceUrls(data.sourceUrls, errors);
+  validateRawManifest(data.rawManifest, errors);
+
+  return errors;
+}
+
+function validateSummary(value: unknown, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push('summary must be an object');
+    return;
+  }
+  for (const field of [
+    'docstringsTotal',
+    'docstringsLinked',
+    'brokenWikiLinks',
+    'wikiSourcesWithoutRaw',
+    'rawManifestFailures',
+  ] as const) {
+    if (!nonNegativeInteger(value[field])) {
+      errors.push(`summary.${field} must be a non-negative integer`);
+    }
+  }
+  if (
+    nonNegativeInteger(value.docstringsTotal) &&
+    nonNegativeInteger(value.docstringsLinked) &&
+    value.docstringsLinked > value.docstringsTotal
+  ) {
+    errors.push('summary.docstringsLinked cannot exceed summary.docstringsTotal');
+  }
+}
+
+function validateDocstrings(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('docstrings must be an array');
+    return;
+  }
+  value.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`docstrings[${index}] must be an object`);
+      return;
+    }
+    requireNonEmpty(entry, 'path', `docstrings[${index}]`, errors);
+    requireNonEmpty(entry, 'symbol', `docstrings[${index}]`, errors);
+    requireNonEmpty(entry, 'wikiPath', `docstrings[${index}]`, errors);
+    requireRepoRelativePath(entry, 'path', `docstrings[${index}]`, errors);
+    requireRepoRelativePath(entry, 'wikiPath', `docstrings[${index}]`, errors);
+  });
+}
+
+function validateWikiSources(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('wikiSources must be an array');
+    return;
+  }
+  value.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`wikiSources[${index}] must be an object`);
+      return;
+    }
+    requireNonEmpty(entry, 'wikiPath', `wikiSources[${index}]`, errors);
+    requireNonEmpty(entry, 'sourceUrl', `wikiSources[${index}]`, errors);
+    requireNonEmpty(entry, 'rawPath', `wikiSources[${index}]`, errors);
+    requireRepoRelativePath(entry, 'wikiPath', `wikiSources[${index}]`, errors);
+    requireRepoRelativePath(entry, 'rawPath', `wikiSources[${index}]`, errors);
+  });
+}
+
+function validateRuleIds(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('ruleIds must be an array');
+    return;
+  }
+  value.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`ruleIds[${index}] must be an object`);
+      return;
+    }
+    if (!nonEmptyString(entry.code)) {
+      errors.push(`ruleIds[${index}].code must be a non-empty string`);
+    } else if (!RULE_ID_PATTERN.test(entry.code)) {
+      errors.push(`ruleIds[${index}].code must match <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN`);
+    }
+    requireNonEmpty(entry, 'sourcePath', `ruleIds[${index}]`, errors);
+    requireRepoRelativePath(entry, 'sourcePath', `ruleIds[${index}]`, errors);
+  });
+}
+
+function validateSourceUrls(value: unknown, errors: string[]): void {
+  if (!Array.isArray(value)) {
+    errors.push('sourceUrls must be an array');
+    return;
+  }
+  value.forEach((entry, index) => {
+    if (!isRecord(entry)) {
+      errors.push(`sourceUrls[${index}] must be an object`);
+      return;
+    }
+    requireNonEmpty(entry, 'url', `sourceUrls[${index}]`, errors);
+    requireNonEmpty(entry, 'rawPath', `sourceUrls[${index}]`, errors);
+    requireRepoRelativePath(entry, 'rawPath', `sourceUrls[${index}]`, errors);
+  });
+}
+
+function validateRawManifest(value: unknown, errors: string[]): void {
+  if (!isRecord(value)) {
+    errors.push('rawManifest must be an object');
+    return;
+  }
+  requireNonEmpty(value, 'path', 'rawManifest', errors);
+  requireRepoRelativePath(value, 'path', 'rawManifest', errors);
+  if (typeof value.ok !== 'boolean') {
+    errors.push('rawManifest.ok must be a boolean');
+  }
+}
+
+function requireNonEmpty(
+  object: Record<string, unknown>,
+  field: string,
+  prefix: string,
+  errors: string[]
+): void {
+  if (!nonEmptyString(object[field])) {
+    errors.push(`${prefix}.${field} must be a non-empty string`);
+  }
+}
+
+function requireRepoRelativePath(
+  object: Record<string, unknown>,
+  field: string,
+  prefix: string,
+  errors: string[]
+): void {
+  const value = object[field];
+  if (nonEmptyString(value) && !isRepoRelativePath(value)) {
+    errors.push(`${prefix}.${field} must be a repository-relative path`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isRepoRelativePath(value: string): boolean {
+  return (
+    !value.startsWith('/') &&
+    !/^[A-Za-z]:[\\/]/.test(value) &&
+    !value.startsWith('file:') &&
+    !value.split(/[\\/]+/).includes('..')
+  );
+}

--- a/src/smoke/types.ts
+++ b/src/smoke/types.ts
@@ -60,6 +60,48 @@ export interface RuleManifest {
 // Compatibility Report types (Issue #163)
 // ---------------------------------------------------------------------------
 
+/** Summary counts exported by backend docstring/wiki/raw traceability reports. */
+export interface TraceabilityReportSummary {
+  readonly docstringsTotal: number;
+  readonly docstringsLinked: number;
+  readonly brokenWikiLinks: number;
+  readonly wikiSourcesWithoutRaw: number;
+  readonly rawManifestFailures: number;
+}
+
+/** Full backend provenance traceability report consumed by OpenQC. */
+export interface TraceabilityReport {
+  readonly schemaVersion: 'openqc.lsp.traceability.v1';
+  readonly serverId: string;
+  readonly repository: string;
+  readonly languageId: string;
+  readonly generatedAt: string;
+  readonly summary: TraceabilityReportSummary;
+  readonly docstrings: readonly {
+    readonly path: string;
+    readonly symbol: string;
+    readonly wikiPath: string;
+  }[];
+  readonly wikiSources: readonly {
+    readonly wikiPath: string;
+    readonly sourceUrl: string;
+    readonly rawPath: string;
+  }[];
+  readonly ruleIds: readonly {
+    readonly code: string;
+    readonly sourcePath: string;
+  }[];
+  readonly sourceUrls: readonly {
+    readonly url: string;
+    readonly rawPath: string;
+    readonly kind?: string;
+  }[];
+  readonly rawManifest: {
+    readonly path: string;
+    readonly ok: boolean;
+  };
+}
+
 /** Status of an individual compatibility check. */
 export type CheckStatus = 'pass' | 'fail' | 'skip' | 'warn';
 

--- a/tests/fixtures/smoke/traceability/cp2k-lsp-enhanced-report.json
+++ b/tests/fixtures/smoke/traceability/cp2k-lsp-enhanced-report.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "cp2k-lsp-enhanced",
+  "repository": "newtontech/cp2k-lsp-enhanced",
+  "languageId": "cp2k",
+  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "summary": {
+    "docstringsTotal": 2,
+    "docstringsLinked": 2,
+    "brokenWikiLinks": 0,
+    "wikiSourcesWithoutRaw": 0,
+    "rawManifestFailures": 0
+  },
+  "docstrings": [
+    {
+      "path": "cp2k_input_tools/diagnostics.py",
+      "symbol": "validate_kind_aliases",
+      "wikiPath": "wiki/rules/kind-aliases.md"
+    },
+    {
+      "path": "cp2k_input_tools/log_parser.py",
+      "symbol": "parse_log_file",
+      "wikiPath": "wiki/rules/runtime-log-diagnostics.md"
+    }
+  ],
+  "wikiSources": [
+    {
+      "wikiPath": "wiki/rules/kind-aliases.md",
+      "sourceUrl": "https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/SUBSYS/KIND.html",
+      "rawPath": "raw/assets/cp2k-kind-reference.html"
+    }
+  ],
+  "ruleIds": [
+    {
+      "code": "CP2K-INPUT-SYNTAX-001",
+      "sourcePath": "cp2k_input_tools/diagnostics.py"
+    },
+    {
+      "code": "CP2K-LOG-RUNTIME-001",
+      "sourcePath": "cp2k_input_tools/log_parser.py"
+    }
+  ],
+  "sourceUrls": [
+    {
+      "url": "https://manual.cp2k.org/trunk/CP2K_INPUT.html",
+      "kind": "official_docs",
+      "rawPath": "raw/assets/cp2k-input-reference.html"
+    }
+  ],
+  "rawManifest": {
+    "path": "raw/assets/manifest.json",
+    "ok": true
+  }
+}

--- a/tests/fixtures/smoke/traceability/dpgen-lsp-report.json
+++ b/tests/fixtures/smoke/traceability/dpgen-lsp-report.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "dpgen-lsp",
+  "repository": "newtontech/dpgen-lsp",
+  "languageId": "dpgen",
+  "generatedAt": "2026-06-15T00:00:00.000Z",
+  "summary": {
+    "docstringsTotal": 2,
+    "docstringsLinked": 2,
+    "brokenWikiLinks": 0,
+    "wikiSourcesWithoutRaw": 0,
+    "rawManifestFailures": 0
+  },
+  "docstrings": [
+    {
+      "path": "src/dpgen_lsp/features/diagnostic.py",
+      "symbol": "validate_machine_sections",
+      "wikiPath": "wiki/entities/machine-json.md"
+    },
+    {
+      "path": "src/dpgen_lsp/features/log_parser.py",
+      "symbol": "parse_log_content",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    }
+  ],
+  "wikiSources": [
+    {
+      "wikiPath": "wiki/entities/machine-json.md",
+      "sourceUrl": "https://docs.deepmodeling.com/projects/dpgen/en/latest/run/mdata.html",
+      "rawPath": "raw/assets/dpgen-official-docs.json"
+    }
+  ],
+  "ruleIds": [
+    {
+      "code": "DPGEN-MACHINE-SCHEMA-001",
+      "sourcePath": "src/dpgen_lsp/features/diagnostic.py"
+    },
+    {
+      "code": "DPGEN-LOG-RUNTIME-001",
+      "sourcePath": "src/dpgen_lsp/features/log_parser.py"
+    }
+  ],
+  "sourceUrls": [
+    {
+      "url": "https://docs.deepmodeling.com/projects/dpgen/en/latest/run/param.html",
+      "kind": "official_docs",
+      "rawPath": "raw/assets/dpgen-official-docs.json"
+    }
+  ],
+  "rawManifest": {
+    "path": "raw/assets/manifest.json",
+    "ok": true
+  }
+}

--- a/tests/unit/smoke/traceabilityReport.test.ts
+++ b/tests/unit/smoke/traceabilityReport.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Traceability report contract tests.
+ *
+ * @see https://github.com/newtontech/OpenQC-VSCode/issues/233
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  TRACEABILITY_REPORT_SCHEMA_VERSION,
+  validateTraceabilityReport,
+} from '../../../src/smoke/traceabilityReport';
+
+const FIXTURES_DIR = path.join(__dirname, '../../fixtures/smoke/traceability');
+
+function loadFixture(name: string): any {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf8'));
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+describe('validateTraceabilityReport', () => {
+  it.each([
+    ['cp2k-lsp-enhanced-report.json', 'cp2k-lsp-enhanced'],
+    ['dpgen-lsp-report.json', 'dpgen-lsp'],
+  ])('validates %s fixture', (fixtureName, serverId) => {
+    const report = loadFixture(fixtureName);
+
+    expect(report.schemaVersion).toBe(TRACEABILITY_REPORT_SCHEMA_VERSION);
+    expect(validateTraceabilityReport(report, { expectedServerId: serverId })).toEqual([]);
+  });
+
+  it('reports server ID mismatches', () => {
+    const report = loadFixture('cp2k-lsp-enhanced-report.json');
+
+    const errors = validateTraceabilityReport(report, { expectedServerId: 'dpgen-lsp' });
+
+    expect(errors).toContain('serverId mismatch: expected "dpgen-lsp", got "cp2k-lsp-enhanced"');
+  });
+
+  it('rejects malformed traceability rule IDs', () => {
+    const report = clone(loadFixture('dpgen-lsp-report.json'));
+    report.ruleIds[0].code = 'DPGEN_SCHEMA_001';
+
+    const errors = validateTraceabilityReport(report, { expectedServerId: 'dpgen-lsp' });
+
+    expect(errors).toContain('ruleIds[0].code must match <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN');
+  });
+
+  it('rejects hidden local absolute paths', () => {
+    const report = clone(loadFixture('cp2k-lsp-enhanced-report.json'));
+    report.docstrings[0].path = '/Users/example/private/cp2k_input_tools/diagnostics.py';
+
+    const errors = validateTraceabilityReport(report, { expectedServerId: 'cp2k-lsp-enhanced' });
+
+    expect(errors).toContain('docstrings[0].path must be a repository-relative path');
+  });
+});


### PR DESCRIPTION
Closes #233

## Summary
- add the OpenQC LSP traceability report JSON schema and contract documentation
- add a TypeScript validator plus CP2K/DP-GEN fixture coverage for schemaVersion, serverId, rule ID format, and repo-relative paths
- teach `check-lsp-family` to report traceability schema compatibility failures clearly
- make `check-lsp-family` and `check-lsp-latest` resolve the real code root from `.worktrees/*` checkouts

## Tests
- `npm run compile`
- `npx jest tests/unit/smoke/traceabilityReport.test.ts --runInBand`
- `npm run lint` (passes with existing curly warnings in unrelated files)
- `npm run format:check`
- `node --check scripts/check-lsp-family.mjs && node --check scripts/check-lsp-latest.mjs`
- `node scripts/check-lsp-family.mjs --json --report-path /tmp/openqc-lsp-family-233.json`
- `npm run lsp:check-latest -- --fail-on-drift`
- pre-commit: `npm run test:unit` (68 suites passed; 1424 passed, 2 skipped)

## Notes
`check-lsp-family` now distinguishes rollout-missing reports from incompatible legacy reports. Current latest checkouts show old traceability schema failures for `abacus-lsp` and `dpgen-lsp`, which is the intended compatibility signal until those backend reports are regenerated with `openqc.lsp.traceability.v1`.
